### PR TITLE
Feature/mc 9551 Importer updates to support Versioned Folders

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,7 @@
           "builder": "@angular-builders/custom-webpack:browser",
           "options": {
             "customWebpackConfig": {
-              "path": "custom-webpack.config.js"
+              "path": "webpack.config.js"
             },
             "outputPath": "dist",
             "index": "src/index.html",

--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -824,7 +824,9 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
 
     let children = [];
     if (this.justShowFolders && node.children) {
-      children = node.children.filter(c => c.domainType === CatalogueItemDomainType.Folder);
+      children = node.children.filter(c =>
+        c.domainType === CatalogueItemDomainType.Folder
+        || (this.shared.features.useVersionedFolders && c.domainType === CatalogueItemDomainType.VersionedFolder));
     } else if (this.doNotShowDataClasses && node.children) {
       children = node.children.filter(c => c.domainType !== CatalogueItemDomainType.DataClass);
     } else {

--- a/src/app/import-models/import-models.component.html
+++ b/src/app/import-models/import-models.component.html
@@ -50,7 +50,7 @@ SPDX-License-Identifier: Apache-2.0
                                              [ngModel]="option.value"
                                              name="Folder"
                                              (ngModelChange)="option.value = $event"
-                                             [accepts]="['Folder']"
+                                             [accepts]="allowedFolderTreeDomainTypes"
                                              ngDefaultControl
                                              [showValidationError]="option.optional === false"
                                              [isRequired]="option.optional == false">

--- a/src/app/import-models/import-models.component.html
+++ b/src/app/import-models/import-models.component.html
@@ -16,128 +16,256 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="heading-container">
-    <h4 *ngIf="importType === 'dataModels'">Import a new Data Model </h4>
-    <h4 *ngIf="importType === 'codeSets'">Import a new Code Set </h4>
-    <h4 *ngIf="importType === 'referenceDataModels'">Import Reference Data Model </h4>
-    <h4 *ngIf="importType === 'terminologies'">Import a new Terminology </h4>
-    <i class="fas fa-info-circle helpIcon" (click)="loadHelp()" matTooltip="Help"></i>
-</div>
-<div *ngIf="importers" style="margin-top: 16px;">
-    <h4 class="marginless">
-        Select an importer<sup class="required">*</sup>
-        <i *ngIf="importerHelp" class="fas fa-info-circle helpIcon" (click)="loadImporterHelp()" matTooltip="Help"></i>
-    </h4>
+<div class="mdm--shadow-block">
+  <div class="panel">
+    <div class="panel-heading">
+      <div class="heading-container">
+        <h4 *ngIf="importType === 'dataModels'">Import a new Data Model</h4>
+        <h4 *ngIf="importType === 'codeSets'">Import a new Code Set</h4>
+        <h4 *ngIf="importType === 'referenceDataModels'">
+          Import Reference Data Model
+        </h4>
+        <h4 *ngIf="importType === 'terminologies'">Import a new Terminology</h4>
+        <i
+          class="fas fa-info-circle helpIcon"
+          (click)="loadHelp()"
+          matTooltip="Help"
+        ></i>
+      </div>
+    </div>
+    <div class="panel-body">
+      <div *ngIf="importers" style="margin-top: 16px">
+        <h4 class="marginless">
+          Select an importer<sup class="required">*</sup>
+          <i
+            *ngIf="importerHelp"
+            class="fas fa-info-circle helpIcon"
+            (click)="loadImporterHelp()"
+            matTooltip="Help"
+          ></i>
+        </h4>
 
-    <mat-form-field appearance="outline" class="mb-2 full-width">
-        <mat-label>Select importer</mat-label>
-        <mat-select aria-label="selectedImporterStr" [(ngModel)]="selectedImporterStr" placeholder="Select..." (selectionChange)="importerChanged()">
-          <mat-option *ngFor="let item of importers" [value]="item">{{item.displayName}}</mat-option>
-        </mat-select>
-    </mat-form-field>
-</div>
+        <mat-form-field appearance="outline" class="mb-2 full-width">
+          <mat-label>Select importer</mat-label>
+          <mat-select
+            aria-label="selectedImporterStr"
+            [(ngModel)]="selectedImporterStr"
+            placeholder="Select..."
+            (selectionChange)="importerChanged()"
+          >
+            <mat-option *ngFor="let item of importers" [value]="item">{{
+              item.displayName
+            }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
 
-<div *ngIf="step >= 2 && selectedImporterGroups && selectedImporterGroups.length > 0">
-    <form #userForm="ngForm" id="userForm" (ngSubmit)="submitForm(userForm.valid)" novalidate enctype="multipart/form-data" method="POST">
-
-        <div *ngFor="let group of selectedImporterGroups">
-            <h4>{{group.name}}</h4>
+      <div
+        *ngIf="
+          step >= 2 &&
+          selectedImporterGroups &&
+          selectedImporterGroups.length > 0
+        "
+      >
+        <form
+          #userForm="ngForm"
+          id="userForm"
+          (ngSubmit)="submitForm(userForm.valid)"
+          novalidate
+          enctype="multipart/form-data"
+          method="POST"
+        >
+          <div *ngFor="let group of selectedImporterGroups">
+            <h4>{{ group.name }}</h4>
             <div *ngFor="let option of group.parameters" class="mb-2">
-                <div class="import-folder" *ngIf="option.type === 'Folder'">
-                    <span>Folder location</span>
-                    <mdm-model-selector-tree [treeSearchDomainType]="'Folder'"
-                                             [justShowFolders]="true"
-                                             [ngModel]="option.value"
-                                             name="Folder"
-                                             (ngModelChange)="option.value = $event"
-                                             [accepts]="allowedFolderTreeDomainTypes"
-                                             ngDefaultControl
-                                             [showValidationError]="option.optional === false"
-                                             [isRequired]="option.optional == false">
-                    </mdm-model-selector-tree>
-                </div>
+              <div class="import-folder" *ngIf="option.type === 'Folder'">
+                <span>Folder location</span>
+                <mdm-model-selector-tree
+                  [treeSearchDomainType]="'Folder'"
+                  [justShowFolders]="true"
+                  [folderFilterFn]="folderFilter"
+                  [ngModel]="option.value"
+                  name="Folder"
+                  (ngModelChange)="option.value = $event"
+                  [accepts]="allowedFolderTreeDomainTypes"
+                  ngDefaultControl
+                  [showValidationError]="option.optional === false"
+                  [isRequired]="option.optional == false"
+                >
+                </mdm-model-selector-tree>
+              </div>
 
-                <div class="import-dataModel" *ngIf="option.type === 'DataModel'">
-                    <mdm-model-selector-tree [treeSearchDomainType]="'DataModel'"
-                                             [ngModel]="option.value"
-                                             name="DataModel"
-                                             [accepts]="['DataModel']"
-                                             (ngModelChange)="option.value = $event"
-                                             ngDefaultControl
-                                             [showValidationError]="option.optional === false"
-                                             [isRequired]="option.optional == false">
-                    </mdm-model-selector-tree>
-                </div>
+              <div class="import-dataModel" *ngIf="option.type === 'DataModel'">
+                <mdm-model-selector-tree
+                  [treeSearchDomainType]="'DataModel'"
+                  [ngModel]="option.value"
+                  name="DataModel"
+                  [accepts]="['DataModel']"
+                  (ngModelChange)="option.value = $event"
+                  ngDefaultControl
+                  [showValidationError]="option.optional === false"
+                  [isRequired]="option.optional == false"
+                >
+                </mdm-model-selector-tree>
+              </div>
 
-                <div class="import-text" *ngIf="option.type === 'Text'">
-                    <div [ngClass]="{'has-error' : userForm.form.get(option.name)?.invalid && userForm.form.get(option.name)?.touched}">
-                        <textarea [(ngModel)]="option.value" name="{{option.name}}" [required]="option.optional == false" rows="5" class="form-control outlined-input"></textarea>
-                    </div>
+              <div class="import-text" *ngIf="option.type === 'Text'">
+                <div
+                  [ngClass]="{
+                    'has-error':
+                      userForm.form.get(option.name)?.invalid &&
+                      userForm.form.get(option.name)?.touched
+                  }"
+                >
+                  <textarea
+                    [(ngModel)]="option.value"
+                    name="{{ option.name }}"
+                    [required]="option.optional == false"
+                    rows="5"
+                    class="form-control outlined-input"
+                  ></textarea>
                 </div>
+              </div>
 
-                <div *ngIf="option.type !== 'Folder' && option.type !== 'DataModel' && option.type != 'Text'">
+              <div
+                *ngIf="
+                  option.type !== 'Folder' &&
+                  option.type !== 'DataModel' &&
+                  option.type != 'Text'
+                "
+              >
+                <div
+                  [ngClass]="{
+                    'has-error':
+                      userForm.form.get(option.name)?.invalid &&
+                      userForm.form.get(option.name)?.touched
+                  }"
+                  class="topping"
+                >
+                  <div *ngIf="formOptionsMap[option.type] === 'checkbox'">
+                    <mat-checkbox
+                      [(ngModel)]="option.value"
+                      name="{{ option.name }}"
+                      [required]="option.optional === false"
+                    >
+                      <span
+                        >{{ option.displayName
+                        }}<span [hidden]="option.optional">*</span></span
+                      >
+                    </mat-checkbox>
+                  </div>
 
-                    <div [ngClass]="{'has-error' : userForm.form.get(option.name)?.invalid && userForm.form.get(option.name)?.touched}" class="topping">
-                        <div *ngIf="formOptionsMap[option.type] === 'checkbox'">
-                            <mat-checkbox [(ngModel)]="option.value" name="{{option.name}}" [required]="option.optional === false">
-                                <span>{{option.displayName}}<span [hidden]="option.optional">*</span></span>
-                            </mat-checkbox>
-                        </div>
-
-                        <div *ngIf="formOptionsMap[option.type] != 'checkbox' && formOptionsMap[option.type] != 'file'">
-                            <span>{{option.displayName}}<span [hidden]="option.optional">*</span></span>
-                            <input type="{{formOptionsMap[option.type]}}" name="{{option.name}}" [(ngModel)]="option.value" [ngClass]="{'outlined-input form-control' : formOptionsMap[option.type] != 'checkbox'}" [required]="option.optional === false">
-                        </div>
-                        <div *ngIf="formOptionsMap[option.type] === 'file'">
-                            <input type="{{formOptionsMap[option.type]}}"
-                                   name="{{option.name}}"
-                                   [(ngModel)]="option.value"
-                                   id="{{option.name}}"
-                                   [ngClass]="{'form-control' : formOptionsMap[option.type] != 'checkbox'}"
-                                   [required]="option.optional === false"
-                                   [attr.valid-file]="formOptionsMap[option.type] == 'file'">
-                        </div>
-                    </div>
+                  <div
+                    *ngIf="
+                      formOptionsMap[option.type] != 'checkbox' &&
+                      formOptionsMap[option.type] != 'file'
+                    "
+                  >
+                    <span
+                      >{{ option.displayName
+                      }}<span [hidden]="option.optional">*</span></span
+                    >
+                    <input
+                      type="{{ formOptionsMap[option.type] }}"
+                      name="{{ option.name }}"
+                      [(ngModel)]="option.value"
+                      [ngClass]="{
+                        'outlined-input form-control':
+                          formOptionsMap[option.type] != 'checkbox'
+                      }"
+                      [required]="option.optional === false"
+                    />
+                  </div>
+                  <div *ngIf="formOptionsMap[option.type] === 'file'">
+                    <input
+                      type="{{ formOptionsMap[option.type] }}"
+                      name="{{ option.name }}"
+                      [(ngModel)]="option.value"
+                      id="{{ option.name }}"
+                      [ngClass]="{
+                        'form-control':
+                          formOptionsMap[option.type] != 'checkbox'
+                      }"
+                      [required]="option.optional === false"
+                      [attr.valid-file]="formOptionsMap[option.type] == 'file'"
+                    />
+                  </div>
                 </div>
-                <small class="block">{{option.description}}</small>
-                <div class="has-error">
-                    <div *ngIf="userForm.form.get(option.name)?.errors?.number && option.type == 'Integer'">
-                        <span class="control-label">This is not a valid number.</span>
-                    </div>
-                    <div *ngIf="userForm.form.get(option.name)?.errors?.required && userForm.form.get(option.name)?.touched">
-                        <span class="control-label">This field is required.</span>
-                    </div>
+              </div>
+              <small class="block">{{ option.description }}</small>
+              <div class="has-error">
+                <div
+                  *ngIf="
+                    userForm.form.get(option.name)?.errors?.number &&
+                    option.type == 'Integer'
+                  "
+                >
+                  <span class="control-label">This is not a valid number.</span>
                 </div>
+                <div
+                  *ngIf="
+                    userForm.form.get(option.name)?.errors?.required &&
+                    userForm.form.get(option.name)?.touched
+                  "
+                >
+                  <span class="control-label">This field is required.</span>
+                </div>
+              </div>
             </div>
-        </div>
-        <div class="full-width mt-2">
+          </div>
+          <div class="full-width mt-2">
             <div *ngIf="importingInProgress">
-                <mat-progress-bar mode="indeterminate" color="accent"></mat-progress-bar>
+              <mat-progress-bar
+                mode="indeterminate"
+                color="accent"
+              ></mat-progress-bar>
             </div>
-        </div>
-        <div>
-            <button mat-button color="warn" type="reset" [disabled]="importingInProgress" style="margin-right: 8px;">Reset</button>
-            <button mat-flat-button color="primary" type="submit" class="custom" [disabled]="userForm.invalid || importingInProgress">
-                Import Model(s)
+          </div>
+          <div>
+            <button
+              mat-button
+              color="warn"
+              type="reset"
+              [disabled]="importingInProgress"
+              style="margin-right: 8px"
+            >
+              Reset
             </button>
-        </div>
-    </form>
-</div>
+            <button
+              mat-flat-button
+              color="primary"
+              type="submit"
+              class="custom"
+              [disabled]="userForm.invalid || importingInProgress"
+            >
+              Import Model(s)
+            </button>
+          </div>
+        </form>
+      </div>
 
-<div *ngIf="importCompleted && importResult.count > 1">
-    <hr>
-    <span><strong>The following Data Models ({{importResult.count}}) are imported successfully:</strong></span>
-    <div *ngFor="let import of importResult.items">
-        <div>
+      <div *ngIf="importCompleted && importResult.count > 1">
+        <hr />
+        <span
+          ><strong
+            >The following Data Models ({{ importResult.count }}) are imported
+            successfully:</strong
+          ></span
+        >
+        <div *ngFor="let import of importResult.items">
+          <div>
             <mdm-element-link [element]="import"></mdm-element-link>
+          </div>
         </div>
-    </div>
-</div>
-<div *ngIf="importHasError && importErrors?.length > 0">
-    <div class="alert alert-danger">
-        <strong>Import Errors ({{importErrors.length}})</strong>
-        <div *ngFor="let error of importErrors">
-            <div>{{error.message}}</div>
+      </div>
+      <div *ngIf="importHasError && importErrors?.length > 0">
+        <div class="alert alert-danger">
+          <strong>Import Errors ({{ importErrors.length }})</strong>
+          <div *ngFor="let error of importErrors">
+            <div>{{ error.message }}</div>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </div>

--- a/src/app/import-models/import-models.component.ts
+++ b/src/app/import-models/import-models.component.ts
@@ -26,7 +26,7 @@ import { BroadcastService } from '../services/broadcast.service';
 import { UIRouterGlobals } from '@uirouter/core/';
 import { ModelDomainRequestType } from '@mdm/model/model-domain-type';
 import { ModelTreeService } from '@mdm/services/model-tree.service';
-import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
+import { CatalogueItemDomainType, MdmTreeItem } from '@maurodatamapper/mdm-resources';
 import { SharedService } from '@mdm/services';
 
 @Component({
@@ -91,6 +91,12 @@ export class ImportModelsComponent implements OnInit {
     }
 
     this.loadImporters();
+  }
+
+  folderFilter(item: MdmTreeItem): boolean {
+    // Only allow folders to be selected when they have the 'createModel' permission. e.g.
+    // finalised Versioned Folders will not have this permission, locking them out of further imports
+    return item.availableActions.includes('createModel');
   }
 
   loadImporters() {

--- a/src/app/import-models/import-models.component.ts
+++ b/src/app/import-models/import-models.component.ts
@@ -26,6 +26,8 @@ import { BroadcastService } from '../services/broadcast.service';
 import { UIRouterGlobals } from '@uirouter/core/';
 import { ModelDomainRequestType } from '@mdm/model/model-domain-type';
 import { ModelTreeService } from '@mdm/services/model-tree.service';
+import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
+import { SharedService } from '@mdm/services';
 
 @Component({
   selector: 'mdm-import',
@@ -64,6 +66,8 @@ export class ImportModelsComponent implements OnInit {
   };
   importType: any;
 
+  allowedFolderTreeDomainTypes = [CatalogueItemDomainType.Folder];
+
   constructor(
     private title: Title,
     private resources: MdmResourcesService,
@@ -72,7 +76,8 @@ export class ImportModelsComponent implements OnInit {
     private stateHandler: StateHandlerService,
     private broadcast: BroadcastService,
     private uiRouterGlobals: UIRouterGlobals,
-    private modelTree: ModelTreeService
+    private modelTree: ModelTreeService,
+    private shared: SharedService
   ) {}
 
   ngOnInit() {
@@ -80,6 +85,11 @@ export class ImportModelsComponent implements OnInit {
       ? this.uiRouterGlobals.params.importType
       : 'dataModels';
     this.title.setTitle('Import');
+
+    if (this.shared.features.useVersionedFolders) {
+      this.allowedFolderTreeDomainTypes.push(CatalogueItemDomainType.VersionedFolder);
+    }
+
     this.loadImporters();
   }
 

--- a/src/app/model-selector-tree/model-selector-tree.component.ts
+++ b/src/app/model-selector-tree/model-selector-tree.component.ts
@@ -32,7 +32,7 @@ import { SecurityHandlerService } from '../services/handlers/security-handler.se
 import { UserSettingsHandlerService } from '../services/utility/user-settings-handler.service';
 import { fromEvent } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
-import { ContainerDomainType, FolderIndexResponse, MdmTreeItem, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
+import { CatalogueItemDomainType, ContainerDomainType, FolderIndexResponse, MdmTreeItem, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-model-selector-tree',
@@ -54,7 +54,7 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   @Input() justShowFolders: any;
   @Input() placeholder: any;
   @Output() placeholderChange = new EventEmitter<any>();
-  @Input() accepts: any;
+  @Input() accepts: CatalogueItemDomainType[];
   @Input() treeSearchDomainType: any; // "Folder" or "DataClass" or "DataModel" use as DomainType=xxx when searching in tree/search?domainType=DataModel
   @Input() readOnlySearchInput: any;
   @Input() multiple: any;

--- a/src/app/model-selector-tree/model-selector-tree.component.ts
+++ b/src/app/model-selector-tree/model-selector-tree.component.ts
@@ -32,7 +32,7 @@ import { SecurityHandlerService } from '../services/handlers/security-handler.se
 import { UserSettingsHandlerService } from '../services/utility/user-settings-handler.service';
 import { fromEvent } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
-import { CatalogueItemDomainType, ContainerDomainType, Folder, FolderIndexResponse, MdmTreeItem, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
+import { CatalogueItemDomainType, ContainerDomainType, FolderIndexResponse, MdmTreeItem, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-model-selector-tree',
@@ -204,7 +204,7 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
     this.loading = true;
     if (folder?.id) {
       this.resources.folder.get(id).subscribe((data: FolderIndexResponse) => {
-        let children = data.body.items;
+        const children = data.body.items;
         this.loading = false;
         this.rootNode = {
           children,

--- a/src/app/model-selector-tree/model-selector-tree.component.ts
+++ b/src/app/model-selector-tree/model-selector-tree.component.ts
@@ -32,7 +32,7 @@ import { SecurityHandlerService } from '../services/handlers/security-handler.se
 import { UserSettingsHandlerService } from '../services/utility/user-settings-handler.service';
 import { fromEvent } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
-import { CatalogueItemDomainType, ContainerDomainType, FolderIndexResponse, MdmTreeItem, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
+import { CatalogueItemDomainType, ContainerDomainType, Folder, FolderIndexResponse, MdmTreeItem, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-model-selector-tree',
@@ -65,6 +65,7 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   @Input() propagateCheckbox: any;
   @Input() usedInModalDialogue: any;
   @Input() doNotApplySettingsFilter: any;
+  @Input() folderFilterFn: (f: MdmTreeItem) => boolean;
   @Output() checkChange = new EventEmitter<any>();
   @Output() ngModelChange = new EventEmitter<any>();
   @ViewChild('searchInputTreeControl', { static: true })
@@ -203,9 +204,10 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
     this.loading = true;
     if (folder?.id) {
       this.resources.folder.get(id).subscribe((data: FolderIndexResponse) => {
+        let children = data.body.items;
         this.loading = false;
         this.rootNode = {
-          children: data.body.items,
+          children,
           isRoot: true
         };
         this.filteredRootNode = this.rootNode;
@@ -214,9 +216,14 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
       });
     } else {
       this.resources.tree.list(ContainerDomainType.Folders, {foldersOnly: true}).subscribe((data: MdmTreeItemListResponse) => {
+        // TODO: this is not a very "Angular way" of filtering data for a component, really the data should be filterd
+        // outside the component and passed into this component as an @Input(), making this a "dumb" component.
+        // Issue currently is that this component is already heavily used and cannot be refactored yet, consider for
+        // the future.
+        const children = this.folderFilterFn ? this.filterFolderTreeItems(data.body) : data.body;
         this.loading = false;
         this.rootNode = {
-          children: data.body,
+          children,
           isRoot: true
         };
         this.filteredRootNode = this.rootNode;
@@ -410,4 +417,16 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
 
   // TODO
   onAddFolder = () => { };
+
+  private filterFolderTreeItems(folders?: MdmTreeItem[]): MdmTreeItem[] {
+    // Recursively filter the folder items and their children
+    return folders.filter(folder => {
+      if (folder.children && folder.children.length > 0) {
+        folder.children = this.filterFolderTreeItems(folder.children);
+        folder.hasChildFolders = folder.children && folder.children.length > 0;
+      }
+
+      return this.folderFilterFn(folder);
+    });
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
         themeName: JSON.stringify(process.env['MDM_UI_THEME_NAME']),
         useFeaureSubscribedCatalogues: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_SUBSCRIBED_CATALOGUES'])),
         useVersionedFolders: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_VERSIONED_FOLDERS'])),
-        useMergeUiV2: Boolean(JSON.stringify(process.env['MDM_UI_MERGE_UI_V2'])),
+        useMergeUiV2: Boolean(JSON.stringify(process.env['MDM_UI_FEATURE_MERGE_UI_V2'])),
       }
     })
   ]


### PR DESCRIPTION
* Ensure that Versioned Folders are visible in the importer folder tree selection
* Only show folders that contain the `createModel` permission now - this ensures that finalised Versioned Folders can never be import targets
* Updated the layout styles of the importer page

**Note**: there is a known issue with importing models into Versioned Folders at the moment, the issue is on the backend: MauroDataMapper/mdm-core#89