### PR TITLE
MC-9516 Add feature toggle for versioned folders

### DIFF
--- a/custom-webpack.config.js
+++ b/custom-webpack.config.js
@@ -23,7 +23,8 @@ module.exports = {
     new webpack.DefinePlugin({
       $ENV: {
         themeName: JSON.stringify(process.env['MDM_UI_THEME_NAME']),
-        useFeaureSubscribedCatalogues: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_SUBSCRIBED_CATALOGUES']))
+        useFeaureSubscribedCatalogues: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_SUBSCRIBED_CATALOGUES'])),
+        useVersionedFolders: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_VERSIONED_FOLDERS'])),
       }
     })
   ]

--- a/src/app/services/shared.model.ts
+++ b/src/app/services/shared.model.ts
@@ -20,4 +20,5 @@ SPDX-License-Identifier: Apache-2.0
 export interface Features {
   useSubscribedCatalogues: boolean;
   useDynamicProfiles: boolean;
+  useVersionedFolders: boolean;
 }

--- a/src/environments/env.d.ts
+++ b/src/environments/env.d.ts
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 interface EnvironmentVariables {
   themeName: string;
   useFeaureSubscribedCatalogues: boolean;
+  useVersionedFolders: boolean;
 }
 
 declare let $ENV: EnvironmentVariables;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -52,6 +52,7 @@ export const environment = {
   checkSessionExpiryTimeout: 300000,
   features: {
     useSubscribedCatalogues: $ENV.useFeaureSubscribedCatalogues ?? true,
-    useDynamicProfiles: true
+    useDynamicProfiles: true,
+    useVersionedFolders: $ENV.useVersionedFolders ?? false
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -56,7 +56,8 @@ export const environment = {
   checkSessionExpiryTimeout: 300000,
   features: {
     useSubscribedCatalogues: true,
-    useDynamicProfiles: true
+    useDynamicProfiles: true,
+    useVersionedFolders: true
   }
 };
 


### PR DESCRIPTION
Currently development mode has this always on.

Production builds have this disabled by default, unless the environment variable MDM_UI_FEATURE_VERSIONED_FOLDERS is used in docker compose