### PR TITLE
Feature/gh 250 Feedback changes to new merge conflict editor

### DIFF
--- a/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.html
+++ b/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.html
@@ -84,28 +84,18 @@ SPDX-License-Identifier: Apache-2.0
       No
     </button>
   </div>
-  <div *ngIf="state === 'confirmResolve'" class="modal-footer pxy-2">
+  <div *ngIf="state === 'conflictsPending'" class="modal-footer pxy-2">
     <p>
-      Conflicts were still found in the content. Are you sure you want to
-      resolve and commit these changes?
+      There are still {{conflictCount}} conflict(s). You cannot resolve until all conflicts are removed.
     </p>
     <button
       mat-button
       color="primary"
       class="mr-1"
       type="button"
-      (click)="resolveConflict()"
-    >
-      Yes
-    </button>
-    <button
-      mat-button
-      color="warn"
-      class="mr-1"
-      type="button"
       (click)="abort()"
     >
-      No
+      OK
     </button>
   </div>
 </div>

--- a/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.ts
+++ b/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.ts
@@ -36,7 +36,7 @@ export class ConflictEditorModalComponent implements OnInit {
 
   state: 'working' | 'confirmCancel' | 'conflictsPending' = 'working';
   valueType: MergeItemValueType = 'string';
-  conflictCount: number = 0;
+  conflictCount = 0;
 
   constructor(
     private dialogRef: MatDialogRef<ConflictEditorModalComponent, ConflictEditorModalResult>,

--- a/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.ts
+++ b/src/app/merge-diff/conflict-editor/conflict-editor-modal/conflict-editor-modal.component.ts
@@ -34,8 +34,9 @@ export class ConflictEditorModalComponent implements OnInit {
   @ViewChild(StringConflictEditorComponent) stringEditor: StringConflictEditorComponent;
   @ViewChild(NumberConflictEditorComponent) numberEditor: NumberConflictEditorComponent;
 
-  state: 'working' | 'confirmCancel' | 'confirmResolve' = 'working';
+  state: 'working' | 'confirmCancel' | 'conflictsPending' = 'working';
   valueType: MergeItemValueType = 'string';
+  conflictCount: number = 0;
 
   constructor(
     private dialogRef: MatDialogRef<ConflictEditorModalComponent, ConflictEditorModalResult>,
@@ -68,12 +69,13 @@ export class ConflictEditorModalComponent implements OnInit {
       return;
     }
 
-    if (this.valueType === 'string' && this.stringEditor.getCurrentConflictCount() === 0) {
+    this.conflictCount = this.stringEditor.getCurrentConflictCount();
+    if (this.conflictCount === 0) {
       this.resolveConflict();
       return;
     }
 
-    this.state = 'confirmResolve';
+    this.state = 'conflictsPending';
   }
 
   resolveConflict() {

--- a/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.html
+++ b/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.html
@@ -24,6 +24,14 @@ SPDX-License-Identifier: Apache-2.0
         <i class="fas fa-file-export" matTooltip="Source Branch"></i>
         <strong>{{ source.branchName }}</strong>
       </small>
+      <button
+        mat-stroked-button
+        color="primary"
+        matTooltip="Take all changes from 'Source'"
+        (click)="copyAllToResolved('source')"
+      >
+        <i class="fas fa-angle-double-right"></i>
+      </button>
     </h5>
     <div
       #sourceView
@@ -38,6 +46,14 @@ SPDX-License-Identifier: Apache-2.0
         <i class="fas fa-file-import" matTooltip="Target Branch"></i>
         <strong>{{ target.branchName }}</strong>
       </small>
+      <button
+        mat-stroked-button
+        color="primary"
+        matTooltip="Take all changes from 'Target'"
+        (click)="copyAllToResolved('target')"
+      >
+        <i class="fas fa-angle-double-left"></i>
+      </button>
     </h5>
     <div
       #targetView

--- a/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.scss
+++ b/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.scss
@@ -60,4 +60,10 @@ $conflictColor: #ffe6e6;
       cursor: pointer;
     }
   }
+
+  h5 {
+    small {
+      margin-right: 16px;
+    }
+  }
 }

--- a/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.ts
+++ b/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.ts
@@ -74,8 +74,11 @@ export class StringConflictEditorComponent implements OnInit, AfterViewInit {
     this.setDiffViewEventListeners(this.targetView);
   }
 
-  resolveDiffConflict(event: Event) {
-    const target = event.currentTarget as HTMLElement;
+  onResolveDiffConflict(event: Event) {
+    this.resolveDiffConflict(event.currentTarget as HTMLElement);
+  }
+
+  resolveDiffConflict(target: HTMLElement) {
     const id = JSON.parse(target.dataset.diffId) as number;
     const value = decodeURI(target.dataset.diffValue);
 
@@ -115,6 +118,14 @@ export class StringConflictEditorComponent implements OnInit, AfterViewInit {
     return resolvedDocument.body.innerHTML;
   }
 
+  copyAllToResolved(branch: 'source' | 'target') {
+    const view = branch === 'source' ? this.sourceView : this.targetView;
+
+    view.nativeElement
+      .querySelectorAll('ins')
+      .forEach(elem => this.resolveDiffConflict(elem));
+  }
+
 
   private initialiseResolvedDiffHtml(
     text1: string,
@@ -129,13 +140,8 @@ export class StringConflictEditorComponent implements OnInit, AfterViewInit {
   private setDiffViewEventListeners(view: ElementRef) {
     view.nativeElement
       .querySelectorAll('ins')
-      .forEach(elem => elem.addEventListener('click', this.resolveDiffConflict.bind(this)));
+      .forEach(elem => elem.addEventListener('click', this.onResolveDiffConflict.bind(this)));
   }
-
-
-
-
-
 
   private checkInsertedTextForResolve(item: DiffTrackedItem) {
     const previousIndex = item.index - 1;

--- a/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.ts
+++ b/src/app/merge-diff/conflict-editor/string-conflict-editor/string-conflict-editor.component.ts
@@ -101,7 +101,9 @@ export class StringConflictEditorComponent implements OnInit, AfterViewInit {
       .parseFromString(this.resolvedText, 'text/html');
 
     const conflicts = resolvedDocument.body.querySelectorAll('span.diff-marker.conflict');
-    return conflicts.length;
+    return Array.from(conflicts)
+      .filter(elem => elem.innerHTML === conflictText)
+      .length;
   }
 
   getFinalResolvedContent() {

--- a/src/app/merge-diff/merge-diff-container/merge-diff-container.component.ts
+++ b/src/app/merge-diff/merge-diff-container/merge-diff-container.component.ts
@@ -266,6 +266,7 @@ export class MergeDiffContainerComponent implements OnInit {
           this.selectedItem = null;
           this.committingList.forEach((item) => {
             item.branchSelected = null;
+            item.branchNameSelected = null;
             this.changesList.push(item);
           });
           this.committingList = new Array<MergeDiffItemModel>();


### PR DESCRIPTION
Resolves #250 

1. Removes user warning if conflicts are still found in resolved text. Must now remove every conflict before accepting.
2. Add "Take all" buttons to source/target views to for copying every change into resolved for fixing conflicts.
3. Fixed bug in cancelling all commits where branch name was still present.