### PR TITLE
Feature/mc 9545 path names

### DIFF
--- a/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.html
+++ b/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.html
@@ -27,9 +27,9 @@ SPDX-License-Identifier: Apache-2.0
         matTooltip="Help"
       ></i>
     </h4>
-    Path: {{ data.item.path }}
   </div>
   <div class="modal-body pxy-2">
+    <mdm-path-name [path]="data.item.path"></mdm-path-name>
     <mdm-string-conflict-editor
       [source]="data.source"
       [target]="data.target"

--- a/src/app/merge-diff/merge-item-selector/merge-item-selector.component.html
+++ b/src/app/merge-diff/merge-item-selector/merge-item-selector.component.html
@@ -26,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0
         creation: item.type === mergeType.Creation,
         deletion: item.type === mergeType.Deletion
       }"
-      *ngFor="let item of (mergeItems | mergeFilter:mergeItemSearch.value)"
+      *ngFor="let item of mergeItems | mergeFilter: mergeItemSearch.value"
       [value]="item"
       (click)="selectedItem(item)"
     >
@@ -38,8 +38,14 @@ SPDX-License-Identifier: Apache-2.0
           'fa-minus-square': item.type === mergeType.Deletion,
           'fa-pen-square': item.type === mergeType.Modification
         }"
+        [matTooltip]="getMergeTypeTooltip(item.type)"
       ></i>
-      {{ item.path }} {{ item.branchSelected | uppercase }}
+      <mdm-path-name
+        [path]="item.path"
+        [suffixLabel]="item.branchSelected | uppercase"
+        [suffixIcon]="getBranchSelectedIcon(item.branchSelected)"
+        [suffixTooltip]="getBranchSelectedTooltip(item.branchSelected)"
+      ></mdm-path-name>
     </mat-list-option>
   </mat-selection-list>
 </div>

--- a/src/app/merge-diff/merge-item-selector/merge-item-selector.component.ts
+++ b/src/app/merge-diff/merge-item-selector/merge-item-selector.component.ts
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
-import { MergeItem, MergeType } from '@maurodatamapper/mdm-resources';
+import { MergeItem, MergeType, MergeUsed } from '@maurodatamapper/mdm-resources';
 import {
   CommittingMergeItem} from '../types/merge-item-type';
 
@@ -46,5 +46,44 @@ export class MergeItemSelectorComponent implements OnInit {
 
   public get mergeType() {
     return MergeType;
+  }
+
+  getBranchSelectedIcon(selected: MergeUsed) {
+    switch (selected) {
+      case MergeUsed.Source:
+        return 'fas fa-forward';
+      case MergeUsed.Target:
+        return 'fas fa-backward';
+      case MergeUsed.Mixed:
+        return 'fab fa-mixer';
+      default:
+        return '';
+    }
+  }
+
+  getBranchSelectedTooltip(selected: MergeUsed) {
+    switch (selected) {
+      case MergeUsed.Source:
+        return 'Take from Source';
+      case MergeUsed.Target:
+        return 'Take from Target';
+      case MergeUsed.Mixed:
+        return 'Mixed/combined content';
+      default:
+        return '';
+    }
+  }
+
+  getMergeTypeTooltip(type: MergeType) {
+    switch (type) {
+      case MergeType.Creation:
+        return 'Created';
+      case MergeType.Deletion:
+        return 'Deleted';
+      case MergeType.Modification:
+        return 'Modified';
+      default:
+        return '';
+    }
   }
 }

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -47,6 +47,7 @@ import { AlertComponent } from '@mdm/shared/alert/alert.component';
 import { BranchSelectorComponent } from '@mdm/shared/branch-selector/branch-selector.component';
 import { ResizableDirective } from '@mdm/directives/resizable.directive';
 import { DataTypeListButtonsComponent } from '@mdm/shared/data-type-list-buttons/data-type-list-buttons.component';
+import { PathNameComponent } from '../../shared/path-name/path-name.component';
 
 @NgModule({
   declarations: [
@@ -69,7 +70,8 @@ import { DataTypeListButtonsComponent } from '@mdm/shared/data-type-list-buttons
     AlertComponent,
     BranchSelectorComponent,
     ResizableDirective,
-    DataTypeListButtonsComponent
+    DataTypeListButtonsComponent,
+    PathNameComponent
   ],
   imports: [
     CommonModule,
@@ -113,7 +115,8 @@ import { DataTypeListButtonsComponent } from '@mdm/shared/data-type-list-buttons
     AlertComponent,
     BranchSelectorComponent,
     ResizableDirective,
-    DataTypeListButtonsComponent
+    DataTypeListButtonsComponent,
+    PathNameComponent
   ]
 })
 export class SharedModule {}

--- a/src/app/shared/path-name/path-name.component.html
+++ b/src/app/shared/path-name/path-name.component.html
@@ -1,0 +1,19 @@
+<!--
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<p>path-name works!</p>

--- a/src/app/shared/path-name/path-name.component.html
+++ b/src/app/shared/path-name/path-name.component.html
@@ -16,4 +16,16 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<p>path-name works!</p>
+<span *ngFor="let element of elements; let i = index">
+  <span *ngIf="i !== 0"> » </span>
+  <span class="path-element-type" [matTooltip]="element.typeName">{{element.type | uppercase}}</span>
+  {{element.label}}
+  <span *ngIf="element.property" class="path-property" matTooltip="Property">
+    <span *ngFor="let name of element.property.qualifiedName">
+      : {{name}}
+    </span>
+  </span>
+</span>
+<span *ngIf="suffixLabel" class="path-suffix" [matTooltip]="suffixTooltip">
+  <i [class]="suffixIcon"></i> {{suffixLabel}}
+</span>

--- a/src/app/shared/path-name/path-name.component.scss
+++ b/src/app/shared/path-name/path-name.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/shared/path-name/path-name.component.scss
+++ b/src/app/shared/path-name/path-name.component.scss
@@ -16,3 +16,25 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+%path-element-part {
+  border-radius: 5%;
+  padding: 0px 2px;
+}
+
+.path-element-type {
+  @extend %path-element-part;
+  border-color: #885923;
+  font-weight: bold;
+}
+
+.path-property {
+  @extend %path-element-part;
+  font-style: italic;
+  font-weight: bold;
+}
+
+.path-suffix {
+  @extend %path-element-part;
+  margin-left: 4px;
+  padding: 0px 4px;
+}

--- a/src/app/shared/path-name/path-name.component.spec.ts
+++ b/src/app/shared/path-name/path-name.component.spec.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { ComponentHarness, setupTestModuleForComponent } from '@mdm/testing/testing.helpers';
+import { PathNameComponent } from './path-name.component';
+
+describe('PathNameComponent', () => {
+  let harness: ComponentHarness<PathNameComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(PathNameComponent);
+  });
+
+  it('should create', () => {
+    expect(harness?.isComponentCreated).toBeTruthy();
+  });
+});

--- a/src/app/shared/path-name/path-name.component.ts
+++ b/src/app/shared/path-name/path-name.component.ts
@@ -16,7 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { PathElement } from './path-name.model';
+import { PathNameService } from './path-name.service';
 
 @Component({
   selector: 'mdm-path-name',
@@ -24,10 +26,16 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./path-name.component.scss']
 })
 export class PathNameComponent implements OnInit {
+  @Input() path: string;
+  @Input() suffixIcon?: string;
+  @Input() suffixLabel?: string;
+  @Input() suffixTooltip?: string;
 
-  constructor() { }
+  elements: PathElement[];
+
+  constructor(private pathNames: PathNameService) { }
 
   ngOnInit(): void {
+    this.elements = this.pathNames.parse(this.path);
   }
-
 }

--- a/src/app/shared/path-name/path-name.component.ts
+++ b/src/app/shared/path-name/path-name.component.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mdm-path-name',
+  templateUrl: './path-name.component.html',
+  styleUrls: ['./path-name.component.scss']
+})
+export class PathNameComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/shared/path-name/path-name.model.ts
+++ b/src/app/shared/path-name/path-name.model.ts
@@ -1,0 +1,78 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+/**
+ * Prefixes used in Mauro to represent Fully Qualified Paths (FQPs).
+ */
+export enum PathElementType {
+  ApiKey = 'ak',
+  Annotation = 'ann',
+  ApiProperty = 'api',
+  Authority = 'auth',
+  Classifier = 'cl',
+  CodeSet = 'cs',
+  CatalogueUser = 'cu',
+  DataClass = 'dc',
+  DataClassComponent = 'dcc',
+  DataElement = 'de',
+  DataElementComponent = 'dec',
+  DataFlow = 'df',
+  DataModel = 'dm',
+  EnumerationType = 'dt',
+  Edit = 'ed',
+  EnumerationValue = 'ev',
+  Folder = 'fo',
+  GroupRole = 'gr',
+  Metadata = 'md',
+  ReferenceDataElement = 'rde',
+  ReferenceDataModel = 'rdm',
+  ReferenceEnumerationType = 'rdt',
+  ReferenceDataValue = 'rdv',
+  ReferenceEnumerationValue = 'rev',
+  ReferenceFile = 'rf',
+  RuleRepresentation = 'rr',
+  ReferenceSummaryMetadata = 'rsm',
+  ReferenceSummaryMetadataReport = 'rsmr',
+  Rule = 'ru',
+  SemanticLink = 'sl',
+  SummaryMetadata = 'sm',
+  SummaryMetadataReport = 'smr',
+  SecurableResourceGroupRole = 'srgr',
+  SubscribedCatalogue = 'subc',
+  SubscribedModel = 'subm',
+  Terminology = 'te',
+  Term = 'tm',
+  TermRelationship = 'tr',
+  TermRelationshipType = 'trt',
+  UserGroup = 'ug',
+  UserImageFile = 'uif',
+  VersionedFolder = 'vf',
+  VersionLink = 'vl'
+}
+
+export interface PathProperty {
+  name: string;
+  qualifiedName: string[];
+}
+
+export interface PathElement {
+  type: PathElementType;
+  label: string;
+  property?: PathProperty;
+}

--- a/src/app/shared/path-name/path-name.model.ts
+++ b/src/app/shared/path-name/path-name.model.ts
@@ -66,6 +66,54 @@ export enum PathElementType {
   VersionLink = 'vl'
 }
 
+export const pathElementTypeNames = new Map<PathElementType, string>(
+  [
+    [ PathElementType.ApiKey, 'API key'],
+    [ PathElementType.Annotation, 'Annotation'],
+    [ PathElementType.ApiProperty, 'API property'],
+    [ PathElementType.Authority, 'Authority'],
+    [ PathElementType.Classifier, 'Classifier'],
+    [ PathElementType.CodeSet, 'Code set'],
+    [ PathElementType.CatalogueUser, 'Catalogue user'],
+    [ PathElementType.DataClass, 'Data class'],
+    [ PathElementType.DataClassComponent, 'Data class component'],
+    [ PathElementType.DataElement, 'Data element'],
+    [ PathElementType.DataElementComponent, 'Data element component'],
+    [ PathElementType.DataFlow, 'Data flow'],
+    [ PathElementType.DataModel, 'Data model'],
+    [ PathElementType.EnumerationType, 'Enumeration type'],
+    [ PathElementType.Edit, 'Edit'],
+    [ PathElementType.EnumerationValue, 'Enumeration value'],
+    [ PathElementType.Folder, 'Folder'],
+    [ PathElementType.GroupRole, 'Group role'],
+    [ PathElementType.Metadata, 'Metadata'],
+    [ PathElementType.ReferenceDataElement, 'Reference data element'],
+    [ PathElementType.ReferenceDataModel, 'Reference data model'],
+    [ PathElementType.ReferenceEnumerationType, 'Reference enumeration type'],
+    [ PathElementType.ReferenceDataValue, 'Reference data value'],
+    [ PathElementType.ReferenceEnumerationValue, 'Reference enumeration value'],
+    [ PathElementType.ReferenceFile, 'Reference file'],
+    [ PathElementType.RuleRepresentation, 'Rule representation'],
+    [ PathElementType.ReferenceSummaryMetadata, 'Reference summary metadata'],
+    [ PathElementType.ReferenceSummaryMetadataReport, 'Reference summary metadata report'],
+    [ PathElementType.Rule, 'Rule'],
+    [ PathElementType.SemanticLink, 'Semantic link'],
+    [ PathElementType.SummaryMetadata, 'Summary metadata'],
+    [ PathElementType.SummaryMetadataReport, 'Summary metadata report'],
+    [ PathElementType.SecurableResourceGroupRole, 'Securable resource group role'],
+    [ PathElementType.SubscribedCatalogue, 'Subscribed catalogue'],
+    [ PathElementType.SubscribedModel, 'Subscribed model'],
+    [ PathElementType.Terminology, 'Terminology'],
+    [ PathElementType.Term, 'Term'],
+    [ PathElementType.TermRelationship, 'Term relationship'],
+    [ PathElementType.TermRelationshipType, 'Term relationship type'],
+    [ PathElementType.UserGroup, 'User group'],
+    [ PathElementType.UserImageFile, 'User image file'],
+    [ PathElementType.VersionedFolder, 'Versioned folder'],
+    [ PathElementType.VersionLink, 'Version link']
+  ]
+);
+
 export interface PathProperty {
   name: string;
   qualifiedName: string[];
@@ -73,6 +121,7 @@ export interface PathProperty {
 
 export interface PathElement {
   type: PathElementType;
+  typeName: string;
   label: string;
   property?: PathProperty;
 }

--- a/src/app/shared/path-name/path-name.service.spec.ts
+++ b/src/app/shared/path-name/path-name.service.spec.ts
@@ -1,0 +1,143 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+import { PathElement, PathElementType } from './path-name.model';
+import { PathNameService } from './path-name.service';
+
+describe('PathNameService', () => {
+  let service: PathNameService;
+
+  beforeEach(() => {
+    service = setupTestModuleForService(PathNameService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('parsing path name', () => {
+    it.each([undefined, null, ''])('should return nothing when no path is provided', (path) => {
+      const actual = service.parse(path);
+      expect(actual).toBeNull();
+    });
+
+    const pathCases: Array<[string, PathElement[]]> = [
+      [
+        'dm:Test Data Model',
+        [
+          { type: PathElementType.DataModel, label: 'Test Data Model' }
+        ]
+      ],
+      [
+        'te:Test Terminology',
+        [
+          { type: PathElementType.Terminology, label: 'Test Terminology' }
+        ]
+      ],
+      [
+        'cs:Test Code Set',
+        [
+          { type: PathElementType.CodeSet, label: 'Test Code Set' }
+        ]
+      ],
+      [
+        'dm:Test Data Model|dc:Test Data Class',
+        [
+          { type: PathElementType.DataModel, label: 'Test Data Model' },
+          { type: PathElementType.DataClass, label: 'Test Data Class' }
+        ]
+      ],
+      [
+        'dm:Test Data Model|dc:Test Data Class|de:Test Data Element',
+        [
+          { type: PathElementType.DataModel, label: 'Test Data Model' },
+          { type: PathElementType.DataClass, label: 'Test Data Class' },
+          { type: PathElementType.DataElement, label: 'Test Data Element' }
+        ]
+      ],
+      [
+        'dm:Test Data Model:description',
+        [
+          {
+            type: PathElementType.DataModel,
+            label: 'Test Data Model',
+            property: {
+              name: 'description',
+              qualifiedName: ['description']
+            }
+          }
+        ]
+      ],
+      [
+        'dm:Test Data Model:rule:rule-representation',
+        [
+          {
+            type: PathElementType.DataModel,
+            label: 'Test Data Model',
+            property: {
+              name: 'rule-representation',
+              qualifiedName: ['rule', 'rule-representation']
+            }
+          }
+        ]
+      ],
+      [
+        'dm:Test Data Model|dc:Test Data Class:description',
+        [
+          {
+            type: PathElementType.DataModel,
+            label: 'Test Data Model'
+          },
+          {
+            type: PathElementType.DataClass,
+            label: 'Test Data Class',
+            property: {
+              name: 'description',
+              qualifiedName: ['description']
+            }
+          }
+        ]
+      ]
+    ];
+
+    it.each(pathCases)(
+      'when parsing %p then the correct parsed output is returned',
+      (path: string, expected: PathElement[]) => {
+        const actual = service.parse(path);
+        expect(actual).toMatchObject(expected);
+      });
+
+    const badPathCases = [
+      'dm',
+      'dm:',
+      ':label',
+      'dm:label|dm',
+      'dm:label|dm:',
+      'dm:label|:label'
+    ];
+
+    it.each(badPathCases)(
+      'when parsing %p then an error is thrown',
+      (path: string) => {
+        expect(() => {
+          service.parse(path)
+        }).toThrow();
+      });
+  });
+});

--- a/src/app/shared/path-name/path-name.service.spec.ts
+++ b/src/app/shared/path-name/path-name.service.spec.ts
@@ -41,34 +41,34 @@ describe('PathNameService', () => {
       [
         'dm:Test Data Model',
         [
-          { type: PathElementType.DataModel, label: 'Test Data Model' }
+          { type: PathElementType.DataModel, typeName: 'Data model', label: 'Test Data Model' }
         ]
       ],
       [
         'te:Test Terminology',
         [
-          { type: PathElementType.Terminology, label: 'Test Terminology' }
+          { type: PathElementType.Terminology, typeName: 'Terminology', label: 'Test Terminology' }
         ]
       ],
       [
         'cs:Test Code Set',
         [
-          { type: PathElementType.CodeSet, label: 'Test Code Set' }
+          { type: PathElementType.CodeSet, typeName: 'Code set', label: 'Test Code Set' }
         ]
       ],
       [
         'dm:Test Data Model|dc:Test Data Class',
         [
-          { type: PathElementType.DataModel, label: 'Test Data Model' },
-          { type: PathElementType.DataClass, label: 'Test Data Class' }
+          { type: PathElementType.DataModel, typeName: 'Data model', label: 'Test Data Model' },
+          { type: PathElementType.DataClass, typeName: 'Data class', label: 'Test Data Class' }
         ]
       ],
       [
         'dm:Test Data Model|dc:Test Data Class|de:Test Data Element',
         [
-          { type: PathElementType.DataModel, label: 'Test Data Model' },
-          { type: PathElementType.DataClass, label: 'Test Data Class' },
-          { type: PathElementType.DataElement, label: 'Test Data Element' }
+          { type: PathElementType.DataModel, typeName: 'Data model', label: 'Test Data Model' },
+          { type: PathElementType.DataClass, typeName: 'Data class', label: 'Test Data Class' },
+          { type: PathElementType.DataElement, typeName: 'Data element', label: 'Test Data Element' }
         ]
       ],
       [
@@ -76,6 +76,7 @@ describe('PathNameService', () => {
         [
           {
             type: PathElementType.DataModel,
+            typeName: 'Data model',
             label: 'Test Data Model',
             property: {
               name: 'description',
@@ -89,6 +90,7 @@ describe('PathNameService', () => {
         [
           {
             type: PathElementType.DataModel,
+            typeName: 'Data model',
             label: 'Test Data Model',
             property: {
               name: 'rule-representation',
@@ -102,10 +104,12 @@ describe('PathNameService', () => {
         [
           {
             type: PathElementType.DataModel,
+            typeName: 'Data model',
             label: 'Test Data Model'
           },
           {
             type: PathElementType.DataClass,
+            typeName: 'Data class',
             label: 'Test Data Class',
             property: {
               name: 'description',

--- a/src/app/shared/path-name/path-name.service.spec.ts
+++ b/src/app/shared/path-name/path-name.service.spec.ts
@@ -140,7 +140,7 @@ describe('PathNameService', () => {
       'when parsing %p then an error is thrown',
       (path: string) => {
         expect(() => {
-          service.parse(path)
+          service.parse(path);
         }).toThrow();
       });
   });

--- a/src/app/shared/path-name/path-name.service.ts
+++ b/src/app/shared/path-name/path-name.service.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
-import { PathElement, PathElementType, PathProperty } from './path-name.model';
+import { PathElement, PathElementType, pathElementTypeNames, PathProperty } from './path-name.model';
 
 @Injectable({
   providedIn: 'root'
@@ -42,6 +42,7 @@ export class PathNameService {
 
       const type = parts[0] as PathElementType;
       const label = parts[1];
+      const typeName = pathElementTypeNames.get(type);
 
       if (parts.length > 2) {
         const qualifiedName = parts.slice(2);
@@ -49,6 +50,7 @@ export class PathNameService {
 
         return {
           type,
+          typeName,
           label,
           property: {
             name,
@@ -59,6 +61,7 @@ export class PathNameService {
 
       return {
         type,
+        typeName,
         label
       };
     });

--- a/src/app/shared/path-name/path-name.service.ts
+++ b/src/app/shared/path-name/path-name.service.ts
@@ -17,14 +17,14 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
-import { PathElement, PathElementType, pathElementTypeNames, PathProperty } from './path-name.model';
+import { PathElement, PathElementType, pathElementTypeNames } from './path-name.model';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PathNameService {
   private readonly elementSeparator = '|';
-  private readonly partSeparator = ':'
+  private readonly partSeparator = ':';
 
   constructor() { }
 

--- a/src/app/shared/path-name/path-name.service.ts
+++ b/src/app/shared/path-name/path-name.service.ts
@@ -1,0 +1,66 @@
+/*
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { PathElement, PathElementType, PathProperty } from './path-name.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PathNameService {
+  private readonly elementSeparator = '|';
+  private readonly partSeparator = ':'
+
+  constructor() { }
+
+  parse(path: string): PathElement[] | null {
+    if (!path || path.length === 0) {
+      return null;
+    }
+
+    const elements = path.split(this.elementSeparator);
+    return elements.map(element => {
+      const parts = element.split(this.partSeparator).filter(p => p && p.length > 0);
+      if (parts.length < 2) {
+        throw new Error(`Path element '${element}' should be in the format 'prefix:label'`);
+      }
+
+      const type = parts[0] as PathElementType;
+      const label = parts[1];
+
+      if (parts.length > 2) {
+        const qualifiedName = parts.slice(2);
+        const name = qualifiedName[qualifiedName.length - 1];
+
+        return {
+          type,
+          label,
+          property: {
+            name,
+            qualifiedName
+          }
+        };
+      }
+
+      return {
+        type,
+        label
+      };
+    });
+  }
+}


### PR DESCRIPTION
Add new `mdm-path-name` component and service to parse fully qualified path names from Mauro into more renderable text format.

![image](https://user-images.githubusercontent.com/3219480/124940724-20378d00-e002-11eb-95bc-eecb79f0e85e.png)

Also added additional tooltips to the merge UI change list to assist with understanding the icons.