### PR TITLE
Feature/mc 9546 Feature flag and module for new Merge Diff UI

### DIFF
--- a/custom-webpack.config.js
+++ b/custom-webpack.config.js
@@ -25,6 +25,7 @@ module.exports = {
         themeName: JSON.stringify(process.env['MDM_UI_THEME_NAME']),
         useFeaureSubscribedCatalogues: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_SUBSCRIBED_CATALOGUES'])),
         useVersionedFolders: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_VERSIONED_FOLDERS'])),
+        useMergeUiV2: Boolean(JSON.stringify(process.env['MDM_UI_MERGE_UI_V2'])),
       }
     })
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "jszip-utils": "^0.1.0",
         "lodash": "4.17.21",
         "marked": "^2.0.1",
+        "ng-mocks": "^9.6.4",
         "ng2-charts": "2.3.3",
         "ngx-ace-wrapper": "^11.0.0",
         "ngx-clipboard": "13.0.1",
@@ -1018,6 +1019,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.10.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
@@ -1283,6 +1285,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.10.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/helper-validator-option": {
@@ -1333,6 +1336,7 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.10.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.10.4",
@@ -2211,6 +2215,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2230,6 +2235,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2244,6 +2250,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "12.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.8.1"
@@ -2257,6 +2264,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -2264,6 +2272,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/import-fresh": {
       "version": "3.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -2275,6 +2284,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2282,6 +2292,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.8.1",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -4308,6 +4319,7 @@
     },
     "node_modules/acorn": {
       "version": "6.4.2",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4338,6 +4350,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.1",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4395,6 +4408,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -4514,6 +4528,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
@@ -4580,6 +4595,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -4587,6 +4603,7 @@
     },
     "node_modules/argparse/node_modules/sprintf-js": {
       "version": "1.0.3",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/aria-query": {
@@ -4765,6 +4782,7 @@
     },
     "node_modules/astral-regex": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5074,6 +5092,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base": {
@@ -5293,6 +5312,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5529,6 +5549,7 @@
     },
     "node_modules/builtin-modules": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5805,6 +5826,7 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
@@ -6105,7 +6127,6 @@
     "node_modules/codelyzer/node_modules/@angular/compiler": {
       "version": "9.0.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "tslib": "^1.10.0"
       }
@@ -6113,7 +6134,6 @@
     "node_modules/codelyzer/node_modules/@angular/core": {
       "version": "9.0.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "rxjs": "^6.5.3",
         "tslib": "^1.10.0",
@@ -6290,6 +6310,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -6526,6 +6547,7 @@
     },
     "node_modules/core-js": {
       "version": "3.6.4",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -7033,6 +7055,7 @@
     },
     "node_modules/debug": {
       "version": "4.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -7256,6 +7279,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -7519,6 +7543,7 @@
     },
     "node_modules/diff": {
       "version": "4.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -7668,6 +7693,7 @@
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -7877,6 +7903,7 @@
     },
     "node_modules/emoji-regex": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/emojis-list": {
@@ -7936,6 +7963,7 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^4.1.1"
@@ -7946,6 +7974,7 @@
     },
     "node_modules/enquirer/node_modules/ansi-colors": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8051,6 +8080,7 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -8134,6 +8164,7 @@
     },
     "node_modules/eslint": {
       "version": "7.10.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -8426,6 +8457,7 @@
     },
     "node_modules/eslint-utils": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
@@ -8439,6 +8471,7 @@
     },
     "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -8454,6 +8487,7 @@
     },
     "node_modules/eslint/node_modules/ansi-regex": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8461,6 +8495,7 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -8474,6 +8509,7 @@
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -8488,6 +8524,7 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -8498,6 +8535,7 @@
     },
     "node_modules/eslint/node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8510,6 +8548,7 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -8517,6 +8556,7 @@
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "12.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.8.1"
@@ -8530,6 +8570,7 @@
     },
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8537,6 +8578,7 @@
     },
     "node_modules/eslint/node_modules/ignore": {
       "version": "4.0.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -8544,6 +8586,7 @@
     },
     "node_modules/eslint/node_modules/import-fresh": {
       "version": "3.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -8555,6 +8598,7 @@
     },
     "node_modules/eslint/node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8562,6 +8606,7 @@
     },
     "node_modules/eslint/node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -8569,6 +8614,7 @@
     },
     "node_modules/eslint/node_modules/semver": {
       "version": "7.3.2",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8579,6 +8625,7 @@
     },
     "node_modules/eslint/node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8589,6 +8636,7 @@
     },
     "node_modules/eslint/node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8596,6 +8644,7 @@
     },
     "node_modules/eslint/node_modules/strip-ansi": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.0"
@@ -8606,6 +8655,7 @@
     },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8616,6 +8666,7 @@
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.8.1",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -8623,6 +8674,7 @@
     },
     "node_modules/eslint/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8636,6 +8688,7 @@
     },
     "node_modules/espree": {
       "version": "7.3.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^7.4.0",
@@ -8648,6 +8701,7 @@
     },
     "node_modules/espree/node_modules/acorn": {
       "version": "7.4.1",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -8658,6 +8712,7 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
@@ -8665,6 +8720,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -8676,6 +8732,7 @@
     },
     "node_modules/esquery": {
       "version": "1.3.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -8686,6 +8743,7 @@
     },
     "node_modules/esquery/node_modules/estraverse": {
       "version": "5.2.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -8717,6 +8775,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9122,6 +9181,7 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -9147,10 +9207,12 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastparse": {
@@ -9213,6 +9275,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^2.0.1"
@@ -9419,6 +9482,7 @@
     },
     "node_modules/flat-cache": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^2.0.0",
@@ -9431,6 +9495,7 @@
     },
     "node_modules/flat-cache/node_modules/rimraf": {
       "version": "2.6.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -9441,6 +9506,7 @@
     },
     "node_modules/flatted": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/flush-write-stream": {
@@ -9570,14 +9636,17 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/genfun": {
@@ -9678,6 +9747,7 @@
     },
     "node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -9696,6 +9766,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9834,6 +9905,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -9855,6 +9927,7 @@
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10476,6 +10549,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -10522,6 +10596,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -10813,6 +10888,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
@@ -10907,6 +10983,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10914,6 +10991,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10929,6 +11007,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -11137,6 +11216,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -13927,8 +14007,7 @@
     },
     "node_modules/jodit-angular/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/jointjs": {
       "version": "3.3.1",
@@ -13947,10 +14026,12 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.14.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -14096,10 +14177,12 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
@@ -14328,6 +14411,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -14980,6 +15064,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -14990,6 +15075,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/minipass": {
@@ -15093,6 +15179,7 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5"
@@ -15150,6 +15237,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -15197,6 +15285,7 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -15211,6 +15300,16 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ng-mocks": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/ng-mocks/-/ng-mocks-9.6.4.tgz",
+      "integrity": "sha512-hyhTVoy4RUi3bufOmxnx1VMIN5c1fnJFnN94mPv8+e1jjwdVQlX0CXkLnkgFJWfL1XV/Eogj19OzqBhyrmF4fw==",
+      "peerDependencies": {
+        "@angular/compiler": ">=5.x <=9.x",
+        "@angular/core": ">=5.x <=9.x",
+        "@angular/forms": ">=5.x <=9.x"
+      }
     },
     "node_modules/ng2-charts": {
       "version": "2.3.3",
@@ -15916,6 +16015,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -15978,6 +16078,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -16401,6 +16502,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -16411,6 +16513,7 @@
     },
     "node_modules/parent-module/node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16493,6 +16596,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16513,6 +16617,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
@@ -17344,6 +17449,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -17839,6 +17945,7 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -18362,6 +18469,7 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18766,6 +18874,7 @@
     },
     "node_modules/regexpp": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18927,6 +19036,7 @@
     },
     "node_modules/resolve": {
       "version": "1.19.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.1.0",
@@ -19811,6 +19921,7 @@
     },
     "node_modules/slice-ansi": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.0",
@@ -20471,6 +20582,7 @@
     },
     "node_modules/string-width": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^7.0.1",
@@ -20483,6 +20595,7 @@
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -20490,6 +20603,7 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
@@ -20567,6 +20681,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20744,6 +20859,7 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
@@ -20828,6 +20944,7 @@
     },
     "node_modules/table": {
       "version": "5.4.6",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^6.10.2",
@@ -21133,6 +21250,7 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/throat": {
@@ -21440,6 +21558,7 @@
     },
     "node_modules/tslint": {
       "version": "6.1.3",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -21468,10 +21587,12 @@
     },
     "node_modules/tslint/node_modules/tslib": {
       "version": "1.14.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tslint/node_modules/tsutils": {
       "version": "2.29.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.8.1"
@@ -21522,6 +21643,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -21576,6 +21698,7 @@
     },
     "node_modules/typescript": {
       "version": "3.8.3",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21791,6 +21914,7 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -21940,6 +22064,7 @@
     },
     "node_modules/v8-compile-cache": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -23149,6 +23274,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23231,10 +23357,12 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mkdirp": "^0.5.1"
@@ -23682,8 +23810,7 @@
       }
     },
     "@angular/animations": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@angular/cdk": {
       "version": "9.2.4",
@@ -23773,12 +23900,10 @@
       }
     },
     "@angular/common": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@angular/compiler": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@angular/compiler-cli": {
       "version": "9.1.12",
@@ -23920,39 +24045,33 @@
       }
     },
     "@angular/core": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@angular/flex-layout": {
-      "version": "9.0.0-beta.31",
-      "requires": {}
+      "version": "9.0.0-beta.31"
     },
     "@angular/forms": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@angular/language-service": {
       "version": "9.1.12",
       "dev": true
     },
     "@angular/material": {
-      "version": "9.2.4",
-      "requires": {}
+      "version": "9.2.4"
     },
     "@angular/platform-browser": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@angular/platform-browser-dynamic": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@angular/router": {
-      "version": "9.1.12",
-      "requires": {}
+      "version": "9.1.12"
     },
     "@babel/code-frame": {
       "version": "7.10.4",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -24179,7 +24298,8 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4"
+      "version": "7.10.4",
+      "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.12.1",
@@ -24228,6 +24348,7 @@
     },
     "@babel/highlight": {
       "version": "7.10.4",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
@@ -24846,6 +24967,7 @@
     },
     "@eslint/eslintrc": {
       "version": "0.1.3",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
@@ -24861,6 +24983,7 @@
       "dependencies": {
         "ajv": {
           "version": "6.12.6",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -24870,25 +24993,30 @@
         },
         "globals": {
           "version": "12.4.0",
+          "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
           }
         },
         "ignore": {
-          "version": "4.0.6"
+          "version": "4.0.6",
+          "dev": true
         },
         "import-fresh": {
           "version": "3.2.2",
+          "dev": true,
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
         },
         "resolve-from": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "type-fest": {
-          "version": "0.8.1"
+          "version": "0.8.1",
+          "dev": true
         }
       }
     },
@@ -26060,8 +26188,7 @@
       "version": "6.0.6"
     },
     "@uirouter/rx": {
-      "version": "0.6.5",
-      "requires": {}
+      "version": "0.6.5"
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -26231,7 +26358,8 @@
       "version": "1.4.12"
     },
     "acorn": {
-      "version": "6.4.2"
+      "version": "6.4.2",
+      "dev": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -26249,7 +26377,7 @@
     },
     "acorn-jsx": {
       "version": "5.3.1",
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -26283,6 +26411,7 @@
     },
     "ajv": {
       "version": "6.12.3",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -26292,13 +26421,11 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -26354,6 +26481,7 @@
     },
     "ansi-styles": {
       "version": "3.2.1",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -26396,12 +26524,14 @@
     },
     "argparse": {
       "version": "1.0.10",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
-          "version": "1.0.3"
+          "version": "1.0.3",
+          "dev": true
         }
       }
     },
@@ -26524,7 +26654,8 @@
       "version": "0.0.7"
     },
     "astral-regex": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "async": {
       "version": "2.6.3",
@@ -26726,7 +26857,8 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -26877,6 +27009,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -27053,7 +27186,8 @@
       "dev": true
     },
     "builtin-modules": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -27247,6 +27381,7 @@
     },
     "chalk": {
       "version": "2.4.2",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -27328,8 +27463,7 @@
     },
     "circular-dependency-plugin": {
       "version": "5.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "cjs-module-lexer": {
       "version": "0.6.0",
@@ -27443,6 +27577,8 @@
     "codelyzer": {
       "version": "6.0.1",
       "requires": {
+        "@angular/compiler": "9.0.0",
+        "@angular/core": "9.0.0",
         "app-root-path": "^3.0.0",
         "aria-query": "^3.0.0",
         "axobject-query": "2.0.2",
@@ -27458,14 +27594,10 @@
       },
       "dependencies": {
         "@angular/compiler": {
-          "version": "9.0.0",
-          "peer": true,
-          "requires": {}
+          "version": "9.0.0"
         },
         "@angular/core": {
-          "version": "9.0.0",
-          "peer": true,
-          "requires": {}
+          "version": "9.0.0"
         },
         "tslib": {
           "version": "1.14.1"
@@ -27599,7 +27731,8 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -27758,7 +27891,8 @@
       }
     },
     "core-js": {
-      "version": "3.6.4"
+      "version": "3.6.4",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.8.0",
@@ -28125,6 +28259,7 @@
     },
     "debug": {
       "version": "4.3.1",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -28273,7 +28408,8 @@
       }
     },
     "deep-is": {
-      "version": "0.1.3"
+      "version": "0.1.3",
+      "dev": true
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -28459,7 +28595,8 @@
       "version": "5.2.1"
     },
     "diff": {
-      "version": "4.0.2"
+      "version": "4.0.2",
+      "dev": true
     },
     "diff-match-patch": {
       "version": "1.0.5"
@@ -28586,6 +28723,7 @@
     },
     "doctrine": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -28739,7 +28877,8 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "7.0.3"
+      "version": "7.0.3",
+      "dev": true
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -28783,12 +28922,14 @@
     },
     "enquirer": {
       "version": "2.3.6",
+      "dev": true,
       "requires": {
         "ansi-colors": "^4.1.1"
       },
       "dependencies": {
         "ansi-colors": {
-          "version": "4.1.1"
+          "version": "4.1.1",
+          "dev": true
         }
       }
     },
@@ -28860,7 +29001,8 @@
       "version": "1.0.3"
     },
     "escape-string-regexp": {
-      "version": "1.0.5"
+      "version": "1.0.5",
+      "dev": true
     },
     "escodegen": {
       "version": "1.14.3",
@@ -28913,6 +29055,7 @@
     },
     "eslint": {
       "version": "7.10.0",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@eslint/eslintrc": "^0.1.3",
@@ -28954,16 +29097,19 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0"
+          "version": "5.0.0",
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.0",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -28971,12 +29117,14 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "cross-spawn": {
           "version": "7.0.3",
+          "dev": true,
           "requires": {
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
@@ -28984,62 +29132,76 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "dev": true
         },
         "globals": {
           "version": "12.4.0",
+          "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
           }
         },
         "has-flag": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "ignore": {
-          "version": "4.0.6"
+          "version": "4.0.6",
+          "dev": true
         },
         "import-fresh": {
           "version": "3.2.2",
+          "dev": true,
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
           }
         },
         "path-key": {
-          "version": "3.1.1"
+          "version": "3.1.1",
+          "dev": true
         },
         "resolve-from": {
-          "version": "4.0.0"
+          "version": "4.0.0",
+          "dev": true
         },
         "semver": {
-          "version": "7.3.2"
+          "version": "7.3.2",
+          "dev": true
         },
         "shebang-command": {
           "version": "2.0.0",
+          "dev": true,
           "requires": {
             "shebang-regex": "^3.0.0"
           }
         },
         "shebang-regex": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
         },
         "supports-color": {
           "version": "7.2.0",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
         },
         "type-fest": {
-          "version": "0.8.1"
+          "version": "0.8.1",
+          "dev": true
         },
         "which": {
           "version": "2.0.2",
+          "dev": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -29196,8 +29358,7 @@
     },
     "eslint-plugin-prefer-arrow": {
       "version": "1.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "3.1.4",
@@ -29215,12 +29376,14 @@
     },
     "eslint-utils": {
       "version": "2.1.0",
+      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "dev": true
         }
       }
     },
@@ -29230,6 +29393,7 @@
     },
     "espree": {
       "version": "7.3.0",
+      "dev": true,
       "requires": {
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.2.0",
@@ -29237,24 +29401,29 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "7.4.1"
+          "version": "7.4.1",
+          "dev": true
         },
         "eslint-visitor-keys": {
-          "version": "1.3.0"
+          "version": "1.3.0",
+          "dev": true
         }
       }
     },
     "esprima": {
-      "version": "4.0.1"
+      "version": "4.0.1",
+      "dev": true
     },
     "esquery": {
       "version": "1.3.1",
+      "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0"
+          "version": "5.2.0",
+          "dev": true
         }
       }
     },
@@ -29273,7 +29442,8 @@
       "version": "4.3.0"
     },
     "esutils": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -29565,7 +29735,8 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.3"
+      "version": "3.1.3",
+      "dev": true
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -29584,10 +29755,12 @@
       }
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "fast-levenshtein": {
-      "version": "2.0.6"
+      "version": "2.0.6",
+      "dev": true
     },
     "fastparse": {
       "version": "1.1.2"
@@ -29633,6 +29806,7 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
       }
@@ -29763,6 +29937,7 @@
     },
     "flat-cache": {
       "version": "2.0.1",
+      "dev": true,
       "requires": {
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
@@ -29771,6 +29946,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -29778,7 +29954,8 @@
       }
     },
     "flatted": {
-      "version": "2.0.2"
+      "version": "2.0.2",
+      "dev": true
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -29863,13 +30040,16 @@
       }
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "function-bind": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "functional-red-black-tree": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "genfun": {
       "version": "5.0.0",
@@ -29931,6 +30111,7 @@
     },
     "glob": {
       "version": "7.1.6",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -29942,6 +30123,7 @@
     },
     "glob-parent": {
       "version": "5.1.1",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -30038,6 +30220,7 @@
     },
     "has": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -30050,7 +30233,8 @@
       }
     },
     "has-flag": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -30483,7 +30667,8 @@
       }
     },
     "imurmurhash": {
-      "version": "0.1.4"
+      "version": "0.1.4",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -30516,6 +30701,7 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -30709,6 +30895,7 @@
     },
     "is-core-module": {
       "version": "2.2.0",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -30761,10 +30948,12 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -30772,6 +30961,7 @@
     },
     "is-glob": {
       "version": "4.0.1",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -30889,7 +31079,8 @@
       "version": "1.0.0"
     },
     "isexe": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -32020,8 +32211,7 @@
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-preset-angular": {
       "version": "8.3.1",
@@ -32684,11 +32874,12 @@
     },
     "jodit-angular": {
       "version": "1.0.119",
-      "requires": {},
+      "requires": {
+        "tslib": "^1.9.0"
+      },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "peer": true
+          "version": "1.14.1"
         }
       }
     },
@@ -32706,10 +32897,12 @@
       "version": "3.5.1"
     },
     "js-tokens": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.0",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -32770,8 +32963,7 @@
         },
         "ws": {
           "version": "7.4.0",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -32796,10 +32988,12 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1"
+      "version": "0.4.1",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -32954,6 +33148,7 @@
     },
     "levn": {
       "version": "0.4.1",
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -33422,12 +33617,14 @@
     },
     "minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.5"
+      "version": "1.2.5",
+      "dev": true
     },
     "minipass": {
       "version": "3.1.3",
@@ -33500,6 +33697,7 @@
     },
     "mkdirp": {
       "version": "0.5.5",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -33543,7 +33741,8 @@
       }
     },
     "ms": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -33579,7 +33778,8 @@
       }
     },
     "natural-compare": {
-      "version": "1.4.0"
+      "version": "1.4.0",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.2",
@@ -33588,6 +33788,11 @@
     "neo-async": {
       "version": "2.6.2",
       "dev": true
+    },
+    "ng-mocks": {
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/ng-mocks/-/ng-mocks-9.6.4.tgz",
+      "integrity": "sha512-hyhTVoy4RUi3bufOmxnx1VMIN5c1fnJFnN94mPv8+e1jjwdVQlX0CXkLnkgFJWfL1XV/Eogj19OzqBhyrmF4fw=="
     },
     "ng2-charts": {
       "version": "2.3.3",
@@ -33630,8 +33835,7 @@
       }
     },
     "ngx-json-viewer": {
-      "version": "2.4.0",
-      "requires": {}
+      "version": "2.4.0"
     },
     "ngx-skeleton-loader": {
       "version": "2.4.4",
@@ -34066,6 +34270,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -34103,6 +34308,7 @@
     },
     "optionator": {
       "version": "0.9.1",
+      "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -34410,12 +34616,14 @@
     },
     "parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       },
       "dependencies": {
         "callsites": {
-          "version": "3.1.0"
+          "version": "3.1.0",
+          "dev": true
         }
       }
     },
@@ -34470,7 +34678,8 @@
       "version": "2.2.0"
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -34481,7 +34690,8 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6"
+      "version": "1.0.6",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -35100,7 +35310,8 @@
       "dev": true
     },
     "prelude-ls": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -35396,7 +35607,8 @@
       "version": "2.0.1"
     },
     "progress": {
-      "version": "2.0.3"
+      "version": "2.0.3",
+      "dev": true
     },
     "promise": {
       "version": "7.3.1",
@@ -35771,7 +35983,8 @@
       }
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -36054,7 +36267,8 @@
       }
     },
     "regexpp": {
-      "version": "3.1.0"
+      "version": "3.1.0",
+      "dev": true
     },
     "regexpu-core": {
       "version": "4.7.1",
@@ -36161,6 +36375,7 @@
     },
     "resolve": {
       "version": "1.19.0",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
@@ -36777,6 +36992,7 @@
     },
     "slice-ansi": {
       "version": "2.1.0",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
@@ -37255,6 +37471,7 @@
     },
     "string-width": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -37262,10 +37479,12 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0"
+          "version": "4.1.0",
+          "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -37315,7 +37534,8 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "strip-outer": {
       "version": "1.0.1",
@@ -37434,6 +37654,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -37491,6 +37712,7 @@
     },
     "table": {
       "version": "5.4.6",
+      "dev": true,
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -37687,7 +37909,8 @@
       }
     },
     "text-table": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "dev": true
     },
     "throat": {
       "version": "5.0.0",
@@ -37886,6 +38109,7 @@
     },
     "tslint": {
       "version": "6.1.3",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
@@ -37903,10 +38127,12 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1"
+          "version": "1.14.1",
+          "dev": true
         },
         "tsutils": {
           "version": "2.29.0",
+          "dev": true,
           "requires": {
             "tslib": "^1.8.1"
           }
@@ -37943,6 +38169,7 @@
     },
     "type-check": {
       "version": "0.4.0",
+      "dev": true,
       "requires": {
         "prelude-ls": "^1.2.1"
       }
@@ -37975,7 +38202,8 @@
       }
     },
     "typescript": {
-      "version": "3.8.3"
+      "version": "3.8.3",
+      "dev": true
     },
     "unbzip2-stream": {
       "version": "1.4.3",
@@ -38118,6 +38346,7 @@
     },
     "uri-js": {
       "version": "4.4.0",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -38230,7 +38459,8 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "7.0.0",
@@ -39120,7 +39350,8 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3"
+      "version": "1.2.3",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -39177,10 +39408,12 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jszip-utils": "^0.1.0",
     "lodash": "4.17.21",
     "marked": "^2.0.1",
+    "ng-mocks": "^9.6.4",
     "ng2-charts": "2.3.3",
     "ngx-ace-wrapper": "^11.0.0",
     "ngx-clipboard": "13.0.1",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -62,6 +62,7 @@ import { FederatedDataModelMainComponent } from './subscribed-catalogues/federat
 import { ServerTimeoutComponent } from './errors/server-timeout/server-timeout.component';
 import { NewVersionComponent } from './shared/new-version/new-version.component';
 import { VersionedFolderComponent } from './versioned-folder/versioned-folder/versioned-folder.component';
+import { MergeDiffContainerComponent } from './merge-diff/merge-diff-container/merge-diff-container.component';
 
 
 export const pageRoutes: { states: Ng2StateDeclaration[] } = {
@@ -265,6 +266,14 @@ export const pageRoutes: { states: Ng2StateDeclaration[] } = {
       name: 'appContainer.mainApp.twoSidePanel.catalogue.modelsMergingGraph',
       url: '/modelsMergingGraph/:modelType/:modelId',
       component: ModelsMergingGraphComponent
+    },
+    {
+      name: 'appContainer.mainApp.mergeDiff',
+      url: '/mergeDiff/:catalogueDomainType/:sourceId/:targetId',
+      component: MergeDiffContainerComponent,
+      params: {
+        targetId: null
+      }
     },
     {
       name: 'appContainer.mainApp.twoSidePanel.catalogue.NewCodeSet',

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,6 +38,7 @@ import { StateRoleAccessService } from './services/utility/state-role-access.ser
 import { UiViewComponent } from './shared/ui-view/ui-view.component';
 import '@mdm/utility/extensions/mat-dialog.extensions';
 import { HttpRequestProgressInterceptor } from './services/http-request-progress.interceptor';
+import { MergeDiffModule } from './merge-diff/merge-diff.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -54,7 +55,8 @@ import { HttpRequestProgressInterceptor } from './services/http-request-progress
     MdmResourcesModule.forRoot({
       defaultHttpRequestOptions: { withCredentials: true },
       apiEndpoint: environment.apiEndpoint
-    })
+    }),
+    MergeDiffModule
   ],
   providers: [
     { provide: MAT_TABS_CONFIG, useValue: { animationDuration: '0ms' } },

--- a/src/app/dataModel/data-model-detail.component.ts
+++ b/src/app/dataModel/data-model-detail.component.ts
@@ -380,7 +380,16 @@ export class DataModelDetailComponent implements OnInit {
   }
 
   merge() {
-    this.stateHandler.Go(
+    if (this.sharedService.features.useMergeUiV2) {
+      return this.stateHandler.Go(
+        'mergediff',
+        {
+          sourceId: this.dataModel.id,
+          catalogueDomainType: this.dataModel.domainType
+        });
+    }
+
+    return this.stateHandler.Go(
       'modelsmerging',
       new ModelMergingModel(
         this.dataModel.id,

--- a/src/app/merge-diff/merge-diff-adapter/merge-diff-adapter.service.spec.ts
+++ b/src/app/merge-diff/merge-diff-adapter/merge-diff-adapter.service.spec.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { TestBed } from '@angular/core/testing';
+
+import { MergeDiffAdapterService } from './merge-diff-adapter.service';
+
+describe('MergeDiffAdapterService', () => {
+  let service: MergeDiffAdapterService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MergeDiffAdapterService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/merge-diff/merge-diff-adapter/merge-diff-adapter.service.spec.ts
+++ b/src/app/merge-diff/merge-diff-adapter/merge-diff-adapter.service.spec.ts
@@ -16,16 +16,14 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { TestBed } from '@angular/core/testing';
-
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
 import { MergeDiffAdapterService } from './merge-diff-adapter.service';
 
 describe('MergeDiffAdapterService', () => {
   let service: MergeDiffAdapterService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(MergeDiffAdapterService);
+    service = setupTestModuleForService(MergeDiffAdapterService);
   });
 
   it('should be created', () => {

--- a/src/app/merge-diff/merge-diff-adapter/merge-diff-adapter.service.ts
+++ b/src/app/merge-diff/merge-diff-adapter/merge-diff-adapter.service.ts
@@ -1,0 +1,63 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+
+/**
+ * Adapter service around {@link MdmResourcesService} to wrap around
+ * merge and diff endpoints.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class MergeDiffAdapterService {
+
+  constructor() { }
+
+  /*
+  TODO: add in adapter functions when required here.
+
+  Idea of the adapter is to:
+
+  1. Correctly map types from mdm-resources to the UI. The types for merge/diff data should be
+  defined in mdm-resources, but the adapter functions here can make them nicer to use, e.g.
+
+  ```
+  getMergeDiff(sourceId: Uuid, targetId: Uuid): Observable<MdmMergeDiffItem[]> {
+    return this.resources.merge
+      .mergeDiff(sourceId, targetId)
+      .pipe(
+        catchError(error => ...),  // Common error handling (maybe)
+        map((response: MdmMergeDiffResponse) => response.body)  // Map to types we care about
+      );
+  }
+  ```
+
+  2. Act as proxies whilst the backend endpoints are being developed, allowing the UI to
+  define the low level functionality required for the UI components, but temporarily return fake
+  data. e.g.
+
+  ```
+  import * as data from './fake-data.json';
+
+  getMergeDiff(sourceId: Uuid, targetId: Uuid): Observable<MdmMergeDiffItem[]> {
+    return of(data);
+  }
+  ```
+  */
+}

--- a/src/app/merge-diff/merge-diff-container/merge-diff-container.component.html
+++ b/src/app/merge-diff/merge-diff-container/merge-diff-container.component.html
@@ -1,0 +1,19 @@
+<!--
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<p>merge-diff-container works!</p>

--- a/src/app/merge-diff/merge-diff-container/merge-diff-container.component.scss
+++ b/src/app/merge-diff/merge-diff-container/merge-diff-container.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/merge-diff/merge-diff-container/merge-diff-container.component.spec.ts
+++ b/src/app/merge-diff/merge-diff-container/merge-diff-container.component.spec.ts
@@ -1,0 +1,43 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MergeDiffContainerComponent } from './merge-diff-container.component';
+
+describe('MergeDiffContainerComponent', () => {
+  let component: MergeDiffContainerComponent;
+  let fixture: ComponentFixture<MergeDiffContainerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MergeDiffContainerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MergeDiffContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/merge-diff/merge-diff-container/merge-diff-container.component.spec.ts
+++ b/src/app/merge-diff/merge-diff-container/merge-diff-container.component.spec.ts
@@ -16,28 +16,17 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentHarness, setupTestModuleForComponent } from '@mdm/testing/testing.helpers';
 import { MergeDiffContainerComponent } from './merge-diff-container.component';
 
 describe('MergeDiffContainerComponent', () => {
-  let component: MergeDiffContainerComponent;
-  let fixture: ComponentFixture<MergeDiffContainerComponent>;
+  let harness: ComponentHarness<MergeDiffContainerComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ MergeDiffContainerComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(MergeDiffContainerComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async() => {
+    harness = await setupTestModuleForComponent(MergeDiffContainerComponent);
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(harness?.isComponentCreated).toBeTruthy();
   });
 });

--- a/src/app/merge-diff/merge-diff-container/merge-diff-container.component.ts
+++ b/src/app/merge-diff/merge-diff-container/merge-diff-container.component.ts
@@ -1,0 +1,49 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+import { SharedService, StateHandlerService } from '@mdm/services';
+
+/**
+ * Top-level view component for the Merge/Diff user interface.
+ *
+ * Controls the top-level data to fetch/render, controls for the overall merge operations and
+ * child components for rendering the different sections of data.
+ */
+@Component({
+  selector: 'mdm-merge-diff-container',
+  templateUrl: './merge-diff-container.component.html',
+  styleUrls: ['./merge-diff-container.component.scss']
+})
+export class MergeDiffContainerComponent implements OnInit {
+
+  constructor(
+    private shared: SharedService,
+    private stateHandler: StateHandlerService) { }
+
+  ngOnInit(): void {
+    if (!this.shared.features.useMergeUiV2) {
+      // Feature toggle guard
+      this.stateHandler.Go('alldatamodel');
+      return;
+    }
+
+    // TODO: load UI...
+  }
+
+}

--- a/src/app/merge-diff/merge-diff.module.ts
+++ b/src/app/merge-diff/merge-diff.module.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedModule } from '@mdm/modules/shared/shared.module';
+import { MaterialModule } from '@mdm/modules/material/material.module';
+import { MergeDiffContainerComponent } from '@mdm/merge-diff/merge-diff-container/merge-diff-container.component';
+
+@NgModule({
+  declarations: [
+    MergeDiffContainerComponent
+  ],
+  imports: [
+    CommonModule,
+    SharedModule,
+    MaterialModule
+  ],
+  exports: [
+    MergeDiffContainerComponent
+  ]
+})
+export class MergeDiffModule { }

--- a/src/app/referenceData/reference-data-details/reference-data-details.component.ts
+++ b/src/app/referenceData/reference-data-details/reference-data-details.component.ts
@@ -456,7 +456,16 @@ export class ReferenceDataDetailsComponent implements OnInit {
   }
 
   merge() {
-    this.stateHandler.Go(
+    if (this.sharedService.features.useMergeUiV2) {
+      return this.stateHandler.Go(
+        'mergediff',
+        {
+          sourceId: this.refDataModel.id,
+          catalogueDomainType: this.refDataModel.domainType
+        });
+    }
+
+    return this.stateHandler.Go(
       'modelsmerging',
       {
         sourceId: this.refDataModel.id,

--- a/src/app/services/handlers/state-handler.service.ts
+++ b/src/app/services/handlers/state-handler.service.ts
@@ -73,6 +73,7 @@ export class StateHandlerService {
         dataflowchain: 'appContainer.mainApp.dataFlowChain',
         modelscomparison: 'appContainer.mainApp.modelsComparison',
         modelsmerging: 'appContainer.mainApp.modelsMerging',
+        mergediff: 'appContainer.mainApp.mergeDiff',
         linksuggestion: 'appContainer.mainApp.linkSuggestion',
         export: 'appContainer.mainApp.twoSidePanel.catalogue.export',
         import: 'appContainer.mainApp.twoSidePanel.catalogue.import',

--- a/src/app/services/shared.model.ts
+++ b/src/app/services/shared.model.ts
@@ -21,4 +21,5 @@ export interface Features {
   useSubscribedCatalogues: boolean;
   useDynamicProfiles: boolean;
   useVersionedFolders: boolean;
+  useMergeUiV2: boolean;
 }

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -1,0 +1,102 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockComponent } from 'ng-mocks';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
+import { TestingModule } from './testing.module';
+
+/**
+ * Represents additional configuration to use when setting up the test module.
+ */
+export interface TestModuleConfiguration {
+  /**
+   * Provide an optional list of additional component declarations.
+   */
+  declarations?: any[];
+
+  /**
+   * Provide an optional list of additional component/module imports.
+   */
+  imports?: any[];
+
+  /**
+   * Provide an optional list of additional providers to use for dependency injection.
+   */
+  providers?: any[];
+}
+
+/**
+ * Represents a created component for testing plus a fixture.
+ *
+ * @typedef T The type of component under test.
+ */
+export class ComponentHarness<T> {
+  constructor(public component: T, public fixture: ComponentFixture<T>) { }
+
+  get isComponentCreated() {
+    return !!this.component;
+  }
+
+  detectChanges() {
+    this.fixture.detectChanges();
+  }
+}
+
+/**
+ * Setup the test module for working with a service.
+ *
+ * @typedef T The type of the service under test.
+ * @param service The type of service under test.
+ * @param configuration Optionally provide additional configuration for the test module.
+ * @returns A new instance of the service under test.
+ */
+export function setupTestModuleForService<T>(service: Type<T>, configuration?: TestModuleConfiguration): T {
+  TestBed.configureTestingModule({
+    imports: [TestingModule, ...configuration?.imports ?? []],
+    providers: configuration?.providers ?? []
+  });
+  return TestBed.inject(service);
+}
+
+/**
+ * Setup the test module for working with a component.
+ *
+ * @typedef T The type of the component under test.
+ * @param componentType The type of the component under test.
+ * @param configuration Optionally provide additional configuration for the test module.
+ * @returns A new `ComponentHarness<T>` containing an instance of the component under test with a fixture.
+ */
+export async function setupTestModuleForComponent<T>(componentType: Type<T>, configuration?: TestModuleConfiguration) {
+  await TestBed
+    .configureTestingModule({
+      imports: [TestingModule, ...configuration?.imports ?? []],
+      declarations: [
+        componentType,
+        MockComponent(NgxSkeletonLoaderComponent),
+        ...configuration?.declarations ?? []],
+      providers: configuration?.providers ?? []
+    })
+    .compileComponents();
+
+  const fixture = TestBed.createComponent(componentType);
+  const component = fixture.componentInstance;
+  fixture.detectChanges();
+  return new ComponentHarness(component, fixture);
+}

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -67,13 +67,13 @@ export class ComponentHarness<T> {
  * @param configuration Optionally provide additional configuration for the test module.
  * @returns A new instance of the service under test.
  */
-export function setupTestModuleForService<T>(service: Type<T>, configuration?: TestModuleConfiguration): T {
+export const setupTestModuleForService = <T>(service: Type<T>, configuration?: TestModuleConfiguration): T => {
   TestBed.configureTestingModule({
     imports: [TestingModule, ...configuration?.imports ?? []],
     providers: configuration?.providers ?? []
   });
   return TestBed.inject(service);
-}
+};
 
 /**
  * Setup the test module for working with a component.
@@ -83,7 +83,7 @@ export function setupTestModuleForService<T>(service: Type<T>, configuration?: T
  * @param configuration Optionally provide additional configuration for the test module.
  * @returns A new `ComponentHarness<T>` containing an instance of the component under test with a fixture.
  */
-export async function setupTestModuleForComponent<T>(componentType: Type<T>, configuration?: TestModuleConfiguration) {
+export const setupTestModuleForComponent = async <T>(componentType: Type<T>, configuration?: TestModuleConfiguration) => {
   await TestBed
     .configureTestingModule({
       imports: [TestingModule, ...configuration?.imports ?? []],
@@ -99,4 +99,4 @@ export async function setupTestModuleForComponent<T>(componentType: Type<T>, con
   const component = fixture.componentInstance;
   fixture.detectChanges();
   return new ComponentHarness(component, fixture);
-}
+};

--- a/src/app/testing/testing.module.ts
+++ b/src/app/testing/testing.module.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MaterialModule } from '@mdm/modules/material/material.module';
+import { MdmResourcesModule } from '@mdm/modules/resources/mdm-resources.module';
+import { UIRouterModule } from '@uirouter/angular';
+import { ToastrModule } from 'ngx-toastr';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    NoopAnimationsModule,
+    MaterialModule,
+    FormsModule,
+    ReactiveFormsModule,
+    UIRouterModule.forRoot({ useHash: true }),
+    ToastrModule.forRoot(),
+    MdmResourcesModule.forRoot({ }),
+    HttpClientTestingModule,
+    NgxSkeletonLoaderModule
+  ],
+  exports: [
+    MaterialModule,
+    UIRouterModule,
+    ReactiveFormsModule
+  ]
+})
+export class TestingModule { }
+

--- a/src/environments/env.d.ts
+++ b/src/environments/env.d.ts
@@ -21,6 +21,7 @@ interface EnvironmentVariables {
   themeName: string;
   useFeaureSubscribedCatalogues: boolean;
   useVersionedFolders: boolean;
+  useMergeUiV2: boolean;
 }
 
 declare let $ENV: EnvironmentVariables;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -53,6 +53,7 @@ export const environment = {
   features: {
     useSubscribedCatalogues: $ENV.useFeaureSubscribedCatalogues ?? true,
     useDynamicProfiles: true,
-    useVersionedFolders: $ENV.useVersionedFolders ?? false
+    useVersionedFolders: $ENV.useVersionedFolders ?? false,
+    useMergeUiV2: $ENV.useMergeUiV2 ?? false
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -57,7 +57,8 @@ export const environment = {
   features: {
     useSubscribedCatalogues: true,
     useDynamicProfiles: true,
-    useVersionedFolders: true
+    useVersionedFolders: true,
+    useMergeUiV2: true
   }
 };
 


### PR DESCRIPTION
* Added the feature flag to use new Merge UI. Enabled for development, can be turned on in production via `MDM_UI_USE_MERGE_V2` environment variable in docker compose
* Created separate Angular module called `MergeDiffModule` to declare/provide all the components/services specifically for this merge/diff feature
* Updated action points in Data Model views to navigate to the new Merge UI using a new route if enabled. New UI is simply a skeleton to fill in at this point.
* Included updated `TestingModule` and testing helper functions for easier `*.spec.ts` file setup with correct modules already imported.