### PR TITLE
Feature/gh 160 Include "Add all Terms" option to multi-term selector

### DIFF
--- a/src/app/shared/code-set-terms-table/code-set-terms-table.component.html
+++ b/src/app/shared/code-set-terms-table/code-set-terms-table.component.html
@@ -31,7 +31,7 @@ SPDX-License-Identifier: Apache-2.0
                     <i class="fas fa-plus"></i>
                     Add Term
                 </button>
-                <button mat-button color="warn" (click)="toggleAddTermsSection()" *ngIf="showAddTerm">
+                <button mat-button color="warn" (click)="toggleAddTermsSection()" *ngIf="showAddTerm" matTooltip="Cancel adding terms">
                     <i class="fas fa-times"></i>
                 </button>
             </div>
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
     </div>
 </div>
 <div *ngIf="showAddTerm">
-    <mdm-multiple-terms-selector [onAddButtonClick]="addTerms" [hideAddButton]=false></mdm-multiple-terms-selector>
+    <mdm-multiple-terms-selector (addingTerms)="addTerms($event)" [hideAddButton]="false"></mdm-multiple-terms-selector>
 </div>
 <div class="table-responsive">
     <table mat-table matSort [dataSource]="records" class="mdm--mat-table mat-elevation-z3 table-striped">

--- a/src/app/shared/code-set-terms-table/code-set-terms-table.component.ts
+++ b/src/app/shared/code-set-terms-table/code-set-terms-table.component.ts
@@ -35,7 +35,7 @@ import { ElementTypesService } from '@mdm/services/element-types.service';
 import { SecurityHandlerService } from '@mdm/services/handlers/security-handler.service';
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { GridService } from '@mdm/services/grid.service';
-import { CatalogueItemDomainType, CodeSetDetail, ModelUpdatePayload } from '@maurodatamapper/mdm-resources';
+import { CatalogueItemDomainType, CodeSetDetail, ModelUpdatePayload, Term } from '@maurodatamapper/mdm-resources';
 import { Access } from '@mdm/model/access';
 
 @Component({
@@ -170,7 +170,7 @@ export class CodeSetTermsTableComponent implements OnInit, AfterViewInit {
     return;
   };
 
-  addTerms(terms) {
+  addTerms = (terms: Term[]) => {
     this.codeSet.terms = this.records;
     // current terms
     const currentTerms = this.codeSet.terms.map((term) => {

--- a/src/app/shared/code-set-terms-table/code-set-terms-table.component.ts
+++ b/src/app/shared/code-set-terms-table/code-set-terms-table.component.ts
@@ -170,7 +170,7 @@ export class CodeSetTermsTableComponent implements OnInit, AfterViewInit {
     return;
   };
 
-  addTerms = (terms: Term[]) => {
+  addTerms(terms: Term[]) {
     this.codeSet.terms = this.records;
     // current terms
     const currentTerms = this.codeSet.terms.map((term) => {

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.html
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.html
@@ -17,74 +17,156 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="mb-2">
-    <span class="block">Select a Terminology<sup class="warn">*</sup></span>
-    <mdm-select width="'100%'"
-                [acceptTypedInput]="false"
-                [valueType]="'static'"
-                [staticValues]="selectorSection.terminologies"
-                [idProperty]="'id'"
-                [displayProperty]="'label'"
-                [searchProperty]="'label'"
-                (selectEvent)="onTerminologySelect($event[0])">
-        <ng-template #lineContent let-item>
-            <div>{{item.label}}</div>
-        </ng-template>
-    </mdm-select>
+  <span class="block">Select a Terminology<sup class="warn">*</sup></span>
+  <mdm-select
+    width="'100%'"
+    [acceptTypedInput]="false"
+    [valueType]="'static'"
+    [staticValues]="selectorSection.terminologies"
+    [idProperty]="'id'"
+    [displayProperty]="'label'"
+    [searchProperty]="'label'"
+    (selectEvent)="onTerminologySelect($event[0])"
+  >
+    <ng-template #lineContent let-item>
+      <div>{{ item.label }}</div>
+    </ng-template>
+  </mdm-select>
 </div>
 <div class="mb-2">
-    <strong>Select a Term</strong>
-  <input #searchInputControl id="searchTreeInput" type="text"  class="form-control outlined-input"
-         [(ngModel)]="selectorSection.termSearchText" [disabled]="!selectorSection.selectedTerminology" [ngModelOptions]='{ debounce: 500 }' focus="inputClick()"
-         placeholder="Search for Terms..." >
+  <mat-checkbox
+    [(ngModel)]="addAllTerms"
+    [disabled]="!selectorSection.selectedTerminology"
+    >Add all Terms</mat-checkbox
+  >
+</div>
+<div class="mb-2" *ngIf="!addAllTerms">
+  <strong>Or select one or more Terms to add</strong>
+  <input
+    #searchInputControl
+    id="searchTreeInput"
+    type="text"
+    class="form-control outlined-input"
+    [(ngModel)]="selectorSection.termSearchText"
+    [disabled]="!selectorSection.selectedTerminology"
+    [ngModelOptions]="{ debounce: 500 }"
+    focus="inputClick()"
+    placeholder="Search for Terms..."
+  />
 
-    <div style="margin-top: 5px;">
-       <div style="max-height: 400px; overflow: auto;" (scroll)="onTableScroll($event)">
-          <!-- <div style="height: 400px; "> -->
-            <mat-table #table [dataSource]="dataSource" style="max-height: 100%; overflow: auto;">
-                <ng-container matColumnDef="label">
-                    <mat-header-row *matHeaderCellDef> Term </mat-header-row>
-                    <mat-cell style="max-width: 50%; width: 50%; text-align: left; word-wrap: break-word; padding-right: 5px; padding-left: 5px" mat-cell *matCellDef="let element">
-                        <mat-checkbox name="showSupersededModels" (change)="termToggle(element)" [(ngModel)]="element.checked">
-                            <mdm-element-link [newWindow]= "true" [showHref]="true" [element]="element"></mdm-element-link>
-                        </mat-checkbox>
-                    </mat-cell>
-                </ng-container>
-                <mat-row class="mat-table-row-select"  *matRowDef="let row; columns: displayedColumns;"></mat-row>
-            </mat-table>
-        </div>
-        <div *ngIf="totalItemCount > 0">
-            <span *ngIf="loading">
-                <i class="fas fa-sync-alt fa-spin"></i>
-            </span>
-            <span style="font-size: 11px; font-style: italic;">
-                {{currentRecord}} / {{totalItemCount}}
-            </span>
-        </div>
+  <div style="margin-top: 5px">
+    <div
+      style="max-height: 400px; overflow: auto"
+      (scroll)="onTableScroll($event)"
+    >
+      <!-- <div style="height: 400px; "> -->
+      <mat-table
+        #table
+        [dataSource]="dataSource"
+        style="max-height: 100%; overflow: auto"
+      >
+        <ng-container matColumnDef="label">
+          <mat-header-row *matHeaderCellDef> Term </mat-header-row>
+          <mat-cell
+            style="
+              max-width: 50%;
+              width: 50%;
+              text-align: left;
+              word-wrap: break-word;
+              padding-right: 5px;
+              padding-left: 5px;
+            "
+            mat-cell
+            *matCellDef="let element"
+          >
+            <mat-checkbox
+              name="showSupersededModels"
+              (change)="termToggle(element)"
+              [(ngModel)]="element.checked"
+            >
+              <mdm-element-link
+                [newWindow]="true"
+                [showHref]="true"
+                [element]="element"
+              ></mdm-element-link>
+            </mat-checkbox>
+          </mat-cell>
+        </ng-container>
+        <mat-row
+          class="mat-table-row-select"
+          *matRowDef="let row; columns: displayedColumns"
+        ></mat-row>
+      </mat-table>
     </div>
+    <div *ngIf="totalItemCount > 0">
+      <span *ngIf="loading">
+        <i class="fas fa-sync-alt fa-spin"></i>
+      </span>
+      <span style="font-size: 11px; font-style: italic">
+        {{ currentRecord }} / {{ totalItemCount }}
+      </span>
+    </div>
+  </div>
 </div>
 
-
-<div style="margin-top: 5px;" *ngIf="selectorSection.selectedTermsArray.length > 0">
-    <div class="mb-2" style="position: relative;" *ngIf="selectorSection.selectedTermsArray && selectorSection.selectedTermsArray.length > 0">
-        <span>Summary of Selected Terms</span>
-        <mdm-paged-list [name]="'linkType'" [mcTitle]="'linkType'" [type]="'static'" [items]="selectorSection.selectedTermsArray" [pageSize]="10">
-            <ng-template #pageListTemplate let-item>
-                <div class="pagedElement">
-                    <div>
-                        <i class="fas fa-times warning" style="margin-right: 8px;" (click)="removeTerm(item)"></i>
-                        <mdm-element-link [element]="item"></mdm-element-link>
-                    </div>
-                    <div>
-                        <span style="font-size: 12px; padding-left: 5px;margin-right: 2px; padding-right: 4px;">
-                            <mdm-element-link [element]="item.terminology"></mdm-element-link>
-                        </span>
-                    </div>
-                </div>
-            </ng-template>
-        </mdm-paged-list>
-    </div>
-    <div style="margin-top: 5px; margin-bottom: 12px;" *ngIf="!hideAddButton">
-        <button mat-flat-button color="primary" type="button" [disabled]="selectorSection.selectedTermsCount === 0" (click)="addSelectedTerms(selectorSection.selectedTermsArray)">Add <span *ngIf="selectorSection.selectedTermsCount > 0">({{selectorSection.selectedTermsCount}})</span></button>
-    </div>
+<div
+  style="margin-top: 5px"
+  *ngIf="addAllTerms || selectorSection.selectedTermsArray.length > 0"
+>
+  <div
+    class="mb-2"
+    style="position: relative"
+    *ngIf="
+      selectorSection.selectedTermsArray &&
+      selectorSection.selectedTermsArray.length > 0
+    "
+  >
+    <span>Summary of Selected Terms</span>
+    <mdm-paged-list
+      [name]="'linkType'"
+      [mcTitle]="'linkType'"
+      [type]="'static'"
+      [items]="selectorSection.selectedTermsArray"
+      [pageSize]="10"
+    >
+      <ng-template #pageListTemplate let-item>
+        <div class="pagedElement">
+          <div>
+            <i
+              class="fas fa-times warning"
+              style="margin-right: 8px"
+              (click)="removeTerm(item)"
+            ></i>
+            <mdm-element-link [element]="item"></mdm-element-link>
+          </div>
+          <div>
+            <span
+              style="
+                font-size: 12px;
+                padding-left: 5px;
+                margin-right: 2px;
+                padding-right: 4px;
+              "
+            >
+              <mdm-element-link [element]="item.terminology"></mdm-element-link>
+            </span>
+          </div>
+        </div>
+      </ng-template>
+    </mdm-paged-list>
+  </div>
+  <div style="margin-top: 5px; margin-bottom: 12px" *ngIf="!hideAddButton">
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      [disabled]="!selectorSection.selectedTerminology || (!addAllTerms && selectorSection.selectedTermsCount === 0)"
+      (click)="addSelectedTerms()"
+    >
+      Add
+      <span *ngIf="selectorSection.selectedTermsCount > 0"
+        >({{ selectorSection.selectedTermsCount }})</span
+      >
+    </button>
+  </div>
 </div>
-

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.html
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.html
@@ -16,157 +16,141 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="mb-2">
-  <span class="block">Select a Terminology<sup class="warn">*</sup></span>
-  <mdm-select
-    width="'100%'"
-    [acceptTypedInput]="false"
-    [valueType]="'static'"
-    [staticValues]="selectorSection.terminologies"
-    [idProperty]="'id'"
-    [displayProperty]="'label'"
-    [searchProperty]="'label'"
-    (selectEvent)="onTerminologySelect($event[0])"
-  >
-    <ng-template #lineContent let-item>
-      <div>{{ item.label }}</div>
-    </ng-template>
-  </mdm-select>
-</div>
-<div class="mb-2">
-  <mat-checkbox
-    [(ngModel)]="addAllTerms"
-    [disabled]="!selectorSection.selectedTerminology"
-    >Add all Terms</mat-checkbox
-  >
-</div>
-<div class="mb-2" *ngIf="!addAllTerms">
-  <strong>Or select one or more Terms to add</strong>
-  <input
-    #searchInputControl
-    id="searchTreeInput"
-    type="text"
-    class="form-control outlined-input"
-    [(ngModel)]="selectorSection.termSearchText"
-    [disabled]="!selectorSection.selectedTerminology"
-    [ngModelOptions]="{ debounce: 500 }"
-    focus="inputClick()"
-    placeholder="Search for Terms..."
-  />
-
-  <div style="margin-top: 5px">
-    <div
-      style="max-height: 400px; overflow: auto"
-      (scroll)="onTableScroll($event)"
+<div class="mdm-multiple-terms-selector">
+  <div class="mb-2">
+    <span class="block">Select a Terminology<sup class="warn">*</sup></span>
+    <mdm-select
+      width="'100%'"
+      [acceptTypedInput]="false"
+      [valueType]="'static'"
+      [staticValues]="selectorSection.terminologies"
+      [idProperty]="'id'"
+      [displayProperty]="'label'"
+      [searchProperty]="'label'"
+      (selectEvent)="onTerminologySelect($event[0])"
     >
-      <!-- <div style="height: 400px; "> -->
-      <mat-table
-        #table
-        [dataSource]="dataSource"
-        style="max-height: 100%; overflow: auto"
-      >
-        <ng-container matColumnDef="label">
-          <mat-header-row *matHeaderCellDef> Term </mat-header-row>
-          <mat-cell
-            style="
-              max-width: 50%;
-              width: 50%;
-              text-align: left;
-              word-wrap: break-word;
-              padding-right: 5px;
-              padding-left: 5px;
-            "
-            mat-cell
-            *matCellDef="let element"
-          >
-            <mat-checkbox
-              name="showSupersededModels"
-              (change)="termToggle(element)"
-              [(ngModel)]="element.checked"
-            >
-              <mdm-element-link
-                [newWindow]="true"
-                [showHref]="true"
-                [element]="element"
-              ></mdm-element-link>
-            </mat-checkbox>
-          </mat-cell>
-        </ng-container>
-        <mat-row
-          class="mat-table-row-select"
-          *matRowDef="let row; columns: displayedColumns"
-        ></mat-row>
-      </mat-table>
-    </div>
-    <div *ngIf="totalItemCount > 0">
-      <span *ngIf="loading">
-        <i class="fas fa-sync-alt fa-spin"></i>
-      </span>
-      <span style="font-size: 11px; font-style: italic">
-        {{ currentRecord }} / {{ totalItemCount }}
-      </span>
-    </div>
-  </div>
-</div>
-
-<div
-  style="margin-top: 5px"
-  *ngIf="addAllTerms || selectorSection.selectedTermsArray.length > 0"
->
-  <div
-    class="mb-2"
-    style="position: relative"
-    *ngIf="
-      selectorSection.selectedTermsArray &&
-      selectorSection.selectedTermsArray.length > 0
-    "
-  >
-    <span>Summary of Selected Terms</span>
-    <mdm-paged-list
-      [name]="'linkType'"
-      [mcTitle]="'linkType'"
-      [type]="'static'"
-      [items]="selectorSection.selectedTermsArray"
-      [pageSize]="10"
-    >
-      <ng-template #pageListTemplate let-item>
-        <div class="pagedElement">
-          <div>
-            <i
-              class="fas fa-times warning"
-              style="margin-right: 8px"
-              (click)="removeTerm(item)"
-            ></i>
-            <mdm-element-link [element]="item"></mdm-element-link>
-          </div>
-          <div>
-            <span
-              style="
-                font-size: 12px;
-                padding-left: 5px;
-                margin-right: 2px;
-                padding-right: 4px;
-              "
-            >
-              <mdm-element-link [element]="item.terminology"></mdm-element-link>
-            </span>
-          </div>
-        </div>
+      <ng-template #lineContent let-item>
+        <div>{{ item.label }}</div>
       </ng-template>
-    </mdm-paged-list>
+    </mdm-select>
   </div>
-  <div style="margin-top: 5px; margin-bottom: 12px" *ngIf="!hideAddButton">
-    <button
-      mat-flat-button
-      color="primary"
-      type="button"
-      [disabled]="!selectorSection.selectedTerminology || (!addAllTerms && selectorSection.selectedTermsCount === 0)"
-      (click)="addSelectedTerms()"
+  <div class="mb-2">
+    <mat-checkbox
+      [(ngModel)]="addAllTerms"
+      [disabled]="!selectorSection.selectedTerminology"
+      >Add all Terms</mat-checkbox
     >
-      Add
-      <span *ngIf="selectorSection.selectedTermsCount > 0"
-        >({{ selectorSection.selectedTermsCount }})</span
+  </div>
+  <div class="mb-2" *ngIf="!addAllTerms">
+    <strong>Or select one or more Terms to add</strong>
+    <input
+      #searchInputControl
+      id="searchTreeInput"
+      type="text"
+      class="form-control outlined-input"
+      [(ngModel)]="selectorSection.termSearchText"
+      [disabled]="!selectorSection.selectedTerminology"
+      [ngModelOptions]="{ debounce: 500 }"
+      focus="inputClick()"
+      placeholder="Search for Terms..."
+    />
+
+    <div class="mt-2">
+      <div
+        class="mdm-multiple-terms-selector__list"
+        (scroll)="onTableScroll($event)"
       >
-    </button>
+        <mat-table #table [dataSource]="dataSource">
+          <ng-container matColumnDef="label">
+            <mat-header-row *matHeaderCellDef> Term </mat-header-row>
+            <mat-cell mat-cell *matCellDef="let element">
+              <mat-checkbox
+                name="showSupersededModels"
+                (change)="termToggle(element)"
+                [(ngModel)]="element.checked"
+              >
+                <mdm-element-link
+                  [newWindow]="true"
+                  [showHref]="true"
+                  [element]="element"
+                ></mdm-element-link>
+              </mat-checkbox>
+            </mat-cell>
+          </ng-container>
+          <mat-row
+            class="mat-table-row-select"
+            *matRowDef="let row; columns: displayedColumns"
+          ></mat-row>
+        </mat-table>
+      </div>
+      <div *ngIf="totalItemCount > 0">
+        <span *ngIf="loading">
+          <i class="fas fa-sync-alt fa-spin"></i>
+        </span>
+        <span class="mdm-multiple-terms-selector__list-footer">
+          {{ currentRecord }} / {{ totalItemCount }}
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div
+    class="mt-2"
+    *ngIf="addAllTerms || selectorSection.selectedTermsArray.length > 0"
+  >
+    <div
+      class="mb-2"
+      style="position: relative"
+      *ngIf="
+        !addAllTerms &&
+        selectorSection.selectedTermsArray &&
+        selectorSection.selectedTermsArray.length > 0
+      "
+    >
+      <span>Summary of Selected Terms</span>
+      <mdm-paged-list
+        [name]="'linkType'"
+        [mcTitle]="'linkType'"
+        [type]="'static'"
+        [items]="selectorSection.selectedTermsArray"
+        [pageSize]="10"
+      >
+        <ng-template #pageListTemplate let-item>
+          <div class="pagedElement">
+            <div>
+              <i
+                class="fas fa-times warning mr-2"
+                (click)="removeTerm(item)"
+              ></i>
+              <mdm-element-link [element]="item"></mdm-element-link>
+            </div>
+            <div>
+              <span class="mdm-multiple-terms-selector__selection">
+                <mdm-element-link
+                  [element]="item.terminology"
+                ></mdm-element-link>
+              </span>
+            </div>
+          </div>
+        </ng-template>
+      </mdm-paged-list>
+    </div>
+    <div class="mt-2 mb-4" *ngIf="!hideAddButton">
+      <button
+        mat-flat-button
+        color="primary"
+        type="button"
+        [disabled]="
+          !selectorSection.selectedTerminology ||
+          (!addAllTerms && selectorSection.selectedTermsCount === 0)
+        "
+        (click)="addSelectedTerms()"
+      >
+        Add
+        <span *ngIf="!addAllTerms && selectorSection.selectedTermsCount > 0"
+          >({{ selectorSection.selectedTermsCount }})</span
+        >
+      </button>
+    </div>
   </div>
 </div>

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.scss
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.scss
@@ -16,3 +16,35 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+.mdm-multiple-terms-selector {
+  &__list {
+    max-height: 400px;
+    overflow: auto;
+
+    mat-table {
+      max-height: 100%;
+      overflow: auto;
+
+      mat-cell {
+        max-width: 50%;
+        width: 50%;
+        text-align: left;
+        word-wrap: break-word;
+        padding-right: 5px;
+        padding-left: 5px;
+      }
+    }
+  }
+
+  &__list-footer {
+    font-size: 11px;
+    font-style: italic;
+  }
+
+  &__selection {
+    font-size: 12px;
+    padding-left: 5px;
+    margin-right: 2px;
+    padding-right: 4px;
+  }
+}

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
@@ -109,17 +109,17 @@ export class MultipleTermsSelectorComponent {
     private contextSearchHandler: ContentSearchHandlerService,
     private cd: ChangeDetectorRef,
     private gridService: GridService,
-    private messageHandler: MessageHandlerService
-  ) {
+    private messageHandler: MessageHandlerService) {
     this.loadTerminologies();
   }
 
-  loadTerminologies = () => {
+  loadTerminologies() {
     this.resources.terminology.list().subscribe((data: TerminologyIndexResponse) => {
       this.selectorSection.terminologies = data.body.items;
     });
-  };
-  onTerminologySelect = (terminology: Terminology) => {
+  }
+
+  onTerminologySelect(terminology: Terminology) {
     this.dataSource = new MatTableDataSource<any>(null);
     this.selectorSection.selectedTerminology = terminology;
     if (terminology != null) {
@@ -128,13 +128,13 @@ export class MultipleTermsSelectorComponent {
       this.totalItemCount = 0;
       this.currentRecord = 0;
     }
-  };
+  }
 
-  runTermSearch = () => {
+  runTermSearch() {
     this.fetch(40, 0);
-  };
+  }
 
-  loadAllTerms = (terminology, pageSize, offset) => {
+  loadAllTerms(terminology, pageSize, offset) {
     this.selectorSection.searchResultOffset = offset;
     this.loading = true;
     const options = this.gridService.constructOptions(pageSize, offset);
@@ -164,8 +164,9 @@ export class MultipleTermsSelectorComponent {
         this.loading = false;
       }
     });
-  };
-  fetch = (pageSize, offset) => {
+  }
+
+  fetch(pageSize, offset) {
     if (this.selectorSection.termSearchText.length === 0 && this.selectorSection.selectedTerminology) {
       // load all elements if possible(just all DataTypes for DataModel and all DataElements for a DataClass)
       return this.loadAllTerms(this.selectorSection.selectedTerminology, pageSize, offset);
@@ -242,7 +243,8 @@ export class MultipleTermsSelectorComponent {
       }
     }
   }
-  calculateDisplayedSoFar = result => {
+
+  calculateDisplayedSoFar(result) {
     this.selectorSection.searchResultTotal = result.body.count;
     if (result.body.count >= this.selectorSection.searchResultPageSize) {
       const total =
@@ -256,8 +258,9 @@ export class MultipleTermsSelectorComponent {
     } else {
       this.selectorSection.searchResultDisplayedSoFar = result.body.count;
     }
-  };
-  termToggle = $item => {
+  }
+
+  termToggle($item) {
     if ($item.checked) {
       this.selectorSection.selectedTerms[$item.id] = $item;
       this.selectorSection.selectedTermsArray.push($item);
@@ -283,9 +286,9 @@ export class MultipleTermsSelectorComponent {
     }
 
     this.selectedTermsChange.emit(this.selectorSection.selectedTermsArray);
+  }
 
-  };
-  removeTerm = ($item) => {
+  removeTerm($item) {
     let i = this.selectorSection.selectedTermsArray.length - 1;
     while (i >= 0) {
       if (this.selectorSection.selectedTermsArray[i].id === $item.id) {
@@ -311,7 +314,7 @@ export class MultipleTermsSelectorComponent {
     if (this.selectedTermsChange) {
       this.selectedTermsChange.emit(this.selectorSection.selectedTermsArray);
     }
-  };
+  }
 
   addSelectedTerms() {
     if (!this.addAllTerms) {
@@ -332,5 +335,5 @@ export class MultipleTermsSelectorComponent {
       .subscribe((response: TermIndexResponse) => {
         this.addingTerms.emit(response.body.items);
       });
-  };
+  }
 }

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
@@ -41,10 +41,13 @@ import { MessageHandlerService } from '@mdm/services';
 })
 export class MultipleTermsSelectorComponent {
   @Input() hideAddButton = true;
+
   @Output() selectedTermsChange = new EventEmitter<any[]>();
   @Output() addingTerms = new EventEmitter<Term[]>();
+
   @ViewChild('searchInputTerms', { static: true })
-  dataSource = new MatTableDataSource();
+  dataSource = new MatTableDataSource<Term>();
+
   pageSize = 40;
   displayedColumns: string[] = ['label'];
   selectorSection = {
@@ -120,7 +123,7 @@ export class MultipleTermsSelectorComponent {
   }
 
   onTerminologySelect(terminology: Terminology) {
-    this.dataSource = new MatTableDataSource<any>(null);
+    this.dataSource = new MatTableDataSource<Term>(null);
     this.selectorSection.selectedTerminology = terminology;
     if (terminology != null) {
       this.fetch(40, 0);
@@ -134,13 +137,13 @@ export class MultipleTermsSelectorComponent {
     this.fetch(40, 0);
   }
 
-  loadAllTerms(terminology, pageSize, offset) {
+  loadAllTerms(terminology: Terminology, pageSize: number, offset: number) {
     this.selectorSection.searchResultOffset = offset;
     this.loading = true;
     const options = this.gridService.constructOptions(pageSize, offset);
     this.selectorSection.loading = true;
 
-    this.resources.terms.list(terminology.id, options).subscribe(result => {
+    this.resources.terms.list(terminology.id, options).subscribe((result: TermIndexResponse) => {
       // make check=true if element is already selected
       result.body.items.forEach(item => {
         item.terminology = terminology;
@@ -166,7 +169,7 @@ export class MultipleTermsSelectorComponent {
     });
   }
 
-  fetch(pageSize, offset) {
+  fetch(pageSize: number, offset: number) {
     if (this.selectorSection.termSearchText.length === 0 && this.selectorSection.selectedTerminology) {
       // load all elements if possible(just all DataTypes for DataModel and all DataElements for a DataClass)
       return this.loadAllTerms(this.selectorSection.selectedTerminology, pageSize, offset);

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
@@ -64,7 +64,7 @@ export class MultipleTermsSelectorComponent {
     loading: false
   };
   loading = false;
-  addAllTerms = true;
+  addAllTerms = false;
 
   searchInputTerms: ElementRef;
   currentRecord: number;

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
@@ -42,7 +42,7 @@ import { MessageHandlerService } from '@mdm/services';
 export class MultipleTermsSelectorComponent {
   @Input() hideAddButton = true;
   @Output() selectedTermsChange = new EventEmitter<any[]>();
-  @Input() onAddButtonClick: any;
+  @Output() addingTerms = new EventEmitter<Term[]>();
   @ViewChild('searchInputTerms', { static: true })
   dataSource = new MatTableDataSource();
   pageSize = 40;
@@ -314,12 +314,8 @@ export class MultipleTermsSelectorComponent {
   };
 
   addSelectedTerms() {
-    if (!this.onAddButtonClick) {
-      return;
-    }
-
     if (!this.addAllTerms) {
-      this.onAddButtonClick(this.selectorSection.selectedTermsArray);
+      this.addingTerms.emit(this.selectorSection.selectedTermsArray);
       return;
     }
 
@@ -334,7 +330,7 @@ export class MultipleTermsSelectorComponent {
         })
       )
       .subscribe((response: TermIndexResponse) => {
-        this.onAddButtonClick(response.body.items);
+        this.addingTerms.emit(response.body.items);
       });
   };
 }


### PR DESCRIPTION
Resolves #160 

Update `mdm-multiple-terms-selector` component to include an "Add all Terms" option:

![image](https://user-images.githubusercontent.com/3219480/125071608-6bf53f80-e0b1-11eb-9629-59aed01858ec.png)

If ticked, then every term in the selected terminology will be added to the parent code set. Untick to revert back to the manual search/filter selection list to pick terms.