### PR TITLE
Feature/mc 9549 Enable Branch/Version/Fork for Versioned Folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2982,7 +2982,7 @@
     },
     "node_modules/@maurodatamapper/mdm-resources": {
       "version": "4.6.0-SNAPSHOT",
-      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#792da7743a40bc8932260a49dbe21f2efdcd9e96",
+      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#005dda1f9929fa7fc4a6ab272e2fbf69f82eadbf",
       "license": "Apache-2.0"
     },
     "node_modules/@ngtools/webpack": {
@@ -25366,7 +25366,7 @@
       }
     },
     "@maurodatamapper/mdm-resources": {
-      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#792da7743a40bc8932260a49dbe21f2efdcd9e96",
+      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#005dda1f9929fa7fc4a6ab272e2fbf69f82eadbf",
       "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#develop"
     },
     "@ngtools/webpack": {

--- a/src/app/code-set/code-set-details/code-set-details.component.html
+++ b/src/app/code-set/code-set-details/code-set-details.component.html
@@ -265,27 +265,7 @@ SPDX-License-Identifier: Apache-2.0
             <i class="fas fa-code-branch" matTooltip="Branch name"></i>
             <span><strong>Branch: </strong></span>
             <span>
-              <select
-                class="form-control"
-                style="
-                  display: inline;
-                  max-width: 120px;
-                  height: 30px;
-                  line-height: 1;
-                  padding: 0 0.35em;
-                  width: auto;
-                "
-                [(ngModel)]="currentBranch"
-                name="currentBranch"
-                (ngModelChange)="onModelChange()"
-              >
-                <option
-                  [value]="item.branch"
-                  *ngFor="let item of branchGraph"
-                >
-                  {{ item.branch ? item.branch : 'main' }}
-                </option>
-              </select>
+              <mdm-branch-selector [catalogueItem]="codeSetDetail"></mdm-branch-selector>
             </span>
           </small>
         </div>

--- a/src/app/code-set/code-set-details/code-set-details.component.ts
+++ b/src/app/code-set/code-set-details/code-set-details.component.ts
@@ -57,8 +57,6 @@ export class CodeSetDetailsComponent implements OnInit {
   deleteInProgress: boolean;
   processing = false;
   addedToFavourite = false;
-  currentBranch = '';
-  branchGraph = [];
   access: Access;
 
   constructor(
@@ -90,7 +88,6 @@ export class CodeSetDetailsComponent implements OnInit {
 
   codeSetDetails(): any {
     this.access = this.securityHandler.elementAccess(this.codeSetDetail);
-    this.getModelGraph(this.codeSetDetail.id);
     this.title.setTitle(`Code Set - ${this.codeSetDetail?.label}`);
   }
 
@@ -208,45 +205,6 @@ export class CodeSetDetailsComponent implements OnInit {
         this.stateHandler.reload();
         this.broadcast.reloadCatalogueTree();
       });
-  }
-
-  getModelGraph (codesetId : string) {
-    this.currentBranch = this.codeSetDetail.branchName;
-    this.branchGraph = [
-      {
-        branch: 'main',
-        label: this.codeSetDetail.label,
-        codesetId,
-        newBranchModelVersion: false,
-        newDocumentationVersion: false,
-        newFork: false
-      }
-    ];
-
-    this.resourcesService.codeSet.modelVersionTree(codesetId).subscribe(
-      (res) => {
-        this.currentBranch = this.codeSetDetail.branchName;
-        this.branchGraph = res.body;
-      },
-      (error) => {
-        this.messageHandler.showError(
-          'There was a problem getting the Model Version Tree.',
-          error
-        );
-      }
-    );
-  }
-
-  onModelChange() {
-    for (const val in this.branchGraph) {
-      if (this.branchGraph[val].branch === this.currentBranch) {
-        this.stateHandler.Go(
-          'codeset',
-          { id: this.branchGraph[val].modelId },
-          { reload: true, location: true }
-        );
-      }
-    }
   }
 
   save() {

--- a/src/app/code-set/code-set-details/code-set-details.component.ts
+++ b/src/app/code-set/code-set-details/code-set-details.component.ts
@@ -351,8 +351,10 @@ export class CodeSetDetailsComponent implements OnInit {
   newVersion() {
     this.stateHandler.Go(
       'newVersionModel',
-      { id: this.codeSetDetail.id, domainType: 'codeSet' },
-      { location: true }
+      {
+        id: this.codeSetDetail.id,
+        domainType: this.codeSetDetail.domainType
+      }
     );
   }
 }

--- a/src/app/dataModel/data-model-detail.component.html
+++ b/src/app/dataModel/data-model-detail.component.html
@@ -357,33 +357,12 @@ SPDX-License-Identifier: Apache-2.0
             </span>
           </small>
         </div>
-        <!-- <div class="text-muted" *ngIf="dataModel && !dataModel?.finalised"> TO DO waiting for back-end -->
         <div class="text-muted" *ngIf="dataModel">
           <small>
             <i class="fas fa-code-branch" matTooltip="Branch name"></i>
             <span><strong>Branch: </strong></span>
             <span>
-              <select
-                class="form-control"
-                style="
-                  display: inline;
-                  max-width: 120px;
-                  height: 30px;
-                  line-height: 1;
-                  padding: 0 0.35em;
-                  width: auto;
-                "
-                [(ngModel)]="currentBranch"
-                name="currentBranch"
-                (ngModelChange)="onModelChange()"
-              >
-                <option
-                  [value]="item.branch"
-                  *ngFor="let item of branchGraph"
-                >
-                {{ item.branch ? item.branch : 'main' }}
-                </option>
-              </select>
+              <mdm-branch-selector [catalogueItem]="dataModel"></mdm-branch-selector>
             </span>
           </small>
         </div>

--- a/src/app/dataModel/data-model-detail.component.ts
+++ b/src/app/dataModel/data-model-detail.component.ts
@@ -65,8 +65,6 @@ export class DataModelDetailComponent implements OnInit {
   compareToList = [];
   exportList = [];
   addedToFavourite = false;
-  branchGraph = [];
-  currentBranch = '';
   downloadLinks = new Array<HTMLAnchorElement>();
   access: Access;
 
@@ -96,8 +94,6 @@ export class DataModelDetailComponent implements OnInit {
   }
 
   dataModelDetails(): any {
-    this.getModelGraph(this.dataModel.id);
-
     if (this.dataModel.semanticLinks) {
       this.dataModel.semanticLinks.forEach((link) => {
         if (link.linkType === 'New Version Of') {
@@ -124,33 +120,6 @@ export class DataModelDetailComponent implements OnInit {
   toggleShowSearch() {
     this.messageService.toggleSearch();
   }
-
-  getModelGraph = (modelId) => {
-    this.resourcesService.dataModel.modelVersionTree(modelId).subscribe(
-      (res) => {
-        this.currentBranch = this.dataModel.branchName;
-        this.branchGraph = res.body;
-      },
-      (error) => {
-        this.messageHandler.showError(
-          'There was a problem getting the Model Version Tree.',
-          error
-        );
-      }
-    );
-  };
-
-  onModelChange = () => {
-    for (const val in this.branchGraph) {
-      if (this.branchGraph[val].branch === this.currentBranch) {
-        this.stateHandler.Go(
-          'datamodel',
-          { id: this.branchGraph[val].modelId },
-          { reload: true, location: true }
-        );
-      }
-    }
-  };
 
   delete(permanent) {
     if (!this.access.showDelete) {

--- a/src/app/dataModel/data-model-detail.component.ts
+++ b/src/app/dataModel/data-model-detail.component.ts
@@ -363,8 +363,10 @@ export class DataModelDetailComponent implements OnInit {
   newVersion() {
     this.stateHandler.Go(
       'newVersionModel',
-      { id: this.dataModel.id, domainType: 'dataModel' },
-      { location: true }
+      {
+        id: this.dataModel.id,
+        domainType: this.dataModel.domainType
+      }
     );
   }
 

--- a/src/app/modules/catalogue/catalogue.module.ts
+++ b/src/app/modules/catalogue/catalogue.module.ts
@@ -184,7 +184,6 @@ import { ProfileDetailsComponent } from '@mdm/shared/profile-details/profile-det
 import { ServerTimeoutComponent } from '@mdm/errors/server-timeout/server-timeout.component';
 import { VersionedFolderComponent } from '@mdm/versioned-folder/versioned-folder/versioned-folder.component';
 import { VersionedFolderDetailComponent } from '../../versioned-folder/versioned-folder-detail/versioned-folder-detail.component';
-import { AlertComponent } from '@mdm/shared/alert/alert.component';
 import { DefaultProfileComponent } from '@mdm/shared/default-profile/default-profile.component';
 import { PipesModule } from '../pipes/pipes.module';
 
@@ -345,7 +344,6 @@ import { PipesModule } from '../pipes/pipes.module';
     ProfileDetailsComponent,
     VersionedFolderComponent,
     VersionedFolderDetailComponent,
-    AlertComponent,
     DefaultProfileComponent
   ],
   imports: [
@@ -519,8 +517,7 @@ import { PipesModule } from '../pipes/pipes.module';
     FederatedDataModelDetailComponent,
     NewFederatedSubscriptionModalComponent,
     ProfileDetailsComponent,
-    DefaultProfileComponent,
-    AlertComponent
+    DefaultProfileComponent
   ]
 })
 export class CatalogueModule { }

--- a/src/app/modules/resources/mdm-resources.models.ts
+++ b/src/app/modules/resources/mdm-resources.models.ts
@@ -20,39 +20,6 @@ import { RequestSettings } from '@maurodatamapper/mdm-resources';
 import { HttpErrorResponse } from '@angular/common/http';
 
 /**
- * Represents a response from an `mdm-resources` API endpoint.
- *
- */
-// export interface MdmResourcesResponse<T = any> {
-//   /**
-//    * The body of the response from the API.
-//    */
-//   body: T;
-// }
-
-/**
- * Represents the body of a `mdm-resources` response for an index/list request.
- *
- */
-// export interface MdmResourcesIndexBody<T = any> {
-//   /**
-//    * Gets the number of items in the returned list.
-//    */
-//   count: number;
-
-//   /**
-//    * Gets the list of items returned from the API.
-//    */
-//   items: T[];
-// }
-
-/**
- * Type alias for an `mdm-resources` API endpoint response for an index/list request.
- *
- */
-// export type MdmResourcesIndexResponse<T = any> = MdmResourcesResponse<MdmResourcesIndexBody<T>>;
-
-/**
  * Interface to define standard properties/options for the `MdmRestHandlerService`.
  *
  * @see MdmRestHandlerService

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -44,6 +44,7 @@ import { ElementLinkComponent } from '@mdm/utility/element-link/element-link.com
 import { DownloadLinkComponent } from '@mdm/utility/download-link/download-link.component';
 import { NewVersionComponent } from '@mdm/shared/new-version/new-version.component';
 import { AlertComponent } from '@mdm/shared/alert/alert.component';
+import { BranchSelectorComponent } from '@mdm/shared/branch-selector/branch-selector.component';
 
 @NgModule({
   declarations: [
@@ -63,7 +64,8 @@ import { AlertComponent } from '@mdm/shared/alert/alert.component';
     ElementLinkComponent,
     DownloadLinkComponent,
     NewVersionComponent,
-    AlertComponent
+    AlertComponent,
+    BranchSelectorComponent
   ],
   imports: [
     CommonModule,
@@ -104,7 +106,8 @@ import { AlertComponent } from '@mdm/shared/alert/alert.component';
     TextDiffComponent,
     DownloadLinkComponent,
     NewVersionComponent,
-    AlertComponent
+    AlertComponent,
+    BranchSelectorComponent
   ]
 })
 export class SharedModule {}

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -43,6 +43,7 @@ import { TextDiffComponent } from '@mdm/shared/text-diff/text-diff.component';
 import { ElementLinkComponent } from '@mdm/utility/element-link/element-link.component';
 import { DownloadLinkComponent } from '@mdm/utility/download-link/download-link.component';
 import { NewVersionComponent } from '@mdm/shared/new-version/new-version.component';
+import { AlertComponent } from '@mdm/shared/alert/alert.component';
 
 @NgModule({
   declarations: [
@@ -61,7 +62,8 @@ import { NewVersionComponent } from '@mdm/shared/new-version/new-version.compone
     TextDiffComponent,
     ElementLinkComponent,
     DownloadLinkComponent,
-    NewVersionComponent
+    NewVersionComponent,
+    AlertComponent
   ],
   imports: [
     CommonModule,
@@ -101,7 +103,8 @@ import { NewVersionComponent } from '@mdm/shared/new-version/new-version.compone
     ElementLinkComponent,
     TextDiffComponent,
     DownloadLinkComponent,
-    NewVersionComponent
+    NewVersionComponent,
+    AlertComponent
   ]
 })
 export class SharedModule {}

--- a/src/app/referenceData/reference-data-details/reference-data-details.component.html
+++ b/src/app/referenceData/reference-data-details/reference-data-details.component.html
@@ -331,27 +331,7 @@ SPDX-License-Identifier: Apache-2.0
             <i class="fas fa-code-branch" matTooltip="Branch name"></i>
             <span><strong>Branch: </strong></span>
             <span>
-              <select
-                class="form-control"
-                style="
-                  display: inline;
-                  max-width: 120px;
-                  height: 30px;
-                  line-height: 1;
-                  padding: 0 0.35em;
-                  width: auto;
-                "
-                [(ngModel)]="currentBranch"
-                name="currentBranch"
-                (ngModelChange)="onModelChange()"
-              >
-                <option
-                  [value]="item.branch"
-                  *ngFor="let item of branchGraph"
-                >
-                {{ item.branch ? item.branch : 'main' }}
-                </option>
-              </select>
+              <mdm-branch-selector [catalogueItem]="refDataModel"></mdm-branch-selector>
             </span>
           </small>
         </div>

--- a/src/app/referenceData/reference-data-details/reference-data-details.component.ts
+++ b/src/app/referenceData/reference-data-details/reference-data-details.component.ts
@@ -439,8 +439,10 @@ export class ReferenceDataDetailsComponent implements OnInit {
   newVersion() {
     this.stateHandler.Go(
       'newversionmodel',
-      { id: this.refDataModel.id, domainType: 'referenceDataModel' },
-      { location: true }
+      {
+        id: this.refDataModel.id,
+        domainType: this.refDataModel.domainType
+      }
     );
   }
 

--- a/src/app/referenceData/reference-data-details/reference-data-details.component.ts
+++ b/src/app/referenceData/reference-data-details/reference-data-details.component.ts
@@ -63,8 +63,6 @@ export class ReferenceDataDetailsComponent implements OnInit {
   exportError = null;
   exportList = [];
   addedToFavourite = false;
-  currentBranch = '';
-  branchGraph = [];
   compareToList = [];
   downloadLinks = new Array<HTMLAnchorElement>();
   access: Access;
@@ -93,8 +91,6 @@ export class ReferenceDataDetailsComponent implements OnInit {
   }
 
   ReferenceModelDetails(): any {
-    this.getModelGraph(this.refDataModel.id);
-
     if (this.refDataModel.semanticLinks) {
       this.refDataModel.semanticLinks.forEach((link) => {
         if (link.linkType === 'New Version Of') {
@@ -231,47 +227,6 @@ export class ReferenceDataDetailsComponent implements OnInit {
         }
       );
   }
-
-  getModelGraph = (modelId) => {
-    this.currentBranch = this.refDataModel.branchName;
-    this.branchGraph = [
-      {
-        branch: 'main',
-        label: this.refDataModel.label,
-        modelId,
-        newBranchModelVersion: false,
-        newDocumentationVersion: false,
-        newFork: false
-      }
-    ];
-
-    this.resourcesService.referenceDataModel
-      .modelVersionTree(modelId)
-      .subscribe(
-        (res) => {
-          this.currentBranch = this.refDataModel.branchName;
-          this.branchGraph = res.body;
-        },
-        (error) => {
-          this.messageHandler.showError(
-            'There was a problem getting the Model Version Tree.',
-            error
-          );
-        }
-      );
-  };
-
-  onModelChange = () => {
-    for (const val in this.branchGraph) {
-      if (this.branchGraph[val].branch === this.currentBranch) {
-        this.stateHandler.Go(
-          'referenceDataModels',
-          { id: this.branchGraph[val].modelId },
-          { reload: true, location: true }
-        );
-      }
-    }
-  };
 
   askForSoftDelete() {
     if (!this.access.showSoftDelete) {

--- a/src/app/services/element-types.service.ts
+++ b/src/app/services/element-types.service.ts
@@ -17,6 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
+import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
 import { StateHandlerService } from './handlers/state-handler.service';
 
 @Injectable({ providedIn: 'root' })
@@ -32,7 +33,7 @@ export class ElementTypesService {
     'New Version Of': { title: 'New Version Of', editable: false }
   };
 
-  private allTypes: Type[] = [
+  private allTypes: CatalogueElementType[] = [
     {
       id: 'Folder',
       link: 'folder',
@@ -195,7 +196,7 @@ export class ElementTypesService {
     },
   ];
 
-  private baseTypes: { [key: string]: Type } = {
+  private baseTypes: { [key: string]: CatalogueElementType } = {
     DataModel: {
       id: 'DataModel',
       link: 'dataModel',
@@ -208,7 +209,7 @@ export class ElementTypesService {
       id: 'ReferenceDataModel',
       link: 'ReferenceDataModel',
       title: 'ReferenceDataModel',
-      resourceName: 'ReferenceDataModel',
+      resourceName: 'referenceDataModel',
       markdown: 'rdm',
       classifiable: true
     },
@@ -357,7 +358,11 @@ export class ElementTypesService {
 
   getBaseTypes() {
     return this.baseTypes;
-  };
+  }
+
+  getBaseTypeForDomainType(domainType: CatalogueItemDomainType): CatalogueElementType {
+    return this.baseTypes[domainType];
+  }
 
   getLinkUrl(element, mode?) {
     if (!element || !element.id) {
@@ -425,7 +430,7 @@ export class ElementTypesService {
   }
 }
 
-export class Type {
+export class CatalogueElementType {
   id: string;
   link: string;
   title: string;

--- a/src/app/services/handlers/security-handler.service.ts
+++ b/src/app/services/handlers/security-handler.service.ts
@@ -287,7 +287,8 @@ export class SecurityHandlerService {
 
     if((element as Finalisable).finalised !== undefined)
     {
-      baseRtn.showNewVersion = (element as Finalisable).finalised;
+      const isFinalised = (element as Finalisable).finalised;
+      baseRtn.showNewVersion = isFinalised && element.availableActions?.includes('createNewVersions');
     }
 
     return baseRtn;

--- a/src/app/shared/branch-selector/branch-selector.component.html
+++ b/src/app/shared/branch-selector/branch-selector.component.html
@@ -18,7 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <select
   class="form-control mdm-branch-selector"
-  name="currentBranch"
   matTooltip="Switch to another branch"
   [(ngModel)]="currentVersionId"
   (ngModelChange)="currentVersionIdChanged()"

--- a/src/app/shared/branch-selector/branch-selector.component.html
+++ b/src/app/shared/branch-selector/branch-selector.component.html
@@ -1,0 +1,29 @@
+<!--
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<select
+  class="form-control mdm-branch-selector"
+  name="currentBranch"
+  matTooltip="Switch to another branch"
+  [(ngModel)]="currentVersionId"
+  (ngModelChange)="currentVersionIdChanged()"
+>
+  <option [value]="item.id" *ngFor="let item of versionList">
+    {{ item.displayName ? item.displayName : 'main' }}
+  </option>
+</select>

--- a/src/app/shared/branch-selector/branch-selector.component.scss
+++ b/src/app/shared/branch-selector/branch-selector.component.scss
@@ -1,0 +1,26 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+.mdm-branch-selector {
+  display: inline;
+  height: 30px;
+  line-height: 1;
+  padding: 0 0.35em;
+  width: auto;
+}

--- a/src/app/shared/branch-selector/branch-selector.component.spec.ts
+++ b/src/app/shared/branch-selector/branch-selector.component.spec.ts
@@ -16,14 +16,47 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
 import { ComponentHarness, setupTestModuleForComponent } from '@mdm/testing/testing.helpers';
+import { of } from 'rxjs';
 import { BranchSelectorComponent } from './branch-selector.component';
+
+interface MdmResourcesBranchableApiStub {
+  simpleModelVersionTree: jest.Mock;
+}
+
+interface MdmResourcesServiceStub {
+  dataModel: MdmResourcesBranchableApiStub;
+}
 
 describe('BranchSelectorComponent', () => {
   let harness: ComponentHarness<BranchSelectorComponent>;
 
+  const mdmResourcesStub: MdmResourcesServiceStub = {
+    dataModel: {
+      simpleModelVersionTree: jest.fn(() => of())
+    }
+  };
+
   beforeEach(async () => {
-    harness = await setupTestModuleForComponent(BranchSelectorComponent);
+    harness = await setupTestModuleForComponent(
+      BranchSelectorComponent,
+      {
+        providers: [
+          {
+            provide: MdmResourcesService,
+            useValue: mdmResourcesStub
+          }
+        ]
+      });
+
+    harness.detectChanges(component => {
+      component.catalogueItem = {
+        id: '1234',
+        domainType: CatalogueItemDomainType.DataModel
+      };
+    });
   });
 
   it('should create', () => {

--- a/src/app/shared/branch-selector/branch-selector.component.spec.ts
+++ b/src/app/shared/branch-selector/branch-selector.component.spec.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { ComponentHarness, setupTestModuleForComponent } from '@mdm/testing/testing.helpers';
+import { BranchSelectorComponent } from './branch-selector.component';
+
+describe('BranchSelectorComponent', () => {
+  let harness: ComponentHarness<BranchSelectorComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(BranchSelectorComponent);
+  });
+
+  it('should create', () => {
+    expect(harness?.isComponentCreated).toBeTruthy();
+  });
+});

--- a/src/app/shared/branch-selector/branch-selector.component.ts
+++ b/src/app/shared/branch-selector/branch-selector.component.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, Input, OnInit } from '@angular/core';
+import { BasicModelVersionItem, BasicModelVersionTreeResponse, CatalogueItem, Uuid } from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { ElementTypesService, MessageHandlerService, StateHandlerService } from '@mdm/services';
+import { EMPTY } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Component({
+  selector: 'mdm-branch-selector',
+  templateUrl: './branch-selector.component.html',
+  styleUrls: ['./branch-selector.component.scss']
+})
+export class BranchSelectorComponent implements OnInit {
+  @Input() catalogueItem: CatalogueItem;
+
+  versionList: BasicModelVersionItem[];
+  currentVersionId: Uuid;
+
+  constructor(
+    private resources: MdmResourcesService,
+    private elementTypes: ElementTypesService,
+    private messageHandler: MessageHandlerService,
+    private stateHandler: StateHandlerService) { }
+
+  ngOnInit(): void {
+    this.currentVersionId = this.catalogueItem.id;
+
+    const domainElementType = this.elementTypes.getBaseTypeForDomainType(this.catalogueItem.domainType);
+
+    this.resources[domainElementType.resourceName]
+      .simpleModelVersionTree(this.catalogueItem.id)
+      .pipe(
+        catchError(error => {
+          this.messageHandler.showError('There was a problem fetching the branch list.', error);
+          return EMPTY;
+        })
+      )
+      .subscribe((response: BasicModelVersionTreeResponse) => {
+        this.versionList = response.body;
+        this.versionList.sort((a, b) => a.displayName.localeCompare(b.displayName));
+      });
+  }
+
+  currentVersionIdChanged() {
+    this.stateHandler.Go(
+      this.catalogueItem.domainType,
+      {
+        id: this.currentVersionId
+      },
+      {
+        reload: true,
+        location: true
+      }
+    );
+  }
+}

--- a/src/app/shared/new-version/new-version.component.html
+++ b/src/app/shared/new-version/new-version.component.html
@@ -39,170 +39,166 @@ SPDX-License-Identifier: Apache-2.0
               <li>Properties</li>
             </ul>
           </div>
-          <div class="mb-2">
+          <form [formGroup]="setupForm">
             <div class="mb-2">
-              <h4 class="mat-h4 marginless">
-                Select the type of the new version that you want to create:
-              </h4>
+              <div class="mb-2">
+                <h4 class="mat-h4 marginless">
+                  Select the type of the new version that you want to create:
+                </h4>
 
-              <div class="mt-2">
-                <mat-form-field appearance="outline">
-                  <mat-label>Type</mat-label>
-                  <mat-select [(ngModel)]="versionType" [disabled]="processing">
-                    <mat-option class="mdm-new-version__type" [value]="'Fork'">
-                      <i class="fas fa-list"></i> New Fork
-                    </mat-option>
-                    <mat-option
-                      class="mdm-new-version__type"
-                      [value]="'Version'"
+                <div class="mt-2">
+                  <mat-form-field appearance="outline">
+                    <mat-label>Type</mat-label>
+                    <mat-select
+                      formControlName="type"
+                      required
+                      (selectionChange)="typeChanged()"
                     >
-                      <i class="fas fa-file-alt"></i> New Version
-                    </mat-option>
-                    <mat-option
-                      class="mdm-new-version__type"
-                      [value]="'Branch'"
-                    >
-                      <i class="fas fa-code-branch"></i> New Branch
-                    </mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-
-              <mdm-alert
-                alertStyle="info"
-                [showIcon]="true"
-                *ngIf="versionType === 'Fork'"
-              >
-                <p>
-                  This will create a copy of
-                  <b>{{ catalogueItem.label }}</b> with a new name, and a new
-                  'main' branch.
-                </p>
-                <p>
-                  Use this option if you are planning on taking this
-                  {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }} in
-                  a new direction, or under a new authority.
-                </p>
-              </mdm-alert>
-
-              <mdm-alert
-                alertStyle="info"
-                [showIcon]="true"
-                *ngIf="versionType === 'Version'"
-              >
-                <p>
-                  This will create a draft copy of
-                  <b>{{ catalogueItem.label }}</b> under the 'main' branch.
-                </p>
-                <p>
-                  Use this option if you want to create the next iteration of
-                  this
-                  {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }}.
-                </p>
-              </mdm-alert>
-
-              <mdm-alert
-                alertStyle="info"
-                [showIcon]="true"
-                *ngIf="versionType === 'Branch'"
-              >
-                <p>
-                  This will create a copy of <b>{{ catalogueItem.label }}</b> in
-                  a new branch. You may choose the name of the new branch.
-                </p>
-                <p>
-                  Use this option if you want to make some changes that you
-                  subsequently wish to merge back into 'main'.
-                </p>
-              </mdm-alert>
-
-              <div *ngIf="versionType === 'Fork'">
-                <div class="mdm--form-input mb-2">
-                  <h4 class="mat-h4 marginless">Additional details:</h4>
-
-                  <div
-                    [ngClass]="{
-                      'form-group': true,
-                      'has-error': errors && errors.label
-                    }"
-                  >
-                    <mat-form-field appearance="outline" class="full-width">
-                      <mat-label>Model name</mat-label>
-                      <input
-                        matInput
-                        [(ngModel)]="form.label"
-                        [disabled]="processing"
-                        required
-                      />
-                      <mat-hint
-                        >The name should be different from the current version
-                        name '{{ catalogueItem.label }}'</mat-hint
+                      <mat-option
+                        class="mdm-new-version__type"
+                        [value]="'Fork'"
                       >
-                    </mat-form-field>
-                    <span
-                      class="help-block warning"
-                      *ngIf="errors && errors.label"
-                      style="margin-left: 16px"
-                      ><small>{{ errors.label }}</small></span
-                    >
-                  </div>
+                        <i class="fas fa-list"></i> New Fork
+                      </mat-option>
+                      <mat-option
+                        class="mdm-new-version__type"
+                        [value]="'Version'"
+                      >
+                        <i class="fas fa-file-alt"></i> New Version
+                      </mat-option>
+                      <mat-option
+                        class="mdm-new-version__type"
+                        [value]="'Branch'"
+                      >
+                        <i class="fas fa-code-branch"></i> New Branch
+                      </mat-option>
+                    </mat-select>
+                    <mat-error *ngIf="setupForm && type.errors?.required">
+                      Please select the type to continue
+                    </mat-error>
+                  </mat-form-field>
                 </div>
-              </div>
 
-              <div *ngIf="versionType === 'Branch'">
-                <div
-                  [ngClass]="{
-                    'form-group': true,
-                    'has-error': errors && errors.label
-                  }"
+                <mdm-alert
+                  alertStyle="info"
+                  [showIcon]="true"
+                  *ngIf="typeValue === 'Fork'"
                 >
+                  <p>
+                    This will create a copy of
+                    <b>{{ catalogueItem.label }}</b> with a new name, and a new
+                    'main' branch.
+                  </p>
+                  <p>
+                    Use this option if you are planning on taking this
+                    {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }}
+                    in a new direction, or under a new authority.
+                  </p>
+                </mdm-alert>
+
+                <mdm-alert
+                  alertStyle="info"
+                  [showIcon]="true"
+                  *ngIf="typeValue === 'Version'"
+                >
+                  <p>
+                    This will create a draft copy of
+                    <b>{{ catalogueItem.label }}</b> under the 'main' branch.
+                  </p>
+                  <p>
+                    Use this option if you want to create the next iteration of
+                    this
+                    {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }}.
+                  </p>
+                </mdm-alert>
+
+                <mdm-alert
+                  alertStyle="info"
+                  [showIcon]="true"
+                  *ngIf="typeValue === 'Branch'"
+                >
+                  <p>
+                    This will create a copy of
+                    <b>{{ catalogueItem.label }}</b> in a new branch. You may
+                    choose the name of the new branch.
+                  </p>
+                  <p>
+                    Use this option if you want to make some changes that you
+                    subsequently wish to merge back into 'main'.
+                  </p>
+                </mdm-alert>
+
+                <div *ngIf="typeValue === 'Fork'">
+                  <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Model name</mat-label>
+                    <input
+                      matInput
+                      type="text"
+                      formControlName="modelName"
+                      required
+                    />
+                    <mat-hint
+                      >The name should be different from the current name '{{
+                        catalogueItem.label
+                      }}'</mat-hint
+                    >
+                    <mat-error *ngIf="setupForm && modelName?.errors?.required">
+                      Please enter a model name
+                    </mat-error>
+                    <mat-error *ngIf="setupForm && modelName?.errors?.forbiddenName">
+                      Please choose a different model name than '{{catalogueItem.label}}'
+                    </mat-error>
+                  </mat-form-field>
+                </div>
+
+                <div *ngIf="typeValue === 'Branch'">
                   <mat-form-field appearance="outline" class="full-width">
                     <mat-label>Branch name</mat-label>
                     <input
                       matInput
-                      [(ngModel)]="form.label"
-                      [disabled]="processing"
+                      type="text"
+                      formControlName="branchName"
                       required
                     />
+                    <mat-error
+                      *ngIf="setupForm && branchName?.errors?.required"
+                    >
+                      Please enter a branch name
+                    </mat-error>
                   </mat-form-field>
-                  <span
-                    class="help-block warning"
-                    *ngIf="errors && errors.label"
-                    style="margin-left: 16px"
-                    ><small>{{ errors.label }}</small></span
-                  >
                 </div>
-              </div>
-              <div *ngIf="step > 1">
-                <button
-                  mat-button
-                  color="warn"
-                  (click)="cancel()"
-                  [disabled]="processing"
-                >
-                  Cancel
-                </button>
-                <button
-                  mat-flat-button
-                  color="primary"
-                  class="custom"
-                  (click)="save()"
-                  [disabled]="processing"
-                >
-                  Add {{ versionType }}
-                </button>
 
-                <div style="margin-top: 5px" *ngIf="processing">
-                  <mat-progress-bar
-                    value="50"
-                    bufferValue="75"
-                    color="accent"
-                    mode="indeterminate"
-                  ></mat-progress-bar>
+                <div *ngIf="typeValue" class="mt-4">
+                  <button
+                    mat-button
+                    color="warn"
+                    (click)="cancel()"
+                    [disabled]="setupForm.disabled"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    mat-flat-button
+                    color="primary"
+                    class="custom"
+                    (click)="create()"
+                    [disabled]="!setupForm.valid || setupForm.disabled"
+                  >
+                    Create
+                  </button>
+
+                  <div style="margin-top: 5px" *ngIf="processing">
+                    <mat-progress-bar
+                      value="50"
+                      bufferValue="75"
+                      color="accent"
+                      mode="indeterminate"
+                    ></mat-progress-bar>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          </form>
         </div>
       </div>
     </div>

--- a/src/app/shared/new-version/new-version.component.html
+++ b/src/app/shared/new-version/new-version.component.html
@@ -47,88 +47,42 @@ SPDX-License-Identifier: Apache-2.0
                 </h4>
 
                 <div class="mt-2">
-                  <mat-form-field appearance="outline">
-                    <mat-label>Type</mat-label>
+                  <mat-form-field appearance="outline" class="full-width">
+                    <mat-label>Action</mat-label>
                     <mat-select
-                      formControlName="type"
+                      formControlName="action"
                       required
-                      (selectionChange)="typeChanged()"
+                      (selectionChange)="actionChanged()"
                     >
+                      <mat-select-trigger>
+                        {{actionSelectedName}}
+                      </mat-select-trigger>
                       <mat-option
-                        class="mdm-new-version__type"
-                        [value]="'Fork'"
+                        *ngFor="let availableAction of availableActions"
+                        class="mdm-new-version__type__option"
+                        [value]="availableAction.value"
                       >
-                        <i class="fas fa-list"></i> New Fork
-                      </mat-option>
-                      <mat-option
-                        class="mdm-new-version__type"
-                        [value]="'Version'"
-                      >
-                        <i class="fas fa-file-alt"></i> New Version
-                      </mat-option>
-                      <mat-option
-                        class="mdm-new-version__type"
-                        [value]="'Branch'"
-                      >
-                        <i class="fas fa-code-branch"></i> New Branch
+                        <h5>
+                          <i class="fas {{ availableAction.icon }}"></i>
+                          {{ availableAction.name }}
+                        </h5>
+                        <p>
+                          <small
+                            [innerHTML]="
+                              availableAction.getDescription(domainType, catalogueItem)
+                            "
+                          >
+                          </small>
+                        </p>
                       </mat-option>
                     </mat-select>
-                    <mat-error *ngIf="setupForm && type.errors?.required">
-                      Please select the type to continue
+                    <mat-error *ngIf="setupForm && action.errors?.required">
+                      Please select the action to continue
                     </mat-error>
                   </mat-form-field>
                 </div>
 
-                <mdm-alert
-                  alertStyle="info"
-                  [showIcon]="true"
-                  *ngIf="typeValue === 'Fork'"
-                >
-                  <p>
-                    This will create a copy of
-                    <b>{{ catalogueItem.label }}</b> with a new name, and a new
-                    'main' branch.
-                  </p>
-                  <p>
-                    Use this option if you are planning on taking this
-                    {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }}
-                    in a new direction, or under a new authority.
-                  </p>
-                </mdm-alert>
-
-                <mdm-alert
-                  alertStyle="info"
-                  [showIcon]="true"
-                  *ngIf="typeValue === 'Version'"
-                >
-                  <p>
-                    This will create a draft copy of
-                    <b>{{ catalogueItem.label }}</b> under the 'main' branch.
-                  </p>
-                  <p>
-                    Use this option if you want to create the next iteration of
-                    this
-                    {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }}.
-                  </p>
-                </mdm-alert>
-
-                <mdm-alert
-                  alertStyle="info"
-                  [showIcon]="true"
-                  *ngIf="typeValue === 'Branch'"
-                >
-                  <p>
-                    This will create a copy of
-                    <b>{{ catalogueItem.label }}</b> in a new branch. You may
-                    choose the name of the new branch.
-                  </p>
-                  <p>
-                    Use this option if you want to make some changes that you
-                    subsequently wish to merge back into 'main'.
-                  </p>
-                </mdm-alert>
-
-                <div *ngIf="typeValue === 'Fork'">
+                <div *ngIf="actionValue === 'Fork'">
                   <mat-form-field appearance="outline" class="full-width">
                     <mat-label>New label</mat-label>
                     <input
@@ -145,13 +99,17 @@ SPDX-License-Identifier: Apache-2.0
                     <mat-error *ngIf="setupForm && label?.errors?.required">
                       Please enter a label
                     </mat-error>
-                    <mat-error *ngIf="setupForm && label?.errors?.forbiddenName">
-                      Please choose a different label than '{{catalogueItem.label}}'
+                    <mat-error
+                      *ngIf="setupForm && label?.errors?.forbiddenName"
+                    >
+                      Please choose a different label than '{{
+                        catalogueItem.label
+                      }}'
                     </mat-error>
                   </mat-form-field>
                 </div>
 
-                <div *ngIf="typeValue === 'Branch'">
+                <div *ngIf="actionValue === 'Branch'">
                   <mat-form-field appearance="outline" class="full-width">
                     <mat-label>Branch name</mat-label>
                     <input
@@ -168,7 +126,7 @@ SPDX-License-Identifier: Apache-2.0
                   </mat-form-field>
                 </div>
 
-                <div *ngIf="typeValue" class="mt-4">
+                <div *ngIf="actionValue" class="mt-4">
                   <button
                     mat-button
                     color="warn"

--- a/src/app/shared/new-version/new-version.component.html
+++ b/src/app/shared/new-version/new-version.component.html
@@ -130,11 +130,11 @@ SPDX-License-Identifier: Apache-2.0
 
                 <div *ngIf="typeValue === 'Fork'">
                   <mat-form-field appearance="outline" class="full-width">
-                    <mat-label>Model name</mat-label>
+                    <mat-label>New label</mat-label>
                     <input
                       matInput
                       type="text"
-                      formControlName="modelName"
+                      formControlName="label"
                       required
                     />
                     <mat-hint
@@ -142,11 +142,11 @@ SPDX-License-Identifier: Apache-2.0
                         catalogueItem.label
                       }}'</mat-hint
                     >
-                    <mat-error *ngIf="setupForm && modelName?.errors?.required">
-                      Please enter a model name
+                    <mat-error *ngIf="setupForm && label?.errors?.required">
+                      Please enter a label
                     </mat-error>
-                    <mat-error *ngIf="setupForm && modelName?.errors?.forbiddenName">
-                      Please choose a different model name than '{{catalogueItem.label}}'
+                    <mat-error *ngIf="setupForm && label?.errors?.forbiddenName">
+                      Please choose a different label than '{{catalogueItem.label}}'
                     </mat-error>
                   </mat-form-field>
                 </div>

--- a/src/app/shared/new-version/new-version.component.html
+++ b/src/app/shared/new-version/new-version.component.html
@@ -16,19 +16,28 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div *ngIf="catalogueItem">
+<div *ngIf="catalogueItem" class="mdm-new-version">
   <div class="mdm--shadow-block">
     <div class="panel">
       <div class="panel-heading">
         <div class="heading-container">
-          <h4>New {{ catalogueItem.label }} version</h4>
+          <h4>New version of "{{ catalogueItem.label }}"</h4>
         </div>
-       
+
+        <div class="panel-body">
           <div class="mb-2 mt-2">
             <p>
-              A new version of <b>{{ catalogueItem.label }}</b> keeps all
-              Classes, Types, Elements and Properties of the original model.
+              A new version of <b>{{ catalogueItem.label }}</b> keeps all of the
+              following:
             </p>
+            <ul>
+              <li *ngIf="domainType === 'VersionedFolder'">Models</li>
+              <li *ngIf="domainType === 'VersionedFolder'">Folders</li>
+              <li>Classes</li>
+              <li>Types</li>
+              <li>Elements</li>
+              <li>Properties</li>
+            </ul>
           </div>
           <div class="mb-2">
             <div class="mb-2">
@@ -36,71 +45,111 @@ SPDX-License-Identifier: Apache-2.0
                 Select the type of the new version that you want to create:
               </h4>
 
-              <div class="mb-2 mt-2">
-                <mat-radio-group
-                  class="marginless"
-                  [(ngModel)]="versionType"
-                  (click)="versionTypeChecked()"
-                  [disabled]="processing"
-                >
-                  <mat-radio-button value="Fork" checked="true"
-                    ><i class="fas fa-list"></i> New Fork</mat-radio-button
-                  >
-                </mat-radio-group>
-                <small>
+              <div class="mt-2">
+                <mat-form-field appearance="outline">
+                  <mat-label>Type</mat-label>
+                  <mat-select [(ngModel)]="versionType" [disabled]="processing">
+                    <mat-option class="mdm-new-version__type" [value]="'Fork'">
+                      <i class="fas fa-list"></i> New Fork
+                    </mat-option>
+                    <mat-option
+                      class="mdm-new-version__type"
+                      [value]="'Version'"
+                    >
+                      <i class="fas fa-file-alt"></i> New Version
+                    </mat-option>
+                    <mat-option
+                      class="mdm-new-version__type"
+                      [value]="'Branch'"
+                    >
+                      <i class="fas fa-code-branch"></i> New Branch
+                    </mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+
+              <mdm-alert
+                alertStyle="info"
+                [showIcon]="true"
+                *ngIf="versionType === 'Fork'"
+              >
+                <p>
                   This will create a copy of
                   <b>{{ catalogueItem.label }}</b> with a new name, and a new
-                  'main' branch. Use this option if you are planning on taking
-                  this model in a new direction, or under a new authority.
-                </small>
-              </div>
+                  'main' branch.
+                </p>
+                <p>
+                  Use this option if you are planning on taking this
+                  {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }} in
+                  a new direction, or under a new authority.
+                </p>
+              </mdm-alert>
 
-              <div class="mb-2">
-                <mat-radio-group
-                  class="marginless"
-                  [(ngModel)]="versionType"
-                  (click)="versionTypeChecked()"
-                  [disabled]="processing"
-                >
-                  <mat-radio-button value="Version"
-                    ><i class="fas fa-file-alt"></i> New
-                    Version</mat-radio-button
+              <mdm-alert
+                alertStyle="info"
+                [showIcon]="true"
+                *ngIf="versionType === 'Version'"
+              >
+                <p>
+                  This will create a draft copy of
+                  <b>{{ catalogueItem.label }}</b> under the 'main' branch.
+                </p>
+                <p>
+                  Use this option if you want to create the next iteration of
+                  this
+                  {{ domainType === 'VersionedFolder' ? 'folder' : 'model' }}.
+                </p>
+              </mdm-alert>
+
+              <mdm-alert
+                alertStyle="info"
+                [showIcon]="true"
+                *ngIf="versionType === 'Branch'"
+              >
+                <p>
+                  This will create a copy of <b>{{ catalogueItem.label }}</b> in
+                  a new branch. You may choose the name of the new branch.
+                </p>
+                <p>
+                  Use this option if you want to make some changes that you
+                  subsequently wish to merge back into 'main'.
+                </p>
+              </mdm-alert>
+
+              <div *ngIf="versionType === 'Fork'">
+                <div class="mdm--form-input mb-2">
+                  <h4 class="mat-h4 marginless">Additional details:</h4>
+
+                  <div
+                    [ngClass]="{
+                      'form-group': true,
+                      'has-error': errors && errors.label
+                    }"
                   >
-                </mat-radio-group>
-                <small
-                  >This will create a copy of
-                  <b>{{ catalogueItem.label }}</b> under the 'main' branch. Use
-                  this option if you want to create the next iteration of this
-                  model.
-                </small>
+                    <mat-form-field appearance="outline" class="full-width">
+                      <mat-label>Model name</mat-label>
+                      <input
+                        matInput
+                        [(ngModel)]="form.label"
+                        [disabled]="processing"
+                        required
+                      />
+                      <mat-hint
+                        >The name should be different from the current version
+                        name '{{ catalogueItem.label }}'</mat-hint
+                      >
+                    </mat-form-field>
+                    <span
+                      class="help-block warning"
+                      *ngIf="errors && errors.label"
+                      style="margin-left: 16px"
+                      ><small>{{ errors.label }}</small></span
+                    >
+                  </div>
+                </div>
               </div>
 
-              <div class="mb-2">
-                <mat-radio-group
-                  class="marginless"
-                  [(ngModel)]="versionType"
-                  (click)="versionTypeChecked()"
-                  [disabled]="processing"
-                >
-                  <mat-radio-button value="Branch"
-                    ><i class="fas fa-code-branch"></i> New
-                    Branch</mat-radio-button
-                  >
-                </mat-radio-group>
-                <small
-                  >This will create a copy of
-                  <b>{{ catalogueItem.label }}</b> in a new branch. You may
-                  choose the name of the new branch. Use this option if you want
-                  to make some changes that you subsequently wish to merge back
-                  into 'main'.
-                </small>
-              </div>
-            </div>
-
-            <div *ngIf="versionType === 'Fork'">
-              <div class="mdm--form-input mb-2">
-                <h4 class="mat-h4 marginless">Additional details:</h4>
-
+              <div *ngIf="versionType === 'Branch'">
                 <div
                   [ngClass]="{
                     'form-group': true,
@@ -108,17 +157,13 @@ SPDX-License-Identifier: Apache-2.0
                   }"
                 >
                   <mat-form-field appearance="outline" class="full-width">
-                    <mat-label>Model name</mat-label>
+                    <mat-label>Branch name</mat-label>
                     <input
                       matInput
                       [(ngModel)]="form.label"
                       [disabled]="processing"
                       required
                     />
-                    <mat-hint
-                      >The name should be different from the current version
-                      name '{{ catalogueItem.label }}'</mat-hint
-                    >
                   </mat-form-field>
                   <span
                     class="help-block warning"
@@ -128,61 +173,37 @@ SPDX-License-Identifier: Apache-2.0
                   >
                 </div>
               </div>
-            </div>
-
-            <div *ngIf="versionType === 'Branch'">
-              <div
-                [ngClass]="{
-                  'form-group': true,
-                  'has-error': errors && errors.label
-                }"
-              >
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>Branch name</mat-label>
-                  <input
-                    matInput
-                    [(ngModel)]="form.label"
-                    [disabled]="processing"
-                    required
-                  />
-                </mat-form-field>
-                <span
-                  class="help-block warning"
-                  *ngIf="errors && errors.label"
-                  style="margin-left: 16px"
-                  ><small>{{ errors.label }}</small></span
+              <div *ngIf="step > 1">
+                <button
+                  mat-button
+                  color="warn"
+                  (click)="cancel()"
+                  [disabled]="processing"
                 >
-              </div>
-            </div>
-            <div *ngIf="step > 1">
-              <button
-                mat-button
-                color="warn"
-                (click)="cancel()"
-                [disabled]="processing"
-              >
-                Cancel
-              </button>
-              <button
-                mat-flat-button
-                color="primary"
-                class="custom"
-                (click)="save()"
-                [disabled]="processing"
-              >
-                Add {{ versionType }}
-              </button>
+                  Cancel
+                </button>
+                <button
+                  mat-flat-button
+                  color="primary"
+                  class="custom"
+                  (click)="save()"
+                  [disabled]="processing"
+                >
+                  Add {{ versionType }}
+                </button>
 
-              <div style="margin-top: 5px" *ngIf="processing">
-                <mat-progress-bar
-                  value="50"
-                  bufferValue="75"
-                  color="accent"
-                  mode="indeterminate"
-                ></mat-progress-bar>
+                <div style="margin-top: 5px" *ngIf="processing">
+                  <mat-progress-bar
+                    value="50"
+                    bufferValue="75"
+                    color="accent"
+                    mode="indeterminate"
+                  ></mat-progress-bar>
+                </div>
               </div>
             </div>
-          </div>     
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/shared/new-version/new-version.component.scss
+++ b/src/app/shared/new-version/new-version.component.scss
@@ -16,3 +16,10 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
+.mdm-new-version__type__option {
+  white-space: normal !important;
+  line-height: normal !important;
+  height: auto !important;
+  padding: 16px;
+}

--- a/src/app/shared/new-version/new-version.component.ts
+++ b/src/app/shared/new-version/new-version.component.ts
@@ -54,7 +54,7 @@ export class NewVersionComponent implements OnInit {
       icon: 'fa-list',
       getDescription: (domainType, item) => {
         return `This will create a copy of <b>${item.label}</b> with a new name, and a new 'main' branch.
-          Use this option if you are planning on taking this ${domainType === CatalogueItemDomainType.VersionedFolder ? 'folder' : 'model'} in a new direction, or under a new authority.`
+          Use this option if you are planning on taking this ${domainType === CatalogueItemDomainType.VersionedFolder ? 'folder' : 'model'} in a new direction, or under a new authority.`;
       }
     },
     {
@@ -64,7 +64,7 @@ export class NewVersionComponent implements OnInit {
       icon: 'fa-file-alt',
       getDescription: (domainType, item) => {
         return `This will create a draft copy of <b>${item.label }</b> under the 'main' branch.
-          Use this option if you want to create the next iteration of this ${domainType === CatalogueItemDomainType.VersionedFolder ? 'folder' : 'model'}.`
+          Use this option if you want to create the next iteration of this ${domainType === CatalogueItemDomainType.VersionedFolder ? 'folder' : 'model'}.`;
       }
     },
     {
@@ -74,7 +74,7 @@ export class NewVersionComponent implements OnInit {
       icon: 'fa-code-branch',
       getDescription: (_, item) => {
         return `This will create a copy of <b>${item.label}</b> in a new branch. You may choose the name of the new branch.
-          Use this option if you want to make some changes that you subsequently wish to merge back into 'main'.`
+          Use this option if you want to make some changes that you subsequently wish to merge back into 'main'.`;
       }
     },
   ];

--- a/src/app/shared/new-version/new-version.component.ts
+++ b/src/app/shared/new-version/new-version.component.ts
@@ -21,7 +21,7 @@ import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn,
 import { Title } from '@angular/platform-browser';
 import { CatalogueItem, Modelable, ForkModelPayload, CatalogueItemDomainType, MdmResponse, BranchModelPayload } from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { StateHandlerService, MessageHandlerService, ElementTypesService, Type } from '@mdm/services';
+import { StateHandlerService, MessageHandlerService, ElementTypesService, CatalogueElementType } from '@mdm/services';
 import { UIRouterGlobals } from '@uirouter/core';
 import { EMPTY, Observable } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
@@ -34,7 +34,7 @@ import { catchError, finalize } from 'rxjs/operators';
 export class NewVersionComponent implements OnInit {
   catalogueItem: CatalogueItem & Modelable;
   domainType: CatalogueItemDomainType;
-  domainElementType: Type;
+  domainElementType: CatalogueElementType;
   processing: boolean;
   setupForm: FormGroup;
 

--- a/src/app/shared/new-version/new-version.component.ts
+++ b/src/app/shared/new-version/new-version.component.ts
@@ -46,8 +46,8 @@ export class NewVersionComponent implements OnInit {
     return this.type.value;
   }
 
-  get modelName() {
-    return this.setupForm.get('modelName');
+  get label() {
+    return this.setupForm.get('label');
   }
 
   get branchName() {
@@ -88,8 +88,8 @@ export class NewVersionComponent implements OnInit {
   }
 
   typeChanged() {
-    if (this.modelName) {
-      this.setupForm.removeControl('modelName');
+    if (this.label) {
+      this.setupForm.removeControl('label');
     }
 
     if (this.branchName) {
@@ -98,7 +98,7 @@ export class NewVersionComponent implements OnInit {
 
     if (this.typeValue === 'Fork') {
       this.setupForm.addControl(
-        'modelName',
+        'label',
         new FormControl(
           '',
           [
@@ -134,7 +134,7 @@ export class NewVersionComponent implements OnInit {
 
     if (this.typeValue === 'Fork') {
       const resource: ForkModelPayload = {
-        label: this.modelName.value,
+        label: this.label.value,
         copyPermissions: false,
         copyDataFlows: false
       };

--- a/src/app/shared/new-version/new-version.component.ts
+++ b/src/app/shared/new-version/new-version.component.ts
@@ -77,7 +77,7 @@ export class NewVersionComponent implements OnInit {
 
     // Setup first key field in form first, remaining form fields depend on the type selected
     this.setupForm = new FormGroup({
-      type: new FormControl('', Validators.required)
+      type: new FormControl('', Validators.required)  // eslint-disable-line @typescript-eslint/unbound-method
     });
 
     this.resources[this.domainElementType.resourceName]
@@ -102,13 +102,15 @@ export class NewVersionComponent implements OnInit {
         new FormControl(
           '',
           [
-            Validators.required,
+            Validators.required,  // eslint-disable-line @typescript-eslint/unbound-method
             this.forbiddenName(this.catalogueItem.label)
           ]));
     }
 
     if (this.typeValue === 'Branch') {
-      this.setupForm.addControl('branchName', new FormControl('', Validators.required));
+      this.setupForm.addControl(
+        'branchName',
+        new FormControl('', Validators.required));  // eslint-disable-line @typescript-eslint/unbound-method
     }
   }
 

--- a/src/app/terminology/terminology-details/terminology-details.component.html
+++ b/src/app/terminology/terminology-details/terminology-details.component.html
@@ -300,27 +300,7 @@ SPDX-License-Identifier: Apache-2.0
             <i class="fas fa-code-branch" matTooltip="Branch name"></i>
             <span><strong>Branch: </strong></span>
             <span>
-              <select
-                class="form-control"
-                style="
-                  display: inline;
-                  max-width: 120px;
-                  height: 30px;
-                  line-height: 1;
-                  padding: 0 0.35em;
-                  width: auto;
-                "
-                [(ngModel)]="currentBranch"
-                name="currentBranch"
-                (ngModelChange)="onModelChange()"
-              >
-                <option
-                  [value]="item.branch"
-                  *ngFor="let item of branchGraph"
-                >
-                {{ item.branch ? item.branch : 'main' }}
-                </option>
-              </select>
+              <mdm-branch-selector [catalogueItem]="mcTerminology"></mdm-branch-selector>
             </span>
           </small>
         </div>

--- a/src/app/terminology/terminology-details/terminology-details.component.ts
+++ b/src/app/terminology/terminology-details/terminology-details.component.ts
@@ -280,8 +280,10 @@ export class TerminologyDetailsComponent implements OnInit {
   newVersion() {
     this.stateHandler.Go(
       'newversionmodel',
-      { id: this.mcTerminology.id, domainType: 'terminology' },
-      { location: true }
+      {
+        id: this.mcTerminology.id,
+        domainType: this.mcTerminology.domainType
+      }
     );
   }
 

--- a/src/app/terminology/terminology-details/terminology-details.component.ts
+++ b/src/app/terminology/terminology-details/terminology-details.component.ts
@@ -63,8 +63,6 @@ export class TerminologyDetailsComponent implements OnInit {
   deleteInProgress = false;
   errorMessage: string;
   exporting: boolean;
-  currentBranch = '';
-  branchGraph = [];
   downloadLinks = new Array<HTMLAnchorElement>();
   access: Access;
   editMode = false;
@@ -93,34 +91,7 @@ export class TerminologyDetailsComponent implements OnInit {
     this.originalTerminology = Object.assign({},this.mcTerminology);
     this.access = this.securityHandler.elementAccess(this.mcTerminology);
     this.loadExporterList();
-    this.getModelGraph(this.mcTerminology.id);
     this.addedToFavourite = this.favouriteHandler.isAdded(this.mcTerminology);
-  }
-
-  getModelGraph(modelId) {
-    this.currentBranch = this.mcTerminology.branchName;
-    this.branchGraph = [
-      {
-        branch: 'main',
-        label: this.mcTerminology.label,
-        modelId,
-        newBranchModelVersion: false,
-        newDocumentationVersion: false,
-        newFork: false
-      }
-    ];
-  }
-
-  onModelChange() {
-    for (const val in this.branchGraph) {
-      if (this.branchGraph[val].branch === this.currentBranch) {
-        this.stateHandler.Go(
-          'terminology',
-          { id: this.branchGraph[val].id },
-          { reload: true, location: true }
-        );
-      }
-    }
   }
 
   save(){

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -42,6 +42,10 @@ export interface TestModuleConfiguration {
   providers?: any[];
 }
 
+export interface TestComponentConfiguration {
+  detectChangesOnCreation?: boolean
+}
+
 /**
  * Represents a created component for testing plus a fixture.
  *
@@ -54,7 +58,10 @@ export class ComponentHarness<T> {
     return !!this.component;
   }
 
-  detectChanges() {
+  detectChanges(setter?: (component: T) => void) {
+    if (setter) {
+      setter(this.component);
+    }
     this.fixture.detectChanges();
   }
 }
@@ -80,23 +87,31 @@ export const setupTestModuleForService = <T>(service: Type<T>, configuration?: T
  *
  * @typedef T The type of the component under test.
  * @param componentType The type of the component under test.
- * @param configuration Optionally provide additional configuration for the test module.
+ * @param moduleConfig Optionally provide additional configuration for the test module.
+ * @param componentConfig Optionally provide additional configuration for the component under test.
  * @returns A new `ComponentHarness<T>` containing an instance of the component under test with a fixture.
  */
-export const setupTestModuleForComponent = async <T>(componentType: Type<T>, configuration?: TestModuleConfiguration) => {
+export const setupTestModuleForComponent = async <T>(
+  componentType: Type<T>,
+  moduleConfig?: TestModuleConfiguration,
+  componentConfig?: TestComponentConfiguration) => {
   await TestBed
     .configureTestingModule({
-      imports: [TestingModule, ...configuration?.imports ?? []],
+      imports: [TestingModule, ...moduleConfig?.imports ?? []],
       declarations: [
         componentType,
         MockComponent(NgxSkeletonLoaderComponent),
-        ...configuration?.declarations ?? []],
-      providers: configuration?.providers ?? []
+        ...moduleConfig?.declarations ?? []],
+      providers: moduleConfig?.providers ?? []
     })
     .compileComponents();
 
   const fixture = TestBed.createComponent(componentType);
   const component = fixture.componentInstance;
-  fixture.detectChanges();
+
+  if (componentConfig?.detectChangesOnCreation) {
+    fixture.detectChanges();
+  }
+
   return new ComponentHarness(component, fixture);
 };

--- a/src/app/testing/testing.helpers.ts
+++ b/src/app/testing/testing.helpers.ts
@@ -43,7 +43,7 @@ export interface TestModuleConfiguration {
 }
 
 export interface TestComponentConfiguration {
-  detectChangesOnCreation?: boolean
+  detectChangesOnCreation?: boolean;
 }
 
 /**

--- a/src/app/testing/testing.module.ts
+++ b/src/app/testing/testing.module.ts
@@ -44,6 +44,7 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
   exports: [
     MaterialModule,
     UIRouterModule,
+    FormsModule,
     ReactiveFormsModule
   ]
 })

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -237,35 +237,15 @@ SPDX-License-Identifier: Apache-2.0
             </span>
           </small>
         </div>
-        <!-- <div class="text-muted" *ngIf="detail">
+        <div class="text-muted" *ngIf="detail">
           <small>
             <i class="fas fa-code-branch" matTooltip="Branch name"></i>
             <span><strong>Branch: </strong></span>
             <span>
-              <select
-                class="form-control"
-                style="
-                  display: inline;
-                  max-width: 120px;
-                  height: 30px;
-                  line-height: 1;
-                  padding: 0 0.35em;
-                  width: auto;
-                "
-                [(ngModel)]="currentBranch"
-                name="currentBranch"
-                (ngModelChange)="onModelChange()"
-              >
-                <option
-                  [value]="item.branch"
-                  *ngFor="let item of branchGraph"
-                >
-                  {{ item.branch ? item.branch : 'main' }}
-                </option>
-              </select>
+              <mdm-branch-selector [catalogueItem]="detail"></mdm-branch-selector>
             </span>
           </small>
-        </div> -->
+        </div>
         <div class="text-muted" *ngIf="detail">
           <small>
             <i class="far fa-calendar-alt" matTooltip="Last update"></i>

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -237,7 +237,7 @@ SPDX-License-Identifier: Apache-2.0
             </span>
           </small>
         </div>
-        <!-- <div class="text-muted" *ngIf="catalogueItem">
+        <!-- <div class="text-muted" *ngIf="detail">
           <small>
             <i class="fas fa-code-branch" matTooltip="Branch name"></i>
             <span><strong>Branch: </strong></span>

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.html
@@ -52,6 +52,14 @@ SPDX-License-Identifier: Apache-2.0
           >
             <i class="fas fa-pencil-alt"></i> Edit Title
           </button>
+          <button
+            mat-menu-item
+            type="button"
+            *ngIf="access.showNewVersion"
+            (click)="newVersion()"
+          >
+            <i class="fas fa-copy"></i> Create a New Version
+          </button>
           <mat-divider></mat-divider>
           <button
             mat-menu-item
@@ -133,10 +141,7 @@ SPDX-License-Identifier: Apache-2.0
             [ngClass]="{ deletedDataModelTitle: detail?.deleted }"
           >
             <span class="dataModelTypeIcon">
-              <i
-                matTooltip="Versioned Folder"
-                class="fas fa-box"
-              ></i>
+              <i matTooltip="Versioned Folder" class="fas fa-box"></i>
             </span>
             <mdm-inline-text-edit
               [readOnly]="false"
@@ -152,25 +157,25 @@ SPDX-License-Identifier: Apache-2.0
             >
             </mdm-inline-text-edit>
             <sup
-            *ngIf="detail?.readableByEveryone"
-            class="text-muted"
-            style="margin-left: 4px"
-            ><i
-              class="fas fa-globe-europe globe fa-xs"
-              aria-hidden="true"
-              matTooltip="Publicly Available"
-            ></i
-          ></sup>
-          <sup
-            *ngIf="detail?.readableByAuthenticatedUsers"
-            class="text-muted"
-            style="margin-left: 4px"
-            ><i
-              class="fas fa-users globe fa-xs"
-              aria-hidden="true"
-              matTooltip="Authenticated users only"
-            ></i
-          ></sup>
+              *ngIf="detail?.readableByEveryone"
+              class="text-muted"
+              style="margin-left: 4px"
+              ><i
+                class="fas fa-globe-europe globe fa-xs"
+                aria-hidden="true"
+                matTooltip="Publicly Available"
+              ></i
+            ></sup>
+            <sup
+              *ngIf="detail?.readableByAuthenticatedUsers"
+              class="text-muted"
+              style="margin-left: 4px"
+              ><i
+                class="fas fa-users globe fa-xs"
+                aria-hidden="true"
+                matTooltip="Authenticated users only"
+              ></i
+            ></sup>
           </h4>
           <span class="inline-block" *ngIf="detail?.deleted">
             <small class="warning"> | Deleted</small>

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -164,53 +164,61 @@ export class VersionedFolderDetailComponent implements OnInit {
   }
 
   finalise() {
-
-     const dialog = this.dialog.open<
-          FinaliseModalComponent,
-          any,
-          FinaliseModalResponse
-        >(FinaliseModalComponent, {
-          data: {
-            title: 'Finalise Versioned Folder',
-            okBtnTitle: 'Finalise Versioned Folder',
-            btnType: 'accent',
-            message: `<p class='marginless'>Please select the version you would like this Versioned Folder</p>
+    const dialog = this.dialog.open<
+      FinaliseModalComponent,
+      any,
+      FinaliseModalResponse
+    >(FinaliseModalComponent, {
+      data: {
+        title: 'Finalise Versioned Folder',
+        okBtnTitle: 'Finalise Versioned Folder',
+        btnType: 'accent',
+        message: `<p class='marginless'>Please select the version you would like this Versioned Folder</p>
                       <p>to be finalised with: </p>`
-          }
-        });
+      }
+    });
 
-        dialog.afterClosed().subscribe((dialogResult) => {
-          if (dialogResult?.status !== ModalDialogStatus.Ok) {
-            return;
-          }
-          this.processing = true;
-          this.resourcesService.versionedFolder
-            .finalise(this.detail.id, dialogResult.request)
-            .subscribe(
-              () => {
-                this.processing = false;
-                this.messageHandler.showSuccess(
-                  'Versioned Folder finalised successfully.'
-                );
-                this.stateHandler.Go(
-                  'versionedFolder',
-                  { id: this.detail.id },
-                  { reload: true }
-                );
-              },
-              (error) => {
-                this.processing = false;
-                this.messageHandler.showError(
-                  'There was a problem finalising the Versioned Folder.',
-                  error
-                );
-              }
+    dialog.afterClosed().subscribe((dialogResult) => {
+      if (dialogResult?.status !== ModalDialogStatus.Ok) {
+        return;
+      }
+      this.processing = true;
+      this.resourcesService.versionedFolder
+        .finalise(this.detail.id, dialogResult.request)
+        .subscribe(
+          () => {
+            this.processing = false;
+            this.messageHandler.showSuccess(
+              'Versioned Folder finalised successfully.'
             );
-        });
-
+            this.stateHandler.Go(
+              'versionedFolder',
+              { id: this.detail.id },
+              { reload: true }
+            );
+          },
+          (error) => {
+            this.processing = false;
+            this.messageHandler.showError(
+              'There was a problem finalising the Versioned Folder.',
+              error
+            );
+          }
+        );
+    });
   }
 
-  delete(permanent: boolean) {
+  newVersion() {
+    this.stateHandler.Go(
+      'newVersionModel',
+      {
+        id: this.detail.id,
+        domainType: this.detail.domainType
+      }
+    );
+  }
+
+  private delete(permanent: boolean) {
     if (!this.access.showSoftDelete && !this.access.showPermanentDelete) {
       return;
     }

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -65,8 +65,6 @@ export class VersionedFolderDetailComponent implements OnInit {
     this.access = this.securityHandler.elementAccess(this.detail);
     this.title.setTitle(`Versioned Folder - ${this.detail?.label}`);
     this.original = Object.assign({}, this.detail);
-
-    this.access.showNewVersion = true;
   }
 
   toggleShowSearch() {

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -65,6 +65,8 @@ export class VersionedFolderDetailComponent implements OnInit {
     this.access = this.securityHandler.elementAccess(this.detail);
     this.title.setTitle(`Versioned Folder - ${this.detail?.label}`);
     this.original = Object.assign({}, this.detail);
+
+    this.access.showNewVersion = true;
   }
 
   toggleShowSearch() {


### PR DESCRIPTION
* Add actions to navigate to `NewVersionComponent` from a Versioned Folder
* Tidy up the UI for the `NewVersionComponent`, especially text to make sure instructions make sense for both models and containers
* Created shared `BranchSelectorComponent` to use correct endpoint for getting version/branch list from a model/folder and update all detail views to use this now

**Note**: there is a known issue in the backend which prevents a new version/branch/fork being created for a Versioned Folder that has child content, see MauroDataMapper/mdm-core#88. Oddly, these actions do work on empty Versioned Folders though.