### PR TITLE
#92 Update tree controls to pre-select folder for import

### DIFF
--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -57,9 +57,9 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
    @Input() searchCriteria: string;
    @Input() defaultCheckedMap: any = {};
 
-   @Output() nodeClickEvent = new EventEmitter<any>();
+   @Output() nodeClickEvent = new EventEmitter<Node>();
    @Output() nodeConfirmClickEvent = new EventEmitter<NodeConfirmClickEvent>();
-   @Output() nodeDbClickEvent = new EventEmitter<any>();
+   @Output() nodeDbClickEvent = new EventEmitter<Node>();
    @Output() nodeCheckedEvent = new EventEmitter<any>();
 
    @Output() addFolderEvent = new EventEmitter<any>();
@@ -92,12 +92,13 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
    @Input() initialExpandedPaths: string[];
    @Input() isComparisonTree = false;
 
+   @Input() selectedNode: FlatNode = null; // Control highlighting
+
    @ViewChild(MatMenuTrigger, { static: false }) contextMenuTrigger: MatMenuTrigger;
    contextMenuPosition = { x: '0', y: '0' };
 
    favourites: { [x: string]: any };
    subscriptions: Subscription = new Subscription();
-   selectedNode = null; // Control highlighting
    checkedList = this.defaultCheckedMap || {};
 
    targetVersions = [];

--- a/src/app/import-models/import-models.component.ts
+++ b/src/app/import-models/import-models.component.ts
@@ -24,6 +24,7 @@ import { StateHandlerService } from '../services/handlers/state-handler.service'
 import { BroadcastService } from '../services/broadcast.service';
 import { UIRouterGlobals } from '@uirouter/core/';
 import { ModelDomainRequestType } from '@mdm/model/model-domain-type';
+import { ModelTreeService } from '@mdm/services/model-tree.service';
 
 @Component({
   selector: 'mdm-import',
@@ -70,6 +71,7 @@ export class ImportModelsComponent implements OnInit {
     private stateHandler: StateHandlerService,
     private broadcastSvc: BroadcastService,
     private uiRouterGlobals: UIRouterGlobals,
+    private modelTree: ModelTreeService
   ) {}
 
   ngOnInit() {
@@ -151,6 +153,11 @@ export class ImportModelsComponent implements OnInit {
           if (option.type === 'Boolean' || option.type === 'boolean') {
             option.optional = true;
             option.value = false;
+          }
+
+          // If the model tree currently has a folder selected, default to that one initially
+          if (option.type === 'Folder' && this.modelTree.currentNode && this.modelTree.currentNode.domainType === 'Folder') {
+            option.value = [this.modelTree.currentNode];
           }
         });
       });

--- a/src/app/model-selector-tree/model-selector-tree.component.ts
+++ b/src/app/model-selector-tree/model-selector-tree.component.ts
@@ -32,6 +32,7 @@ import { UserSettingsHandlerService } from '../services/utility/user-settings-ha
 import { fromEvent } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { ContainerDomainType, FolderIndexResponse, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
+import { Node } from '@mdm/folders-tree/flat-node';
 
 @Component({
   selector: 'mdm-model-selector-tree',
@@ -68,7 +69,7 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   @Output() ngModelChange = new EventEmitter<any>();
   @ViewChild('searchInputTreeControl', { static: true })
   searchInputTreeControl: ElementRef;
-  selectedElementsVal: any;
+  selectedElementsVal: Node[];
   @Input()
   get ngModel() {
     return this.selectedElements;
@@ -90,7 +91,7 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   rootNode: any;
   filteredRootNode: any;
   markChildren: any;
-  selectedElements: any[] = [];
+  selectedElements: Node[] = [];
   searchCriteria: any;
   hasValidationError: boolean;
   inSearchMode: any;
@@ -219,6 +220,13 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
           isRoot: true
         };
         this.filteredRootNode = this.rootNode;
+
+        if ((this.selectedElements?.length ?? 0) > 0 && !this.multiple) {
+          // If a node has already been initially selected, update the input field to
+          // display it
+          this.searchCriteria = this.selectedElements[0].label;
+        }
+
       }, () => {
         this.loading = false;
       });
@@ -331,15 +339,15 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   }
 
 
-  onNodeClick = (node) => {
-    this.click(node);
+  onNodeClick(node: Node) {
+    this.selectNode(node);
   };
 
-  onNodeDbClick = (node) => {
-    this.click(node);
+  onNodeDbClick(node: Node) {
+    this.selectNode(node);
   };
 
-  click = (node) => {
+  selectNode(node: Node) {
     this.hasValidationError = false;
 
     if (this.accepts && this.accepts.indexOf(node.domainType) === -1) {

--- a/src/app/services/model-tree.service.ts
+++ b/src/app/services/model-tree.service.ts
@@ -17,11 +17,12 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
 import { SubscribedCatalogue, SubscribedCatalogueIndexResponse } from '@maurodatamapper/mdm-resources';
-import { Node, DOMAIN_TYPE } from '@mdm/folders-tree/flat-node';
+import { Node, DOMAIN_TYPE, FlatNode } from '@mdm/folders-tree/flat-node';
 import { MdmResourcesService, MdmRestHandlerOptions } from '@mdm/modules/resources';
 import { SubscribedCataloguesService } from '@mdm/subscribed-catalogues/subscribed-catalogues.service';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import { BroadcastService } from './broadcast.service';
 import { SharedService } from './shared.service';
 import { MessageHandlerService } from './utility/message-handler.service';
 import { UserSettingsHandlerService } from './utility/user-settings-handler.service';
@@ -31,12 +32,17 @@ import { UserSettingsHandlerService } from './utility/user-settings-handler.serv
 })
 export class ModelTreeService {
 
+  currentNode?: Node;
+
   constructor(
     private resources: MdmResourcesService,
     private sharedService: SharedService,
     private userSettingsHandler: UserSettingsHandlerService,
     private subscribedCatalogues: SubscribedCataloguesService,
-    private messageHandler: MessageHandlerService) { }
+    private messageHandler: MessageHandlerService,
+    private broadcast: BroadcastService) {
+      this.broadcast.subscribe('$folderTreeNodeSelection', (fnode: FlatNode) => this.currentNode = fnode.node);
+    }
 
   getLocalCatalogueTreeNodes(noCache?: boolean): Observable<Node[]> {
     let options: any = {};

--- a/src/app/shared/models/models.component.html
+++ b/src/app/shared/models/models.component.html
@@ -142,6 +142,7 @@ SPDX-License-Identifier: Apache-2.0
                                         (addChildDataClassEvent)="onAddChildDataClass($event)"
                                         (addChildDataElementEvent)="onAddChildDataElement($event)"
                                         (addChildDataTypeEvent)="onAddChildDataType($event)"
+                                        (nodeClickEvent)="onNodeClick($event)"
                                         (nodeDbClickEvent)="onNodeDbClick($event)"
                                         (nodeConfirmClickEvent)="onNodeConfirmClick($event)">
                             </mdm-folders-tree>

--- a/src/app/shared/models/models.component.ts
+++ b/src/app/shared/models/models.component.ts
@@ -310,7 +310,13 @@ export class ModelsComponent implements OnInit, OnDestroy {
       );
   }
 
-  onNodeDbClick(node: Node) {
+  onNodeClick(node: Node) {
+    this.modelTree.currentNode = node;
+  }
+
+  onNodeDbClick(node: Node ){
+    this.modelTree.currentNode = node;
+
     // if the element if a dataModel, load it
     if (
       [DOMAIN_TYPE.DataModel, DOMAIN_TYPE.Terminology].indexOf(


### PR DESCRIPTION
* Track when model tree view has selected a node
* Have import-models component pre-select chosen folder matching current model tree if a folder is selected

Fixes #92 