### PR TITLE
MC-9573 Add info to OpenID Connect provider pages

### DIFF
--- a/src/app/admin/openid-connect-provider/openid-connect-provider.component.html
+++ b/src/app/admin/openid-connect-provider/openid-connect-provider.component.html
@@ -28,6 +28,15 @@ SPDX-License-Identifier: Apache-2.0
   *ngIf="form"
   [formGroup]="form.group"
 >
+  <mdm-alert alertStyle="info" [showIcon]="true">
+    <p>
+      It may be necessary to provide information about Mauro to this OpenID
+      Connect provider. Here are some details which you may require:
+    </p>
+    <ul>
+      <li><code>redirect_uri</code>: <strong>{{redirectUri}}</strong></li>
+    </ul>
+  </mdm-alert>
   <mat-form-field appearance="outline">
     <mat-label>Label</mat-label>
     <input matInput formControlName="label" required />

--- a/src/app/admin/openid-connect-provider/openid-connect-provider.component.ts
+++ b/src/app/admin/openid-connect-provider/openid-connect-provider.component.ts
@@ -20,7 +20,7 @@ import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { OpenIdConnectProviderDetail, OpenIdConnectProvidersDetailResponse, Uuid } from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { MessageHandlerService, SharedService, StateHandlerService } from '@mdm/services';
+import { MessageHandlerService, SecurityHandlerService, SharedService, StateHandlerService } from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
 import { UIRouterGlobals } from '@uirouter/angular';
 import { EMPTY, Observable } from 'rxjs';
@@ -37,6 +37,7 @@ export class OpenidConnectProviderComponent implements OnInit {
   editExisting = false;
   form: OpenIdConnectProviderForm;
   previewImageUrl?: string;
+  redirectUri: string;
 
   constructor(
     private uiRouterGlobals: UIRouterGlobals,
@@ -45,13 +46,16 @@ export class OpenidConnectProviderComponent implements OnInit {
     private stateHandler: StateHandlerService,
     private editing: EditingService,
     private shared: SharedService,
-    private title: Title) { }
+    private title: Title,
+    private securityHandler: SecurityHandlerService) { }
 
   ngOnInit(): void {
     if (!this.shared.features.useOpenIdConnect) {
       this.stateHandler.Go('alldatamodel');
       return;
     }
+
+    this.redirectUri = this.securityHandler.getOpenIdAuthorizeUrl().toString();
 
     this.editing.start();
 

--- a/src/app/services/handlers/security-handler.service.ts
+++ b/src/app/services/handlers/security-handler.service.ts
@@ -341,7 +341,7 @@ export class SecurityHandlerService {
     return baseRtn;
   }
 
-  private getOpenIdAuthorizeUrl() {
+  public getOpenIdAuthorizeUrl() {
     const authorizationUrl = this.stateHandler.getURL('appContainer.mainApp.openIdConnectAuthorizing');
     const baseUrl = `${window.location.protocol}//${window.location.host}`;
     return new URL(authorizationUrl, baseUrl);


### PR DESCRIPTION
Show the `redirect_uri` to admins, required for OpenID Connect to work between identity providers.