### PR TITLE
Feature/mc 9517 Detail views for Versioned Folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2981,7 +2981,7 @@
     },
     "node_modules/@maurodatamapper/mdm-resources": {
       "version": "4.6.0-SNAPSHOT",
-      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#6ec2aba46355cfbd4bfd377cd707384d66bc9744",
+      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#1444c524dadc1573eb23f970a688d40e0fa2d66f",
       "license": "Apache-2.0"
     },
     "node_modules/@ngtools/webpack": {
@@ -25355,7 +25355,7 @@
       }
     },
     "@maurodatamapper/mdm-resources": {
-      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#6ec2aba46355cfbd4bfd377cd707384d66bc9744",
+      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#1444c524dadc1573eb23f970a688d40e0fa2d66f",
       "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#develop"
     },
     "@ngtools/webpack": {

--- a/src/app/access/group-access-new.component.ts
+++ b/src/app/access/group-access-new.component.ts
@@ -57,6 +57,7 @@ export class GroupAccessNewComponent implements OnInit {
     DataModel: { name: 'dataModel', message: 'Data Model' },
     Classifier: { name: 'classifier', message: 'Classifier' },
     Folder: { name: 'folder', message: 'Folder' },
+    VersionedFolder: { name: 'versionedFolder', message: 'Versioned Folder' },
     Terminology: { name: 'terminology', message: 'Terminology' },
     CodeSet: { name: 'codeSet', message: 'CodeSet' },
   };

--- a/src/app/access/share-with/share-with.component.ts
+++ b/src/app/access/share-with/share-with.component.ts
@@ -38,6 +38,7 @@ export class ShareWithComponent implements OnInit {
     DataModel: { name: 'dataModel', message: 'Data Model' },
     Classifier: { name: 'classifier', message: 'Classifier' },
     Folder: { name: 'folder', message: 'Folder' },
+    VersionedFolder: { name: 'versionedFolder', message: 'Versioned Folder' },
     Terminology: { name: 'terminology', message: 'Terminology' },
     CodeSet: { name: 'codeSet', message: 'CodeSet' },
     ReferenceDataModel: { name: 'referenceDataModel', message: 'ReferenceDataModel' }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -61,6 +61,7 @@ import { SubscribedCatalogueMainComponent } from './subscribed-catalogues/subscr
 import { FederatedDataModelMainComponent } from './subscribed-catalogues/federated-data-model-main/federated-data-model-main.component';
 import { ServerTimeoutComponent } from './errors/server-timeout/server-timeout.component';
 import { NewVersionComponent } from './shared/new-version/new-version.component';
+import { VersionedFolderComponent } from './versioned-folder/versioned-folder/versioned-folder.component';
 
 
 export const pageRoutes: { states: Ng2StateDeclaration[] } = {
@@ -96,8 +97,8 @@ export const pageRoutes: { states: Ng2StateDeclaration[] } = {
       }
     },
     {
-      name: 'appContainer.mainApp.twoSidePanel.catalogue.folder',
       url: '/folder/:id/{tabView:string}?edit',
+      name: 'appContainer.mainApp.twoSidePanel.catalogue.folder',
       component: FolderComponent,
       params: { tabView: { value: null, squash: true, dynamic: true } }
     },
@@ -293,6 +294,12 @@ export const pageRoutes: { states: Ng2StateDeclaration[] } = {
         tabView: { dynamic: true, value: null, squash: true },
         dataModel: null
       }
+    },
+    {
+      name: 'appContainer.mainApp.twoSidePanel.catalogue.versionedFolder',
+      url: '/versionedFolder/:id/{tabView:string}',
+      component: VersionedFolderComponent,
+      params: { tabView: { dynamic: true, value: null, squash: true } }
     }
   ]
 };

--- a/src/app/model/access.ts
+++ b/src/app/model/access.ts
@@ -17,16 +17,21 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
+/**
+ * Represents access/permissions flags to determine what a catalogue item can do.
+ *
+ * @see {@link SecurityHandlerService.elementAccess}
+ */
 export interface Access {
-    showEdit : boolean;
-    canEditDescription: boolean;
-    showNewVersion?: boolean;
-    showFinalise: boolean;
-    showPermission: boolean;
-    showSoftDelete: boolean;
-    showPermanentDelete: boolean;
-    canAddAnnotation: boolean;
-    canAddMetadata: boolean;
-    showDelete: boolean;
-    canAddLink: boolean;
-  }
+  showEdit: boolean;
+  canEditDescription: boolean;
+  showNewVersion?: boolean;
+  showFinalise: boolean;
+  showPermission: boolean;
+  showSoftDelete: boolean;
+  showPermanentDelete: boolean;
+  canAddAnnotation: boolean;
+  canAddMetadata: boolean;
+  showDelete: boolean;
+  canAddLink: boolean;
+}

--- a/src/app/model/editable-forms.ts
+++ b/src/app/model/editable-forms.ts
@@ -142,6 +142,23 @@ export class ItemDetailForm<T extends Labelable> extends FormGroupState<T> {
   }
 }
 
+export class ContainerDefaultProfileForm<T extends Describable> extends FormGroupState<T> {
+
+  get description() {
+    return this.formGroup.get('description');
+  }
+
+  set descriptionValue(value: string) {
+    this.description.setValue(value);
+  }
+
+  constructor() {
+    super(new FormGroup({
+      description: new FormControl('')
+    }));
+  }
+}
+
 /**
  * Represents the state of a form that can be edited.
  *
@@ -247,15 +264,3 @@ export interface Labelable {
 export interface Describable {
   description?: string;
 }
-
-export class DefaultContainerProfileForm<T extends Labelable & Describable> implements Resetable<T> {
-  label: string;
-  description: string;
-
-  reset(original: T): void {
-    this.label = original.label;
-    this.description = original.description;
-  }
-}
-
-export type DefaultContainerProfileEditor<T extends Labelable & Describable> = Editable<T, DefaultContainerProfileForm<T>>;

--- a/src/app/model/editable-forms.ts
+++ b/src/app/model/editable-forms.ts
@@ -39,6 +39,7 @@ export class Editable<T, F extends Resetable<T>> {
   private onShowSource = new Subject<void>();
   private onCancelSource = new Subject<void>();
   private onResetSource = new Subject<T>();
+  private onFinishSource = new Subject<void>();
 
   /**
    * Observable to subscribe to when the editable object state is being shown.
@@ -57,6 +58,11 @@ export class Editable<T, F extends Resetable<T>> {
    * `T` may provide an `id` property but `F` requires the data object associated with that ID.
    */
   onReset = this.onResetSource.asObservable();
+
+  /**
+   * Observable to subscribe to when the editable object state has finished editing.
+   */
+  onFinish = this.onFinishSource.asObservable();
 
    /**
     * Determine if form data is being deleted.
@@ -100,6 +106,12 @@ export class Editable<T, F extends Resetable<T>> {
     this.isEditing = false;
     this.reset();
     this.onCancelSource.next();
+  }
+
+  finish(next: T) {
+    this.isEditing = false;
+    this.reset(next);
+    this.onFinishSource.next();
   }
 }
 

--- a/src/app/model/editable-forms.ts
+++ b/src/app/model/editable-forms.ts
@@ -32,6 +32,12 @@ export interface Resetable<T> {
   reset(original: T): void;
 }
 
+/**
+ * Represents the state of a form that can be edited.
+ *
+ * @typedef T The type of the original object state.
+ * @typedef F The type of the form state to track against the original state in {@link T}.
+ */
 export class FormState<T, F extends FormGroupState<T>> {
   private onShowSource = new Subject<void>();
   private onCancelSource = new Subject<void>();
@@ -39,17 +45,17 @@ export class FormState<T, F extends FormGroupState<T>> {
   private onFinishSource = new Subject<void>();
 
   /**
-   * Observable to subscribe to when the editable object state is being shown.
+   * Observable to subscribe to when the editable form is being shown.
    */
   onShow = this.onShowSource.asObservable();
 
   /**
-   * Observable to subscribe to when the editable object state is being cancelled.
+   * Observable to subscribe to when the editable form is being cancelled.
    */
   onCancel = this.onCancelSource.asObservable();
 
   /**
-   * Observable to subscribe to when the editable object state is being reset.
+   * Observable to subscribe to when the editable form is being reset.
    *
    * Use this when it is required to set further data to `F` that `T` provides only the basis of, for instance
    * `T` may provide an `id` property but `F` requires the data object associated with that ID.
@@ -57,16 +63,24 @@ export class FormState<T, F extends FormGroupState<T>> {
   onReset = this.onResetSource.asObservable();
 
   /**
-   * Observable to subscribe to when the editable object state has finished editing.
+   * Observable to subscribe to when the editable form has finished editing.
    */
   onFinish = this.onFinishSource.asObservable();
 
   isEditing: boolean = false;
 
+  /**
+   * Helper property to get the {@link FormGroup} to use for rendering.
+   */
   get formGroup(): FormGroup {
     return this.form.formGroup;
   }
 
+  /**
+   * Creates a new FormState object.
+   * @param original The original object state.
+   * @param form The form definition to map to the original object state and track changes made.
+   */
   constructor(
     public original: T,
     public form: F) {
@@ -88,17 +102,27 @@ export class FormState<T, F extends FormGroupState<T>> {
     this.onResetSource.next(this.original);
   }
 
+  /**
+   * Show the form for editing.
+   */
   show() {
     this.isEditing = true;
     this.onShowSource.next();
   }
 
+  /**
+   * Cancel editing the form and reset the form state back to the {@link original}.
+   */
   cancel() {
     this.isEditing = false;
     this.reset();
     this.onCancelSource.next();
   }
 
+  /**
+   * Finish editing the form after saving, setting the current form state to the new object state.
+   * @param next The new object state after saving.
+   */
   finish(next: T) {
     this.isEditing = false;
     this.reset(next);
@@ -106,28 +130,60 @@ export class FormState<T, F extends FormGroupState<T>> {
   }
 }
 
+/**
+ * Wrapper around an Angular {@link FormGroup} to track state easier.
+ *
+ * This is an abstract class and should be derived from. Each derived class should:
+ *
+ * 1. Define the {@link FormGroup} and controls required to define the form.
+ * 2. Add `get` properties to access the form controls.
+ */
 export abstract class FormGroupState<T> implements Resetable<T> {
 
+  /**
+   * Helper property to check if the form is currently valid.
+   */
   get valid() {
     return this.formGroup.valid;
   }
 
+  /**
+   * Creates a new `FormGroupState`.
+   * @param formGroup The {@link FormGroup} to track.
+   */
   constructor(public formGroup: FormGroup) { }
 
-  reset(original: T): void {
-    this.formGroup.reset(original);
+  /**
+   * Resets the form group to a new object state.
+   * @param state The object state to reset the form to.
+   *
+   * The property keys in `state` should match the form control names.
+   */
+  reset(state: T): void {
+    this.formGroup.reset(state);
   }
 
+  /**
+   * Enable the controls in the form group.
+   */
   enable() {
     this.formGroup.enable();
   }
 
+  /**
+   * Disable the controls in the form group.
+   */
   disable() {
     this.formGroup.disable();
   }
 }
 
-export class ItemDetailForm<T extends Labelable> extends FormGroupState<T> {
+/**
+ * `FormGroupState` object to track form fields related to catalogue item details.
+ *
+ * This state object tracks changes to catalogue item labels.
+ */
+export class CatalogueItemDetailForm<T extends Labelable> extends FormGroupState<T> {
 
   get label() {
     return this.formGroup.get('label');
@@ -142,6 +198,11 @@ export class ItemDetailForm<T extends Labelable> extends FormGroupState<T> {
   }
 }
 
+/**
+ * `FormGroupState` object to track form fields related to container default profiles.
+ *
+ * This state object tracks changes to description fields of container types.
+ */
 export class ContainerDefaultProfileForm<T extends Describable> extends FormGroupState<T> {
 
   get description() {
@@ -162,6 +223,7 @@ export class ContainerDefaultProfileForm<T extends Describable> extends FormGrou
 /**
  * Represents the state of a form that can be edited.
  *
+ * @deprecated Use {@link FormState} instead. Phase out this class type.
  */
 export class Editable<T, F extends Resetable<T>> {
   private onShowSource = new Subject<void>();

--- a/src/app/model/editable-forms.ts
+++ b/src/app/model/editable-forms.ts
@@ -116,3 +116,33 @@ export class EditableRecord<T, E> implements EditableObject {
       this.inEdit = settings.inEdit;
     }
 }
+
+export interface Labelable {
+  label: string;
+}
+
+export interface Describable {
+  description?: string;
+}
+
+export class DetailViewForm<T extends Labelable> implements Resetable<T> {
+  label: string;
+
+  reset(original: T): void {
+    this.label = original.label;
+  }
+}
+
+export type DetailViewEditor<T extends Labelable> = Editable<T, DetailViewForm<T>>;
+
+export class DefaultContainerProfileForm<T extends Labelable & Describable> implements Resetable<T> {
+  label: string;
+  description: string;
+
+  reset(original: T): void {
+    this.label = original.label;
+    this.description = original.description;
+  }
+}
+
+export type DefaultContainerProfileEditor<T extends Labelable & Describable> = Editable<T, DefaultContainerProfileForm<T>>;

--- a/src/app/model/editable-forms.ts
+++ b/src/app/model/editable-forms.ts
@@ -67,7 +67,7 @@ export class FormState<T, F extends FormGroupState<T>> {
    */
   onFinish = this.onFinishSource.asObservable();
 
-  isEditing: boolean = false;
+  isEditing = false;
 
   /**
    * Helper property to get the {@link FormGroup} to use for rendering.
@@ -78,6 +78,7 @@ export class FormState<T, F extends FormGroupState<T>> {
 
   /**
    * Creates a new FormState object.
+   *
    * @param original The original object state.
    * @param form The form definition to map to the original object state and track changes made.
    */
@@ -88,11 +89,11 @@ export class FormState<T, F extends FormGroupState<T>> {
   }
 
   /**
- * Reset the form state of this object.
- *
- * @param next The next `T` object to set to `original` if overriding the original value. If not provided, the value
- * currently stored in `original` will be used.
- */
+   * Reset the form state of this object.
+   *
+   * @param next The next `T` object to set to `original` if overriding the original value. If not provided, the value
+   * currently stored in `original` will be used.
+   */
   reset(next?: T) {
     if (next) {
       this.original = next;
@@ -121,6 +122,7 @@ export class FormState<T, F extends FormGroupState<T>> {
 
   /**
    * Finish editing the form after saving, setting the current form state to the new object state.
+   *
    * @param next The new object state after saving.
    */
   finish(next: T) {
@@ -149,12 +151,14 @@ export abstract class FormGroupState<T> implements Resetable<T> {
 
   /**
    * Creates a new `FormGroupState`.
+   *
    * @param formGroup The {@link FormGroup} to track.
    */
   constructor(public formGroup: FormGroup) { }
 
   /**
    * Resets the form group to a new object state.
+   *
    * @param state The object state to reset the form to.
    *
    * The property keys in `state` should match the form control names.

--- a/src/app/model/editable-forms.ts
+++ b/src/app/model/editable-forms.ts
@@ -137,11 +137,43 @@ export interface Describable {
   description?: string;
 }
 
-export class DetailViewForm<T extends Labelable> implements Resetable<T> {
+export type Errors<T> = {
+  [key in keyof Partial<T>]: string;
+}
+
+export interface Validatable<T> {
+  isValid: boolean;
+  errors: Errors<T>;
+
+  validate(): boolean;
+}
+
+export class DetailViewForm<T extends Labelable> implements Resetable<T>, Validatable<DetailViewForm<T>> {
+  isValid: boolean;
+  errors: Errors<DetailViewForm<T>>;
+
   label: string;
 
   reset(original: T): void {
     this.label = original.label;
+    this.validate();
+  }
+
+  validate(): boolean {
+    this.errors = { };
+
+    if (!this.label || (this.label && this.label.trim().length === 0)) {
+      this.errors.label = 'Please enter a label';
+    }
+
+    if (Object.keys(this.errors).length === 0) {
+      this.isValid = true;
+    }
+    else {
+      this.isValid = false;
+    }
+
+    return this.isValid;
   }
 }
 

--- a/src/app/model/ui.model.ts
+++ b/src/app/model/ui.model.ts
@@ -1,0 +1,25 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+export interface TabDescriptor {
+  index: number;
+  name: string;
+}
+
+export type AnnotationViewOption = 'default' | 'attachments';

--- a/src/app/model/ui.model.ts
+++ b/src/app/model/ui.model.ts
@@ -17,9 +17,22 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
+/**
+ * Describes a tab in a tab group.
+ */
 export interface TabDescriptor {
+  /**
+   * The index number of the tab.
+   */
   index: number;
+
+  /**
+   * The name of the tab.
+   */
   name: string;
 }
 
+/**
+ * Defines what annotation views are available.
+ */
 export type AnnotationViewOption = 'default' | 'attachments';

--- a/src/app/modules/catalogue/catalogue.module.ts
+++ b/src/app/modules/catalogue/catalogue.module.ts
@@ -182,6 +182,8 @@ import { ApiPropertyTableComponent } from '@mdm/admin/api-property-table/api-pro
 import { ApiPropertyComponent } from '@mdm/admin/api-property/api-property.component';
 import { ProfileDetailsComponent } from '@mdm/shared/profile-details/profile-details.component';
 import { ServerTimeoutComponent } from '@mdm/errors/server-timeout/server-timeout.component';
+import { VersionedFolderComponent } from '@mdm/versioned-folder/versioned-folder/versioned-folder.component';
+import { VersionedFolderDetailComponent } from '../../versioned-folder/versioned-folder-detail/versioned-folder-detail.component';
 
 @NgModule({
   declarations: [
@@ -337,7 +339,9 @@ import { ServerTimeoutComponent } from '@mdm/errors/server-timeout/server-timeou
     SubscribedCatalogueDetailComponent,
     FederatedDataModelMainComponent,
     FederatedDataModelDetailComponent,
-    ProfileDetailsComponent
+    ProfileDetailsComponent,
+    VersionedFolderComponent,
+    VersionedFolderDetailComponent
   ],
   imports: [
     AdminModule,

--- a/src/app/modules/resources/mdm-resources.service.ts
+++ b/src/app/modules/resources/mdm-resources.service.ts
@@ -53,7 +53,8 @@ import {
   MdmVersioningResource,
   MdmApiPropertyResources,
   MdmSubscribedCataloguesResource,
-  MdmProfileResource
+  MdmProfileResource,
+  MdmVersionedFolderResource
 } from '@maurodatamapper/mdm-resources';
 import { MdmRestHandlerService } from './mdm-rest-handler.service';
 
@@ -73,6 +74,7 @@ export class MdmResourcesService {
   terms = new MdmTermResource(this.resourcesConfig, this.restHandler);
   term = new MdmTermResource(this.resourcesConfig, this.restHandler);
   folder = new MdmFolderResource(this.resourcesConfig, this.restHandler);
+  versionedFolder = new MdmVersionedFolderResource(this.resourcesConfig, this.restHandler);
   catalogueUser = new MdmCatalogueUserResource(this.resourcesConfig, this.restHandler);
   catalogueItem = new MdmCatalogueItemResource(this.resourcesConfig, this.restHandler);
   enumerationValues = new MdmEnumerationValuesResource(this.resourcesConfig, this.restHandler);

--- a/src/app/profile-base/profile-base.component.ts
+++ b/src/app/profile-base/profile-base.component.ts
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { CatalogueItem, ModelDomainType } from '@maurodatamapper/mdm-resources';
 import { AddProfileModalComponent } from '@mdm/modals/add-profile-modal/add-profile-modal.component';
 import { EditProfileModalComponent } from '@mdm/modals/edit-profile-modal/edit-profile-modal.component';
 import { MdmResourcesService } from '@mdm/modules/resources';
@@ -36,7 +37,7 @@ export class ProfileBaseComponent extends BaseComponent {
   descriptionView = 'default';
   lastDescriptionView: string;
 
-  catalogueItem: any;
+  catalogueItem: CatalogueItem;
 
   constructor(protected resourcesService: MdmResourcesService,
     protected dialog: MatDialog,
@@ -155,7 +156,7 @@ export class ProfileBaseComponent extends BaseComponent {
     });
   };
 
-  async UsedProfiles(domainType: string, id: any) {
+  async UsedProfiles(domainType: ModelDomainType | string, id: any) {
     await this.resourcesService.profile
       .usedProfiles(domainType, id)
       .subscribe((profiles: { body: { [x: string]: any } }) => {
@@ -170,7 +171,7 @@ export class ProfileBaseComponent extends BaseComponent {
   }
 
   async UnUsedProfiles(
-    domainType: string,
+    domainType: ModelDomainType | string,
     id: any
   ) {
     await this.resourcesService.profile

--- a/src/app/services/editing.service.ts
+++ b/src/app/services/editing.service.ts
@@ -33,6 +33,7 @@ const editableRouteNames = [
   'appContainer.mainApp.twoSidePanel.catalogue.dataType',
   'appContainer.mainApp.twoSidePanel.catalogue.dataElement',
   'appContainer.mainApp.twoSidePanel.catalogue.folder',
+  'appContainer.mainApp.twoSidePanel.catalogue.versionedFolder',
   'appContainer.mainApp.twoSidePanel.catalogue.ReferenceDataModel',
   'appContainer.adminArea.user',
   'appContainer.adminArea.group',

--- a/src/app/services/handlers/security-handler.model.ts
+++ b/src/app/services/handlers/security-handler.model.ts
@@ -20,30 +20,6 @@ SPDX-License-Identifier: Apache-2.0
 import { HttpErrorResponse } from '@angular/common/http';
 import { MdmResourcesError } from '@mdm/modules/resources/mdm-resources.models';
 
-// /**
-//  * Credentials to send to `mdm-resources` for the sign-in operation.
-//  */
-// export interface SignInCredentials {
-//   username: string;
-//   password: string;
-// }
-
-// /**
-//  * The result of a successful sign-in operation.
-//  */
-//  export interface SignInResult {
-//   id: string;
-//   token?: string;
-//   emailAddress: string;
-//   firstName: string;
-//   lastName: string;
-//   pending?: boolean;
-//   disabled?: boolean;
-//   createdBy?: string;
-//   userRole?: string;
-//   needsToResetPassword?: boolean;
-// }
-
 export enum SignInErrorType {
   UnknownError,
   InvalidCredentials,
@@ -90,18 +66,6 @@ export class SignInError extends MdmResourcesError {
   }
 }
 
-// export interface AuthenticatedSessionResult {
-//   authenticatedSession: boolean;
-// }
-
-// export interface AdministrationSessionResult {
-//   applicationAdministrationSession: boolean;
-// }
-
-// export type SignInResponse = MdmResourcesResponse<SignInResult>;
-// export type AdministrationSessionResponse = MdmResourcesResponse<AdministrationSessionResult>;
-// export type AuthenticatedSessionResponse = MdmResourcesResponse<AuthenticatedSessionResult>;
-
 /**
  * Represents the common details of a signed in user.
  */
@@ -115,4 +79,26 @@ export interface UserDetails {
   role?: string;
   isAdmin?: boolean;
   needsToResetPassword?: boolean;
+}
+
+export interface ContainerAccess {
+  showEdit: boolean;
+  showPermission: boolean;
+  showSoftDelete: boolean;
+  showPermanentDelete: boolean;
+  canAddMetadata: boolean;
+  canAddAnnotation: boolean;
+}
+
+export interface DataModelAccess {
+  showEdit: boolean;
+  canEditDescription: boolean;
+  showNewVersion: boolean;
+  showFinalise: boolean;
+  showPermission: boolean;
+  showSoftDelete: boolean;
+  showPermanentDelete: boolean;
+  canAddAnnotation: boolean;
+  canAddMetadata: boolean;
+  canAddLink: boolean;
 }

--- a/src/app/services/handlers/security-handler.model.ts
+++ b/src/app/services/handlers/security-handler.model.ts
@@ -88,6 +88,7 @@ export interface ContainerAccess {
   showPermanentDelete: boolean;
   canAddMetadata: boolean;
   canAddAnnotation: boolean;
+  showFinalise: boolean;
 }
 
 export interface DataModelAccess {

--- a/src/app/services/handlers/security-handler.model.ts
+++ b/src/app/services/handlers/security-handler.model.ts
@@ -80,26 +80,3 @@ export interface UserDetails {
   isAdmin?: boolean;
   needsToResetPassword?: boolean;
 }
-
-export interface ContainerAccess {
-  showEdit: boolean;
-  showPermission: boolean;
-  showSoftDelete: boolean;
-  showPermanentDelete: boolean;
-  canAddMetadata: boolean;
-  canAddAnnotation: boolean;
-  showFinalise: boolean;
-}
-
-export interface DataModelAccess {
-  showEdit: boolean;
-  canEditDescription: boolean;
-  showNewVersion: boolean;
-  showFinalise: boolean;
-  showPermission: boolean;
-  showSoftDelete: boolean;
-  showPermanentDelete: boolean;
-  canAddAnnotation: boolean;
-  canAddMetadata: boolean;
-  canAddLink: boolean;
-}

--- a/src/app/services/handlers/state-handler.service.ts
+++ b/src/app/services/handlers/state-handler.service.ts
@@ -38,6 +38,7 @@ export class StateHandlerService {
         enumerationvalues: 'appContainer.mainApp.twoSidePanel.catalogue.enumerationValues',
         dataelement: 'appContainer.mainApp.twoSidePanel.catalogue.dataElement',
         folder: 'appContainer.mainApp.twoSidePanel.catalogue.folder',
+        versionedfolder: 'appContainer.mainApp.twoSidePanel.catalogue.versionedFolder',
         classification: 'appContainer.mainApp.twoSidePanel.catalogue.classification',
         diagram: 'appContainer.mainApp.diagram',
 
@@ -93,6 +94,7 @@ export class StateHandlerService {
     let state = name;
     const needsRedirect = [
       'appContainer.mainapp.twoSidePanel.catalogue.folder', 'folder',
+      'appContainer.mainapp.twoSidePanel.catalogue.versionedFolder', 'versionedfolder',
       'appContainer.mainapp.twoSidePanel.catalogue.datamodel', 'datamodel',
       'appContainer.mainapp.twoSidePanel.catalogue.referencedatamodel', 'referencedatamodel',
       'appContainer.mainapp.twoSidePanel.catalogue.dataclass', 'dataclass',

--- a/src/app/utility/editable-form-buttons/editable-form-buttons.component.html
+++ b/src/app/utility/editable-form-buttons/editable-form-buttons.component.html
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
             matTooltip="{{displayEditTitle}}"
             class="paddingless"
             [disabled]="processing"
-            *ngIf="!editable.visible && !editable.deletePending && !hideEdit"
+            *ngIf="!isEditorVisible && !editable.deletePending && !hideEdit"
             (click)="editClicked()"
             aria-label="Edit">
         <i class="fas fa-pencil-alt editButton"></i>
@@ -74,7 +74,7 @@ SPDX-License-Identifier: Apache-2.0
             color="warn"
             type="button"
             [disabled]="editable.waiting || processing"
-            *ngIf="editable.visible && !hideCancel"
+            *ngIf="isEditorVisible && !hideCancel"
             (click)="cancelEditClicked()"
             aria-label="Cancel edit">
             Cancel edit
@@ -86,7 +86,7 @@ SPDX-License-Identifier: Apache-2.0
             type="submit"
             class="custom"
             [disabled]="editable.waiting || editable.validationError"
-            *ngIf="editable.visible"
+            *ngIf="isEditorVisible"
             (click)="saveClicked()"
             aria-label="Save">
             Save changes

--- a/src/app/utility/editable-form-buttons/editable-form-buttons.component.ts
+++ b/src/app/utility/editable-form-buttons/editable-form-buttons.component.ts
@@ -18,7 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { EditingService } from '@mdm/services/editing.service';
-import { Editable } from '@mdm/model/folderModel';
 
 @Component({
   selector: 'mdm-editable-form-buttons',

--- a/src/app/utility/editable-form-buttons/editable-form-buttons.component.ts
+++ b/src/app/utility/editable-form-buttons/editable-form-buttons.component.ts
@@ -26,11 +26,11 @@ import { Editable } from '@mdm/model/folderModel';
    styleUrls: ['./editable-form-buttons.component.scss']
 })
 export class EditableFormButtonsComponent implements OnInit {
-  @Input() deleteIcon: any;
-  @Input() deleteTitle: any;
-  @Input() editTitle: any;
+  @Input() deleteIcon: any = null;
+  @Input() deleteTitle  = '';
+  @Input() editTitle = '';
   @Input() processing: any;
-  @Input() editable: Editable;
+  @Input() editable: any;
   @Input() onEditClicked: any;
   @Input() onDeleteClicked: any;
   @Input() onConfirmDelete: any;
@@ -48,6 +48,10 @@ export class EditableFormButtonsComponent implements OnInit {
   public displayDeleteIcon: any = this.deleteIcon;
 
   public displayEditTitle: string = this.editTitle;
+
+  get isEditorVisible(): boolean {
+    return this.editable && (this.editable.visible || this.editable.isEditing);
+  }
 
   constructor(private editingService: EditingService) {}
 
@@ -127,7 +131,7 @@ export class EditableFormButtonsComponent implements OnInit {
         return;
       }
 
-      if (this.editable) {
+      if (this.editable && this.editable.cancel) {
         this.editable.cancel();
       }
       if (this.onCancelEdit) {

--- a/src/app/utility/editable-form-buttons/editable-form-buttons.component.ts
+++ b/src/app/utility/editable-form-buttons/editable-form-buttons.component.ts
@@ -25,7 +25,7 @@ import { EditingService } from '@mdm/services/editing.service';
    styleUrls: ['./editable-form-buttons.component.scss']
 })
 export class EditableFormButtonsComponent implements OnInit {
-  @Input() deleteIcon: any = null;
+  @Input() deleteIcon = null;
   @Input() deleteTitle  = '';
   @Input() editTitle = '';
   @Input() processing: any;

--- a/src/app/utility/markdown/markdown-text-area/markdown-text-area.component.html
+++ b/src/app/utility/markdown/markdown-text-area/markdown-text-area.component.html
@@ -48,8 +48,8 @@ SPDX-License-Identifier: Apache-2.0
 
 <div *ngIf="editableForm">
     <div class="xeditableTextArea">
-        <textarea *ngIf="editableForm.visible"
-                  [(ngModel)]="editableForm[property]"
+        <textarea *ngIf="isEditorVisible"
+                  [(ngModel)]="editorModel"
                   name="{{ property }}"
                   class="full-width"
                   rows="{{ rows ? rows : '6' }}"
@@ -57,7 +57,7 @@ SPDX-License-Identifier: Apache-2.0
                   #editableTextArea
                   (keyup)="descriptionKeyUp($event)"></textarea>
 
-        <div style="float: right; margin-bottom: 10px;" *ngIf="editableForm.visible">
+        <div style="float: right; margin-bottom: 10px;" *ngIf="isEditorVisible">
             <mat-checkbox name="showMarkdown" [(ngModel)]="formData.showMarkDownPreview" style="position: relative;">
               Preview
             </mat-checkbox>
@@ -67,14 +67,14 @@ SPDX-License-Identifier: Apache-2.0
             </button>
         </div>
         <div *ngIf="!hideHelpText">
-            <div style="float: left; margin-top: 8px; margin-right: 15px;" *ngIf="inEditMode || editableForm.visible">
+            <div style="float: left; margin-top: 8px; margin-right: 15px;" *ngIf="inEditMode || isEditorVisible">
                 <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">GitHub Markdown guide</a>
             </div>
         </div>
 
         <div style="clear: both;">
-            <span mdmMarkdown [markdown]="editableForm[property]" *ngIf="editableForm.visible && formData.showMarkDownPreview"></span>
-            <span mdmMarkdown [markdown]="element[property]" *ngIf="!editableForm.visible"></span>
+            <span mdmMarkdown [markdown]="editorModel" *ngIf="isEditorVisible && formData.showMarkDownPreview"></span>
+            <span mdmMarkdown [markdown]="element[property]" *ngIf="!isEditorVisible"></span>
         </div>
     </div>
 </div>

--- a/src/app/utility/markdown/markdown-text-area/markdown-text-area.component.ts
+++ b/src/app/utility/markdown/markdown-text-area/markdown-text-area.component.ts
@@ -54,6 +54,26 @@ export class MarkdownTextAreaComponent implements OnInit {
     this.descriptionChange.emit(this.descriptionVal);
   }
 
+  get isEditorVisible(): boolean {
+    return this.editableForm && (this.editableForm.visible || this.editableForm.isEditing);
+  }
+
+  get editorModel() {
+    if (this.editableForm.form) {
+      return this.editableForm.form[this.property];
+    }
+    return this.editableForm[this.property];
+  }
+
+  set editorModel(value) {
+    if (this.editableForm.form) {
+      this.editableForm.form[this.property] = value;
+      return;
+    }
+
+    this.editableForm[this.property] = value;
+  }
+
   elementDialogue;
   lastWasShiftKey: any;
   formData: any = {

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="panel panel-default mdm--shadow-block">
-  <form name="form" (ngSubmit)="save()" disable-submit-on-enter>
+  <form name="form" [formGroup]="editor.formGroup" (ngSubmit)="save()" disable-submit-on-enter>
     <div class="panel-body">
       <div class="full-width" style="clear: both" *ngIf="detail">
         <button
@@ -34,9 +34,7 @@ SPDX-License-Identifier: Apache-2.0
           <button
             mat-menu-item
             type="button"
-            *ngIf="
-              access.showEdit && !editor.isEditing && !editor.deletePending
-            "
+            *ngIf="access.showEdit && !editor.isEditing"
             (click)="showForm()"
           >
             <i class="fas fa-pencil-alt"></i> Edit Title
@@ -76,7 +74,7 @@ SPDX-License-Identifier: Apache-2.0
         <div
           *ngIf="access.showPermission"
           style="position: relative; float: right; margin-right: 8px"
-          [hidden]="editor.isEditing || editor.deletePending"
+          [hidden]="editor.isEditing"
         >
           <button
             mat-icon-button
@@ -98,7 +96,7 @@ SPDX-License-Identifier: Apache-2.0
             margin-right: 8px;
             margin-left: 8px;
           "
-          [hidden]="editor.isEditing || editor.deletePending"
+          [hidden]="editor.isEditing"
         >
           <button
             mat-icon-button
@@ -131,22 +129,22 @@ SPDX-License-Identifier: Apache-2.0
               *ngIf="!editor.isEditing"
               class="dataModelDetailsLabel"
               style="font-weight: 500"
-              >{{ editor.form.label }}</span
+              >{{ detail.label }}</span
             >
             <mat-form-field
               *ngIf="editor.isEditing"
               appearance="outline"
               style="width: 100%"
             >
-              <mat-label>Label</mat-label>
               <input
                 matInput
                 name="label"
-                [(ngModel)]="editor.form.label"
+                formControlName="label"
+                placeholder="Label"
                 required
               />
-              <mat-error *ngIf="editor.form.errors && editor.form.errors.label">
-                {{ editor.form.errors.label }}
+              <mat-error *ngIf="editor.form?.label?.errors?.required">
+                 Label is required
               </mat-error>
             </mat-form-field>
             <mdm-editable-form-buttons

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="panel panel-default mdm--shadow-block">
-  <form name="form" [formGroup]="editor.formGroup" (ngSubmit)="save()" disable-submit-on-enter>
+  <form name="form" (ngSubmit)="save()" disable-submit-on-enter>
     <div class="panel-body">
       <div class="full-width" style="clear: both" *ngIf="detail">
         <button
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
           <button
             mat-menu-item
             type="button"
-            *ngIf="access.showEdit && !editor.isEditing"
+            *ngIf="access.showEdit && !isEditing"
             (click)="showForm()"
           >
             <i class="fas fa-pencil-alt"></i> Edit Title
@@ -74,7 +74,7 @@ SPDX-License-Identifier: Apache-2.0
         <div
           *ngIf="access.showPermission"
           style="position: relative; float: right; margin-right: 8px"
-          [hidden]="editor.isEditing"
+          [hidden]="isEditing"
         >
           <button
             mat-icon-button
@@ -96,7 +96,7 @@ SPDX-License-Identifier: Apache-2.0
             margin-right: 8px;
             margin-left: 8px;
           "
-          [hidden]="editor.isEditing"
+          [hidden]="isEditing"
         >
           <button
             mat-icon-button
@@ -125,37 +125,19 @@ SPDX-License-Identifier: Apache-2.0
                 class="fas fa-project-diagram"
               ></i>
             </span>
-            <span
-              *ngIf="!editor.isEditing"
-              class="dataModelDetailsLabel"
-              style="font-weight: 500"
-              >{{ detail.label }}</span
+            <mdm-inline-text-edit
+              [readOnly]="false"
+              [inEditMode]="isEditing"
+              [(ngModel)]="detail.label"
+              [isRequired]="true"
+              [showButtons]="true"
+              (saveClicked)="save()"
+              (cancelClicked)="cancel()"
+              [name]="'moduleName'"
+              size="20"
+              [styleCss]="'dataModelDetailsLabel'"
             >
-            <mat-form-field
-              *ngIf="editor.isEditing"
-              appearance="outline"
-              style="width: 100%"
-            >
-              <input
-                matInput
-                name="label"
-                formControlName="label"
-                placeholder="Label"
-                required
-              />
-              <mat-error *ngIf="editor.form?.label?.errors?.required">
-                 Label is required
-              </mat-error>
-            </mat-form-field>
-            <mdm-editable-form-buttons
-              *ngIf="editor"
-              [hidden]="!editor.isEditing"
-              [onCancelEdit]="cancel"
-              [editable]="editor"
-              [textLocation]="'left'"
-              [hideDelete]="true"
-              [hideCancel]="false"
-            ></mdm-editable-form-buttons>
+            </mdm-inline-text-edit>
             <sup
               *ngIf="detail?.readableByEveryone"
               class="text-muted"

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -16,4 +16,249 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<p>versioned-folder-detail works!</p>
+<div class="panel panel-default mdm--shadow-block">
+  <form
+    editable-form
+    name="form"
+    (ngSubmit)="submitForm()"
+    disable-submit-on-enter
+  >
+    <div class="panel-body">
+      <div class="full-width" style="clear: both" *ngIf="detail">
+        <button
+          type="button"
+          mat-icon-button
+          [matMenuTriggerFor]="userActions"
+          style="position: relative; float: right; margin-right: 4px"
+        >
+          <i class="fas fa-ellipsis-v"></i>
+          <span style="display: none">Menu</span>
+        </button>
+        <!--First level Menu-->
+        <mat-menu #userActions="matMenu" class="mdm--mat-menu--actions">
+          <button
+            mat-menu-item
+            type="button"
+            *ngIf="access.showEdit && !editor.isEditing && !editor.deletePending"
+            (click)="editLabel()"
+          >
+            <i class="fas fa-pencil-alt"></i> Edit Title
+          </button>
+          <mat-divider></mat-divider>
+          <button
+            mat-menu-item
+            type="button"
+            [matMenuTriggerFor]="userActionsDelete"
+            *ngIf="access.showSoftDelete || access.showPermanentDelete"
+            class="warning"
+          >
+            <i class="far fa-trash-alt warning"></i> Delete
+          </button>
+        </mat-menu>
+        <!-- End of first level menu -->
+
+        <!--Second level sub Menu-->
+        <mat-menu #userActionsDelete="matMenu">
+          <button
+            mat-menu-item
+            (click)="askForSoftDelete()"
+            *ngIf="access.showSoftDelete && !detail.deleted"
+          >
+            Mark as deleted
+          </button>
+          <button
+            mat-menu-item
+            (click)="askForPermanentDelete()"
+            *ngIf="access.showPermanentDelete"
+          >
+            Delete <span class="warning">permanently</span>
+          </button>
+        </mat-menu>
+        <!-- End of Second level sub Menu-->
+
+        <div
+          *ngIf="access.showPermission"
+          style="position: relative; float: right; margin-right: 8px"
+          [hidden]="editor.isEditing || editor.deletePending"
+        >
+          <button
+            mat-icon-button
+            color="primary"
+            type="button"
+            class="paddingless"
+            (click)="showSecurityDialog()"
+            matTooltip="User & Group Access"
+            aria-label="User & Group Access"
+          >
+            <i class="fas fa-user-lock"></i>
+          </button>
+        </div>
+
+        <div
+          style="
+            position: relative;
+            float: right;
+            margin-right: 8px;
+            margin-left: 8px;
+          "
+          [hidden]="editor.isEditing || editor.deletePending"
+        >
+          <button
+            mat-icon-button
+            color="primary"
+            type="button"
+            class="paddingless"
+            (click)="toggleShowSearch()"
+            [disabled]="processing"
+            matTooltip="Search"
+            aria-label="Search"
+          >
+            <i class="fas fa-search"></i>
+          </button>
+        </div>
+      </div>
+
+      <div *ngIf="detail">
+        <div class="data-model-header">
+          <h4
+            class="inline-block marginless"
+            [ngClass]="{ deletedDataModelTitle: detail?.deleted }"
+          >
+            <span class="dataModelTypeIcon">
+              <i
+                matTooltip="Versioned Folder"
+                class="fas fa-project-diagram"
+              ></i>
+            </span>
+            <mdm-inline-text-edit
+              [readOnly]="!access.showEdit"
+              [inEditMode]="editor.isEditing"
+              [(ngModel)]="editor.form.label"
+              [name]="'moduleName'"
+              size="20"
+              [styleCss]="'dataModelDetailsLabel'"
+            >
+            </mdm-inline-text-edit>
+            <mdm-editable-form-buttons
+              *ngIf="editor"
+              [hidden]="!editor.isEditing"
+              [onCancelEdit]="cancelEdit"
+              [editable]="editor"
+              [textLocation]="'left'"
+              [hideDelete]="true"
+              [hideCancel]="false"
+            ></mdm-editable-form-buttons>
+            <sup
+              *ngIf="detail?.readableByEveryone"
+              class="text-muted"
+              style="margin-left: 4px"
+              ><i
+                class="fas fa-globe-europe globe fa-xs"
+                aria-hidden="true"
+                matTooltip="Publicly Available"
+              ></i
+            ></sup>
+          </h4>
+          <span class="inline-block" *ngIf="detail?.deleted">
+            <small class="warning"> | Deleted</small>
+          </span>
+
+          <mdm-element-status [result]="detail"></mdm-element-status>
+        </div>
+      </div>
+
+      <div class="detail-icons">
+        <div class="text-muted">
+          <small>
+            <i class="fas fa-cube" matTooltip="Item type"></i>
+            <span>
+              <strong>Item type: </strong>
+              <span class="item-type">Versioned Folder</span>
+            </span>
+          </small>
+        </div>
+        <div class="text-muted" *ngIf="detail?.documentationVersion">
+          <small>
+            <i matTooltip="Documentation Version" class="fas fa-copy"></i>
+            <span
+              ><strong>Documentation Version: </strong
+              >{{ detail.documentationVersion }}</span
+            >
+          </small>
+        </div>
+        <div
+          class="text-muted"
+          *ngIf="detail?.modelVersion && detail?.finalised"
+        >
+          <small>
+            <i matTooltip="Model Version" class="fas fa-file-alt"></i>
+            <span>
+              <strong>Version: </strong>{{ detail.modelVersion }}
+            </span>
+            <span *ngIf="detail.modelVersionTag" class="tag-name">
+              <i matTooltip="Model Version Tag" class="fas fa-tag"></i>
+              <span>{{ detail.modelVersionTag }}</span>
+            </span>
+          </small>
+        </div>
+        <!-- <div class="text-muted" *ngIf="catalogueItem">
+          <small>
+            <i class="fas fa-code-branch" matTooltip="Branch name"></i>
+            <span><strong>Branch: </strong></span>
+            <span>
+              <select
+                class="form-control"
+                style="
+                  display: inline;
+                  max-width: 120px;
+                  height: 30px;
+                  line-height: 1;
+                  padding: 0 0.35em;
+                  width: auto;
+                "
+                [(ngModel)]="currentBranch"
+                name="currentBranch"
+                (ngModelChange)="onModelChange()"
+              >
+                <option
+                  [value]="item.branchName"
+                  *ngFor="let item of branchGraph"
+                >
+                  {{ item.branchName }}
+                </option>
+              </select>
+            </span>
+          </small>
+        </div> -->
+        <div class="text-muted" *ngIf="detail">
+          <small>
+            <i class="far fa-calendar-alt" matTooltip="Last update"></i>
+            <span>
+              <strong>Last update: </strong>
+              {{ detail.lastUpdated | date: 'yyyy-MM-dd HH:mm:ss' }}
+            </span>
+          </small>
+        </div>
+        <div class="text-muted" *ngIf="detail?.readableByEveryone">
+          <small>
+            <i
+              class="fas fa-globe-europe globe"
+              aria-hidden="true"
+              matTooltip="Availability"
+            ></i>
+            <span><strong>Availability: </strong>Publicly Readable</span>
+          </small>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+
+<div style="clear: both" *ngIf="processing">
+  <mat-progress-bar
+    value="50"
+    bufferValue="75"
+    color="accent"
+    mode="indeterminate"
+  ></mat-progress-bar>
+</div>

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -1,0 +1,19 @@
+<!--
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<p>versioned-folder-detail works!</p>

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -17,12 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="panel panel-default mdm--shadow-block">
-  <form
-    editable-form
-    name="form"
-    (ngSubmit)="submitForm()"
-    disable-submit-on-enter
-  >
+  <form name="form" (ngSubmit)="save()" disable-submit-on-enter>
     <div class="panel-body">
       <div class="full-width" style="clear: both" *ngIf="detail">
         <button
@@ -39,8 +34,10 @@ SPDX-License-Identifier: Apache-2.0
           <button
             mat-menu-item
             type="button"
-            *ngIf="access.showEdit && !editor.isEditing && !editor.deletePending"
-            (click)="editLabel()"
+            *ngIf="
+              access.showEdit && !editor.isEditing && !editor.deletePending
+            "
+            (click)="showForm()"
           >
             <i class="fas fa-pencil-alt"></i> Edit Title
           </button>
@@ -130,19 +127,32 @@ SPDX-License-Identifier: Apache-2.0
                 class="fas fa-project-diagram"
               ></i>
             </span>
-            <mdm-inline-text-edit
-              [readOnly]="!access.showEdit"
-              [inEditMode]="editor.isEditing"
-              [(ngModel)]="editor.form.label"
-              [name]="'moduleName'"
-              size="20"
-              [styleCss]="'dataModelDetailsLabel'"
+            <span
+              *ngIf="!editor.isEditing"
+              class="dataModelDetailsLabel"
+              style="font-weight: 500"
+              >{{ editor.form.label }}</span
             >
-            </mdm-inline-text-edit>
+            <mat-form-field
+              *ngIf="editor.isEditing"
+              appearance="outline"
+              style="width: 100%"
+            >
+              <mat-label>Label</mat-label>
+              <input
+                matInput
+                name="label"
+                [(ngModel)]="editor.form.label"
+                required
+              />
+              <mat-error *ngIf="editor.form.errors && editor.form.errors.label">
+                {{ editor.form.errors.label }}
+              </mat-error>
+            </mat-form-field>
             <mdm-editable-form-buttons
               *ngIf="editor"
               [hidden]="!editor.isEditing"
-              [onCancelEdit]="cancelEdit"
+              [onCancelEdit]="cancel"
               [editable]="editor"
               [textLocation]="'left'"
               [hideDelete]="true"
@@ -192,9 +202,7 @@ SPDX-License-Identifier: Apache-2.0
         >
           <small>
             <i matTooltip="Model Version" class="fas fa-file-alt"></i>
-            <span>
-              <strong>Version: </strong>{{ detail.modelVersion }}
-            </span>
+            <span> <strong>Version: </strong>{{ detail.modelVersion }} </span>
             <span *ngIf="detail.modelVersionTag" class="tag-name">
               <i matTooltip="Model Version Tag" class="fas fa-tag"></i>
               <span>{{ detail.modelVersionTag }}</span>

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.scss
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -22,11 +22,11 @@ import { MatDialog } from '@angular/material/dialog';
 import { Title } from '@angular/platform-browser';
 import { VersionedFolderDetail, VersionedFolderDetailResponse } from '@maurodatamapper/mdm-resources';
 import { SecurityModalComponent } from '@mdm/modals/security-modal/security-modal.component';
+import { Access } from '@mdm/model/access';
 import { FormState, CatalogueItemDetailForm } from '@mdm/model/editable-forms';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { BroadcastService, MessageHandlerService, MessageService, SharedService, StateHandlerService } from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
-import { ContainerAccess } from '@mdm/services/handlers/security-handler.model';
 import { EMPTY, Subject } from 'rxjs';
 import { catchError, finalize, takeUntil } from 'rxjs/operators';
 
@@ -38,7 +38,7 @@ import { catchError, finalize, takeUntil } from 'rxjs/operators';
 export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
 
   @Input() detail: VersionedFolderDetail;
-  @Input() access: ContainerAccess;
+  @Input() access: Access;
 
   @Output() afterSave = new EventEmitter<VersionedFolderDetail>();
 

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -21,7 +21,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Title } from '@angular/platform-browser';
 import { VersionedFolderDetail, VersionedFolderDetailResponse } from '@maurodatamapper/mdm-resources';
 import { SecurityModalComponent } from '@mdm/modals/security-modal/security-modal.component';
-import { FormState, ItemDetailForm } from '@mdm/model/editable-forms';
+import { FormState, CatalogueItemDetailForm } from '@mdm/model/editable-forms';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { BroadcastService, MessageHandlerService, MessageService, SharedService, StateHandlerService } from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
@@ -41,7 +41,7 @@ export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
 
   @Output() afterSave = new EventEmitter<VersionedFolderDetail>();
 
-  editor: FormState<VersionedFolderDetail, ItemDetailForm<VersionedFolderDetail>>;
+  editor: FormState<VersionedFolderDetail, CatalogueItemDetailForm<VersionedFolderDetail>>;
 
   isAdminUser = false;
   processing = false;
@@ -64,7 +64,7 @@ export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
 
     this.title.setTitle(`Versioned Folder - ${this.detail?.label}`);
 
-    this.editor = new FormState(this.detail, new ItemDetailForm());
+    this.editor = new FormState(this.detail, new CatalogueItemDetailForm());
 
     this.editor.onShow
       .pipe(takeUntil(this.unsubscribe$))

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mdm-versioned-folder-detail',
+  templateUrl: './versioned-folder-detail.component.html',
+  styleUrls: ['./versioned-folder-detail.component.scss']
+})
+export class VersionedFolderDetailComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -98,36 +98,38 @@ export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
     });
   }
 
-  editLabel() {
+  showForm() {
     this.editor.show();
   }
 
-  cancelEdit() {
+  cancel() {
     this.editor?.cancel();
   }
 
-  submitForm() {
+  save() {
+    if (!this.editor.form.validate()) {
+      return;
+    }
+
     const resource: ContainerUpdatePayload = {
       id: this.detail.id,
       label: this.editor.form.label
     };
 
-    if (this.validateLabel(this.editor.form.label)) {
-      this.resourcesService.versionedFolder
-        .update(this.detail.id, resource)
-        .pipe(
-          catchError(error => {
-            this.messageHandler.showError('There was a problem updating the Versioned Folder.', error);
-            return EMPTY;
-          })
-        )
-        .subscribe(
-          (response: VersionedFolderDetailResponse) => {
-            this.messageHandler.showSuccess('Versioned Folder updated successfully.');
-            this.editor.finish(response.body);
-            this.broadcast.broadcast('$reloadFoldersTree');
-          });
-    }
+    this.resourcesService.versionedFolder
+      .update(this.detail.id, resource)
+      .pipe(
+        catchError(error => {
+          this.messageHandler.showError('There was a problem updating the Versioned Folder.', error);
+          return EMPTY;
+        })
+      )
+      .subscribe(
+        (response: VersionedFolderDetailResponse) => {
+          this.messageHandler.showSuccess('Versioned Folder updated successfully.');
+          this.editor.finish(response.body);
+          this.broadcast.broadcast('$reloadFoldersTree');
+        });
   }
 
   askForSoftDelete() {
@@ -175,15 +177,6 @@ export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
         }
       )
       .subscribe(() => this.delete(true));
-  }
-
-  validateLabel(data): any {
-    if (!data || (data && data.trim().length === 0)) {
-      //this.errorMessage = 'DataModel name can not be empty';
-      return false;
-    } else {
-      return true;
-    }
   }
 
   private delete(permanent: boolean) {

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Title } from '@angular/platform-browser';
 import { VersionedFolderDetail, VersionedFolderDetailResponse } from '@maurodatamapper/mdm-resources';
@@ -38,6 +38,8 @@ export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
 
   @Input() detail: VersionedFolderDetail;
   @Input() access: ContainerAccess;
+
+  @Output() afterSave = new EventEmitter<VersionedFolderDetail>();
 
   editor: FormState<VersionedFolderDetail, ItemDetailForm<VersionedFolderDetail>>;
 
@@ -62,9 +64,7 @@ export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
 
     this.title.setTitle(`Versioned Folder - ${this.detail?.label}`);
 
-    this.editor = new FormState(
-      this.detail,
-      new ItemDetailForm<VersionedFolderDetail>());
+    this.editor = new FormState(this.detail, new ItemDetailForm());
 
     this.editor.onShow
       .pipe(takeUntil(this.unsubscribe$))
@@ -131,6 +131,7 @@ export class VersionedFolderDetailComponent implements OnInit, OnDestroy {
         (response: VersionedFolderDetailResponse) => {
           this.messageHandler.showSuccess('Versioned Folder updated successfully.');
           this.editor.finish(response.body);
+          this.afterSave.emit(response.body);
           this.broadcast.broadcast('$reloadFoldersTree');
         });
   }

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Title } from '@angular/platform-browser';

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="full-width">
-  <!-- <mdm-data-model-detail [afterSave]="afterSave"></mdm-data-model-detail> -->
+  <mdm-versioned-folder-detail *ngIf="detail" [detail]="detail" [access]="access"></mdm-versioned-folder-detail>
 </div>
 <div *ngIf="showSearch" style="clear: both">
   <div class="mdm--shadow-block">
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
       </div>
       <div class="panel-body panel-table">
         <mdm-advanced-search-bar
-          [parent]="versionedFolder"
+          [parent]="detail"
           [showRestrictTo]="false"
           [doNotShowDataModelInModelPath]="false"
           [doNotDisplayModelPathStatus]="false"
@@ -177,7 +177,7 @@ SPDX-License-Identifier: Apache-2.0
         <div class="full-width">
           <mdm-data-set-metadata
             *ngIf="this.descriptionView === 'other'"
-            [parent]="versionedFolder"
+            [parent]="detail"
             [type]="'dynamic'"
             [domainType]="'versionedFolders'"
             [isProfileView]="true"
@@ -197,10 +197,10 @@ SPDX-License-Identifier: Apache-2.0
               <tr>
                 <td class="detailsRowHeader">Description</td>
                 <td class="elementDetailDescription">
-                  <div *ngIf="versionedFolder">
+                  <div *ngIf="detail">
                     <mdm-markdown-text-area
                       [editableForm]="editor"
-                      [element]="versionedFolder"
+                      [element]="detail"
                       [property]="'description'"
                     ></mdm-markdown-text-area>
                   </div>
@@ -272,8 +272,8 @@ SPDX-License-Identifier: Apache-2.0
 
         <div *ngIf="annotationsView === 'default'">
           <mdm-annotation-list
-            *ngIf="versionedFolder"
-            [parent]="versionedFolder"
+            *ngIf="detail"
+            [parent]="detail"
             [domainType]="'versionedFolders'"
           ></mdm-annotation-list>
         </div>
@@ -284,8 +284,8 @@ SPDX-License-Identifier: Apache-2.0
         >
           <div class="pxy-2">
             <mdm-attachment-list
-              *ngIf="versionedFolder"
-              [parent]="versionedFolder"
+              *ngIf="detail"
+              [parent]="detail"
               [domainType]="'versionedFolders'"
             ></mdm-attachment-list>
           </div>
@@ -314,8 +314,8 @@ SPDX-License-Identifier: Apache-2.0
     <div class="full-width">
       <mdm-history
         (totalCount)="historyCountEmitter($event)"
-        *ngIf="versionedFolder"
-        [parent]="versionedFolder"
+        *ngIf="detail"
+        [parent]="detail"
         [parentType]="'VersionedFolder'"
         [parentId]="parentId"
         [domainType]="'versionedFolders'"
@@ -341,8 +341,8 @@ SPDX-License-Identifier: Apache-2.0
     </ng-template>
     <div class="full-width">
       <mdm-constraints-rules
-        *ngIf="versionedFolder"
-        [parent]="versionedFolder"
+        *ngIf="detail"
+        [parent]="detail"
         [domainType]="'versionedFolders'"
         (totalCount)="rulesCountEmitter($event)"
       ></mdm-constraints-rules>

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
@@ -16,4 +16,336 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<p>versioned-folder works!</p>
+<div class="full-width">
+  <!-- <mdm-data-model-detail [afterSave]="afterSave"></mdm-data-model-detail> -->
+</div>
+<div *ngIf="showSearch" style="clear: both">
+  <div class="mdm--shadow-block">
+    <div class="panel">
+      <div class="panel-heading">
+        <div class="heading-container">
+          <h4 class="marginless">Search</h4>
+          <div style="float: right">
+            <button
+              mat-button
+              color="warn"
+              type="button"
+              class="paddingless"
+              (click)="toggleShowSearch()"
+              matTooltip="Close"
+              aria-label="Close"
+            >
+              <i class="fas fa-times"></i>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="panel-body panel-table">
+        <mdm-advanced-search-bar
+          [parent]="versionedFolder"
+          [showRestrictTo]="false"
+          [doNotShowDataModelInModelPath]="false"
+          [doNotDisplayModelPathStatus]="false"
+          [showDomainTypes]="[
+            'Folder',
+            'DataModel',
+            'DataClass',
+            'DataType',
+            'DataElement'
+          ]"
+        >
+        </mdm-advanced-search-bar>
+      </div>
+    </div>
+  </div>
+</div>
+
+<mat-tab-group
+  #tab
+  animationDuration="0ms"
+  [selectedIndex]="activeTab"
+  (selectedIndexChange)="tabSelected($event)"
+>
+  <mat-tab label="Description">
+    <ng-template matTabContent>
+      <div class="mb-2 full-width">
+        <div class="heading-container">
+          <div
+            fxFlex
+            fxLayout="row"
+            fxLayout.md="row"
+            fxLayout.sm="row"
+            fxLayout.xs="column"
+            fxLayoutAlign="space-around"
+          >
+            <div
+              fxFlex
+              fxLayout="row"
+              fxFlex="50"
+              fxFlex.md="50"
+              fxFlex.sm="100"
+              fxFlex.xs="100"
+              fxLayoutAlign="flex-start center"
+              fxLayoutAlign.xs="flex-start center"
+            >
+              <mat-form-field
+                appearance="outline"
+                class="paddingless"
+                style="max-width: 430px; width: 100%"
+              >
+                <mat-select
+                  [(ngModel)]="descriptionView"
+                  name="descriptionView"
+                  (ngModelChange)="changeProfile()"
+                >
+                  <mat-option value="default">Default profile</mat-option>
+                  <mat-divider></mat-divider>
+                  <mat-option
+                    *ngFor="let option of allUsedProfiles"
+                    [value]="option.value"
+                    >{{ option.display }}</mat-option
+                  >
+                  <mat-divider></mat-divider>
+                  <mat-option value="other">Other properties</mat-option>
+                  <mat-divider *ngIf="access?.canAddMetadata"></mat-divider>
+                  <mat-option *ngIf="access?.canAddMetadata" value="addnew">Add new profile...</mat-option
+                  >
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div
+              fxFlex
+              fxLayout="row"
+              fxFlex="50"
+              fxFlex.md="50"
+              fxFlex.sm="100"
+              fxFlex.xs="100"
+              fxLayoutAlign="flex-end center"
+              fxLayoutAlign.xs="flex-start center"
+            >
+              <button
+                mat-flat-button
+                *ngIf="
+                  this.descriptionView !== 'default' &&
+                  this.descriptionView !== 'other' &&
+                  this.descriptionView !== 'addNew' &&
+                  access?.showEdit
+                "
+                color="primary"
+                type="button"
+                class="mr-1"
+                (click)="editProfile(false)"
+              >
+                <i class="fas fa-pencil-alt"></i> Edit
+              </button>
+
+              <button
+                mat-flat-button
+                *ngIf="
+                  this.descriptionView !== 'default' &&
+                  this.descriptionView !== 'other' &&
+                  this.descriptionView !== 'addNew' &&
+                  access?.showPermanentDelete
+                "
+                color="warn"
+                type="button"
+                class="mr-1"
+                (click)="deleteProfile()"
+              >
+                <i class="fas fa-trash-alt"></i> Delete
+              </button>
+
+              <button
+                mat-flat-button
+                *ngIf="this.descriptionView === 'default' && access?.showEdit"
+                color="primary"
+                type="button"
+                class="mr-1"
+                (click)="editAll()"
+              >
+                Edit
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <mdm-profile-details
+          *ngIf="this.currentProfileDetails"
+          [currentProfileDetails]="this.currentProfileDetails"
+        ></mdm-profile-details>
+
+        <div class="full-width">
+          <mdm-data-set-metadata
+            *ngIf="this.descriptionView === 'other'"
+            [parent]="versionedFolder"
+            [type]="'dynamic'"
+            [domainType]="'versionedFolders'"
+            [isProfileView]="true"
+          ></mdm-data-set-metadata>
+        </div>
+        <form
+          editable-form
+          name="form"
+          (ngSubmit)="submitForm()"
+          disable-submit-on-enter
+        >
+          <table
+            *ngIf="this.descriptionView === 'default' && editor"
+            class="table table-bordered mdm--table-fixed"
+          >
+            <tbody>
+              <tr>
+                <td class="detailsRowHeader">Description</td>
+                <td class="elementDetailDescription">
+                  <div *ngIf="versionedFolder">
+                    <mdm-markdown-text-area
+                      [editableForm]="editor"
+                      [element]="versionedFolder"
+                      [property]="'description'"
+                    ></mdm-markdown-text-area>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <mdm-editable-form-buttons
+            *ngIf="editor"
+            [hidden]="!editor.isEditing"
+            [onCancelEdit]="cancelEdit"
+            [editable]="editor"
+            [textLocation]="'left'"
+            [hideDelete]="true"
+            [hideCancel]="false"
+          ></mdm-editable-form-buttons>
+        </form>
+      </div>
+    </ng-template>
+  </mat-tab>
+  <mat-tab label="Annotations">
+    <ng-template matTabContent>
+      <div class="full-width">
+        <div class="heading-container">
+          <div
+            fxFlex
+            fxLayout="row"
+            fxLayout.md="row"
+            fxLayout.sm="row"
+            fxLayout.xs="column"
+            fxLayoutAlign="space-around"
+          >
+            <div
+              fxFlex
+              fxLayout="row"
+              fxFlex="50"
+              fxFlex.md="50"
+              fxFlex.sm="100"
+              fxFlex.xs="100"
+              fxLayoutAlign="flex-start center"
+              fxLayoutAlign.xs="flex-start center"
+            >
+              <mat-form-field
+                appearance="outline"
+                class="paddingless"
+                style="max-width: 230px; width: 100%"
+              >
+                <mat-select
+                  [(ngModel)]="annotationsView"
+                  name="annotationsView"
+                >
+                  <mat-option value="default">Comments</mat-option>
+                  <mat-option value="attachments">Attachments</mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+            <div
+              fxFlex
+              fxLayout="row"
+              fxFlex="50"
+              fxFlex.md="50"
+              fxFlex.sm="100"
+              fxFlex.xs="100"
+              fxLayoutAlign="flex-end center"
+              fxLayoutAlign.xs="flex-start center"
+            ></div>
+          </div>
+        </div>
+
+        <div *ngIf="annotationsView === 'default'">
+          <mdm-annotation-list
+            *ngIf="versionedFolder"
+            [parent]="versionedFolder"
+            [domainType]="'versionedFolders'"
+          ></mdm-annotation-list>
+        </div>
+
+        <div
+          class="mdm--shadow-block bordered"
+          *ngIf="annotationsView === 'attachments'"
+        >
+          <div class="pxy-2">
+            <mdm-attachment-list
+              *ngIf="versionedFolder"
+              [parent]="versionedFolder"
+              [domainType]="'versionedFolders'"
+            ></mdm-attachment-list>
+          </div>
+        </div>
+      </div>
+    </ng-template>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      History
+      <span *ngIf="isLoadingHistory" class="mdm--skeleton-badge">
+        <ngx-skeleton-loader
+          count="1"
+          appearance="circle"
+          [theme]="{
+            'border-radius': '5px',
+            height: '31px',
+            width: '28px',
+            'background-color': '#b7bbc5'
+          }"
+        ></ngx-skeleton-loader>
+      </span>
+      ({{ historyItemCount }})
+    </ng-template>
+
+    <div class="full-width">
+      <mdm-history
+        (totalCount)="historyCountEmitter($event)"
+        *ngIf="versionedFolder"
+        [parent]="versionedFolder"
+        [parentType]="'VersionedFolder'"
+        [parentId]="parentId"
+        [domainType]="'versionedFolders'"
+      ></mdm-history>
+    </div>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      Rules
+      <span *ngIf="isLoadingRules" class="mdm--skeleton-badge">
+        <ngx-skeleton-loader
+          count="1"
+          appearance="circle"
+          [theme]="{
+            'border-radius': '5px',
+            height: '31px',
+            width: '28px',
+            'background-color': '#b7bbc5'
+          }"
+        ></ngx-skeleton-loader>
+      </span>
+      ({{ rulesItemCount }})
+    </ng-template>
+    <div class="full-width">
+      <mdm-constraints-rules
+        *ngIf="versionedFolder"
+        [parent]="versionedFolder"
+        [domainType]="'versionedFolders'"
+        (totalCount)="rulesCountEmitter($event)"
+      ></mdm-constraints-rules>
+    </div>
+  </mat-tab>
+</mat-tab-group>

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
@@ -63,7 +63,7 @@ SPDX-License-Identifier: Apache-2.0
 <mat-tab-group
   #tab
   animationDuration="0ms"
-  [selectedIndex]="activeTab"
+  [selectedIndex]="activeTab.index"
   (selectedIndexChange)="tabSelected($event)"
 >
   <mat-tab label="Description">

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
@@ -17,7 +17,12 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="full-width">
-  <mdm-versioned-folder-detail *ngIf="detail" [detail]="detail" [access]="access"></mdm-versioned-folder-detail>
+  <mdm-versioned-folder-detail
+    *ngIf="detail"
+    [detail]="detail"
+    [access]="access"
+    (afterSave)="afterDetailSave($event)"
+  ></mdm-versioned-folder-detail>
 </div>
 <div *ngIf="showSearch" style="clear: both">
   <div class="mdm--shadow-block">
@@ -108,7 +113,8 @@ SPDX-License-Identifier: Apache-2.0
                   <mat-divider></mat-divider>
                   <mat-option value="other">Other properties</mat-option>
                   <mat-divider *ngIf="access?.canAddMetadata"></mat-divider>
-                  <mat-option *ngIf="access?.canAddMetadata" value="addnew">Add new profile...</mat-option
+                  <mat-option *ngIf="access?.canAddMetadata" value="addnew"
+                    >Add new profile...</mat-option
                   >
                 </mat-select>
               </mat-form-field>
@@ -161,7 +167,7 @@ SPDX-License-Identifier: Apache-2.0
                 color="primary"
                 type="button"
                 class="mr-1"
-                (click)="editAll()"
+                (click)="showForm()"
               >
                 Edit
               </button>
@@ -184,9 +190,10 @@ SPDX-License-Identifier: Apache-2.0
           ></mdm-data-set-metadata>
         </div>
         <form
-          editable-form
+          *ngIf="editor"
           name="form"
-          (ngSubmit)="submitForm()"
+          [formGroup]="editor.formGroup"
+          (ngSubmit)="save()"
           disable-submit-on-enter
         >
           <table
@@ -197,13 +204,11 @@ SPDX-License-Identifier: Apache-2.0
               <tr>
                 <td class="detailsRowHeader">Description</td>
                 <td class="elementDetailDescription">
-                  <div *ngIf="detail">
-                    <mdm-markdown-text-area
-                      [editableForm]="editor"
-                      [element]="detail"
-                      [property]="'description'"
-                    ></mdm-markdown-text-area>
-                  </div>
+                  <mdm-content-editor
+                    [description]="editor.form.description.value"
+                    (descriptionChange)="editor.form.descriptionValue = $event"
+                    [inEditMode]="editor.isEditing"
+                  ></mdm-content-editor>
                 </td>
               </tr>
             </tbody>
@@ -211,7 +216,7 @@ SPDX-License-Identifier: Apache-2.0
           <mdm-editable-form-buttons
             *ngIf="editor"
             [hidden]="!editor.isEditing"
-            [onCancelEdit]="cancelEdit"
+            [onCancelEdit]="cancel"
             [editable]="editor"
             [textLocation]="'left'"
             [hideDelete]="true"

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
@@ -20,7 +20,6 @@ SPDX-License-Identifier: Apache-2.0
   <mdm-versioned-folder-detail
     *ngIf="detail"
     [detail]="detail"
-    [access]="access"
     (afterSave)="afterDetailsSaved($event)"
   ></mdm-versioned-folder-detail>
 </div>

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
@@ -1,0 +1,19 @@
+<!--
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<p>versioned-folder works!</p>

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.html
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
     *ngIf="detail"
     [detail]="detail"
     [access]="access"
-    (afterSave)="afterDetailSave($event)"
+    (afterSave)="afterDetailsSaved($event)"
   ></mdm-versioned-folder-detail>
 </div>
 <div *ngIf="showSearch" style="clear: both">

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.scss
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.ts
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mdm-versioned-folder',
+  templateUrl: './versioned-folder.component.html',
+  styleUrls: ['./versioned-folder.component.scss']
+})
+export class VersionedFolderComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.ts
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.ts
@@ -16,18 +16,238 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatTabGroup } from '@angular/material/tabs';
+import { Title } from '@angular/platform-browser';
+import { ContainerUpdatePayload, PermissionsResponse, SecurableDomainType, Uuid, VersionedFolderDetail, VersionedFolderDetailResponse } from '@maurodatamapper/mdm-resources';
+import { DefaultContainerProfileEditor, DefaultContainerProfileForm, Editable } from '@mdm/model/editable-forms';
+import { AnnotationViewOption, TabDescriptor } from '@mdm/model/ui.model';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { ProfileBaseComponent } from '@mdm/profile-base/profile-base.component';
+import { MessageHandlerService, MessageService, SecurityHandlerService, SharedService, StateHandlerService } from '@mdm/services';
+import { EditingService } from '@mdm/services/editing.service';
+import { ContainerAccess } from '@mdm/services/handlers/security-handler.model';
+import { UIRouterGlobals } from '@uirouter/angular';
+import { EMPTY, Subject, Subscription } from 'rxjs';
+import { catchError, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'mdm-versioned-folder',
   templateUrl: './versioned-folder.component.html',
   styleUrls: ['./versioned-folder.component.scss']
 })
-export class VersionedFolderComponent implements OnInit {
+export class VersionedFolderComponent extends ProfileBaseComponent implements OnInit, AfterViewInit, OnDestroy {
 
-  constructor() { }
+  @ViewChild('tab', { static: false }) tabGroup: MatTabGroup;
 
-  ngOnInit(): void {
+  parentId: Uuid;
+  versionedFolder: VersionedFolderDetail;
+  showSecuritySection: boolean;
+
+  activeTab: TabDescriptor;
+  editor: DefaultContainerProfileEditor<VersionedFolderDetail>;
+  access: ContainerAccess;
+
+  showSearch = false;
+  showExtraTabs = false;
+
+  annotationsView: AnnotationViewOption = 'default';
+  historyItemCount = 0;
+  isLoadingHistory = true;
+  rulesItemCount = 0;
+  isLoadingRules = true;
+
+  private subscriptions: Subscription[] = [];
+  private unsubscribe$ = new Subject<void>();
+
+  constructor(
+    resources: MdmResourcesService,
+    private messages: MessageService,
+    private shared: SharedService,
+    private uiRouterGlobals: UIRouterGlobals,
+    private stateHandler: StateHandlerService,
+    private securityHandler: SecurityHandlerService,
+    private title: Title,
+    dialog: MatDialog,
+    messageHandler: MessageHandlerService,
+    editingService: EditingService
+  ) {
+    super(resources, dialog, editingService, messageHandler);
   }
 
+  ngOnInit(): void {
+    // Feature toggle guard
+    if (!this.shared.features.useVersionedFolders) {
+      this.stateHandler.NotFound({ location: false });
+      return;
+    }
+
+    if (!this.uiRouterGlobals.params.id) {
+      this.stateHandler.NotFound({ location: false });
+      return;
+    }
+
+    this.showExtraTabs = this.shared.isLoggedIn();
+    this.parentId = this.uiRouterGlobals.params.id;
+
+    this.activeTab = this.getTabByName(this.uiRouterGlobals.params.tabView);
+    this.tabSelected(this.activeTab);
+
+    this.title.setTitle('Versioned Folder');
+
+    this.loadDetails(this.parentId);
+
+    this.subscriptions.push(
+      this.messages.changeSearch.subscribe((show: boolean) => {
+        this.showSearch = show;
+      }));
+  }
+
+  ngAfterViewInit(): void {
+    this.editingService.setTabGroupClickEvent(this.tabGroup);
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(sub => sub.unsubscribe());
+
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  tabSelected(tab: TabDescriptor | number) {
+    const selected = typeof tab === 'number' ? this.getTabByIndex(tab) : tab;
+    this.stateHandler.Go(
+      'versionedFolder',
+      { tabView: selected.name },
+      { notify: false });
+  }
+
+  toggleShowSearch() {
+    this.messages.toggleSearch();
+  }
+
+  editAll() {
+    this.editor.show();
+  };
+
+  cancelEdit() {
+    this.editor?.cancel();
+  }
+
+  submitForm() {
+    this.editingService.stop();
+
+    const resource: ContainerUpdatePayload = {
+      id: this.versionedFolder.id,
+      description: this.editor.form.description ?? ''
+    };
+
+    this.resourcesService.versionedFolder
+      .update(this.versionedFolder.id, resource)
+      .pipe(
+        catchError(error => {
+          this.messageHandler.showError('There was a problem updating the Versioned Folder.', error);
+          return EMPTY;
+        })
+      )
+      .subscribe((response: VersionedFolderDetailResponse) => {
+        this.messageHandler.showSuccess('Versioned Folder updated successfully.');
+        this.versionedFolder = response.body;
+        this.editor.isEditing = false;
+        this.editor.reset(this.versionedFolder);
+      });
+  };
+
+  historyCountEmitter(value: number) {
+    this.isLoadingHistory = false;
+    this.historyItemCount = value;
+  }
+
+  rulesCountEmitter($event) {
+    this.isLoadingRules = false;
+    this.rulesItemCount = $event;
+  }
+
+  private loadDetails(id: Uuid) {
+    this.resourcesService.versionedFolder
+      .get(id)
+      .subscribe((response: VersionedFolderDetailResponse) => {
+        this.versionedFolder = response.body;
+        this.catalogueItem = this.versionedFolder;
+        this.access = this.securityHandler.defineCatalogueItemAccess(this.versionedFolder);
+
+        if (this.shared.isLoggedIn(true)) {
+          this.checkPermissions(id);
+          // TODO: load profiles once backend supports it
+          // this.UsedProfiles(ModelDomainType.VERSIONED_FOLDERS, id);
+          // this.UnUsedProfiles(ModelDomainType.VERSIONED_FOLDERS, id);
+        } else {
+          this.messages.FolderSendMessage(this.versionedFolder);
+          this.messages.dataChanged(this.versionedFolder);
+        }
+
+        this.editor = new Editable<VersionedFolderDetail, DefaultContainerProfileForm<VersionedFolderDetail>>(
+          this.versionedFolder,
+          new DefaultContainerProfileForm());
+
+        this.editor.onShow
+          .pipe(takeUntil(this.unsubscribe$))
+          .subscribe(() => {
+            this.editingService.start();
+          });
+
+        this.editor.onCancel
+          .pipe(takeUntil(this.unsubscribe$))
+          .subscribe(() => {
+            this.editingService.stop();
+          });
+      });
+  }
+
+  private checkPermissions(id: Uuid) {
+    this.resourcesService.security
+      .permissions(SecurableDomainType.VersionedFolders, id)
+      .subscribe((response: PermissionsResponse) => {
+        Object
+          .keys(response.body)
+          .forEach((attrname) => {
+            this.versionedFolder[attrname] = response.body[attrname];
+          });
+
+        // Send it to message service to receive in child components
+        this.messages.FolderSendMessage(this.versionedFolder);
+        this.messages.dataChanged(this.versionedFolder);
+      });
+  }
+
+  private getTabByName(tabName: string): TabDescriptor {
+    switch (tabName) {
+      case 'description':
+        return { index: 0, name: 'description' };
+      case 'annotations':
+        return { index: 1, name: 'annotations' };
+      case 'history':
+        return { index: 2, name: 'history' };
+      case 'rulesConstraints':
+        return { index: 3, name: 'rulesConstraints' };
+      default:
+        return { index: 0, name: 'description' };
+    }
+  }
+
+  private getTabByIndex(index: number) {
+    switch (index) {
+      case 0:
+        return { index: 0, name: 'description' };
+      case 1:
+        return { index: 1, name: 'annotations' };
+      case 2:
+        return { index: 2, name: 'history' };
+      case 3:
+        return { index: 3, name: 'rulesConstraints' };
+      default:
+        return { index: 0, name: 'description' };
+    }
+  }
 }

--- a/src/app/versioned-folder/versioned-folder/versioned-folder.component.ts
+++ b/src/app/versioned-folder/versioned-folder/versioned-folder.component.ts
@@ -21,13 +21,13 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatTabGroup } from '@angular/material/tabs';
 import { Title } from '@angular/platform-browser';
 import { PermissionsResponse, SecurableDomainType, Uuid, VersionedFolderDetail, VersionedFolderDetailResponse } from '@maurodatamapper/mdm-resources';
+import { Access } from '@mdm/model/access';
 import { ContainerDefaultProfileForm, FormState } from '@mdm/model/editable-forms';
 import { AnnotationViewOption, TabDescriptor } from '@mdm/model/ui.model';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { ProfileBaseComponent } from '@mdm/profile-base/profile-base.component';
 import { MessageHandlerService, MessageService, SecurityHandlerService, SharedService, StateHandlerService } from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
-import { ContainerAccess } from '@mdm/services/handlers/security-handler.model';
 import { UIRouterGlobals } from '@uirouter/angular';
 import { EMPTY, Subject, Subscription } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
@@ -46,7 +46,7 @@ export class VersionedFolderComponent extends ProfileBaseComponent implements On
 
   activeTab: TabDescriptor;
   editor: FormState<VersionedFolderDetail, ContainerDefaultProfileForm<VersionedFolderDetail>>;
-  access: ContainerAccess;
+  access: Access;
 
   showSearch = false;
   showExtraTabs = false;
@@ -187,7 +187,7 @@ export class VersionedFolderComponent extends ProfileBaseComponent implements On
   private setupDetails(value: VersionedFolderDetail) {
     this.detail = value;
     this.catalogueItem = this.detail;
-    this.access = this.securityHandler.defineCatalogueItemAccess(this.detail);
+    this.access = this.securityHandler.elementAccess(this.detail);
 
     if (this.shared.isLoggedIn(true)) {
       this.checkPermissions(this.detail.id);


### PR DESCRIPTION
Create the parent/child detail view components to render the details for Versioned Folders. Displays:

* Standard details - a mixture of folder (container) properties and data model (versionable) properties
* Description tab
* Annotations tab
* History tab
* Rules tab
* User access/permissions

Known issues:

* Any versioned folders created are not yet visible in the tree, but can be accessed by their route URL
* The property metadata view of versioned folders do not work because profiles are not supported in the backend yet

The form editing capabilities of the parent/detail components has been changed to try and create state tracking objects for the forms. Some of the form details have been modified to use Angular reactive forms and `FormGroups` instead for tidier input changes and validation. Because this is a departure from the other views, this can be up for debate.

Also up for debate are changes to names - trying to match some of the changes already made in PR #140, any other suggestions can be commented on.