### PR TITLE
Fixes for Model Data Types creation and display

### DIFF
--- a/src/app/services/element-types.service.ts
+++ b/src/app/services/element-types.service.ts
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
 import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
+import { domain } from 'process';
 import { StateHandlerService } from './handlers/state-handler.service';
 
 @Injectable({ providedIn: 'root' })
@@ -427,6 +428,12 @@ export class ElementTypesService {
         domainType: element.domainType,
         mode
       });
+  }
+
+  isModelDataType(domainType: CatalogueItemDomainType) {
+    return domainType === CatalogueItemDomainType.CodeSetType
+      || domainType === CatalogueItemDomainType.TerminologyType
+      || domainType === CatalogueItemDomainType.ReferenceDataModelType;
   }
 }
 

--- a/src/app/services/element-types.service.ts
+++ b/src/app/services/element-types.service.ts
@@ -18,7 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
 import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
-import { domain } from 'process';
 import { StateHandlerService } from './handlers/state-handler.service';
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/shared/element-data-type/element-data-type.component.html
+++ b/src/app/shared/element-data-type/element-data-type.component.html
@@ -87,4 +87,14 @@ SPDX-License-Identifier: Apache-2.0
       <mdm-element-link [element]="elementDataType.terminology" [newWindow]="newWindow"></mdm-element-link>
     </span>
   </span>
+  <span *ngIf="elementDataType.domainType == 'ModelDataType'">
+    <div>
+      <a href="{{link}}">{{elementDataType.label}}</a><span class="dataTypeLabel dataTypeEnumeration">({{elementDataType.modelResourceDomainType}})</span>
+    </div>
+    <div *ngIf="modelResource">
+      <span style="font-size: 13px;">[<span style="font-style: italic">ref:&nbsp;</span>
+        <mdm-element-link [element]="modelResource" [newWindow]="newWindow"></mdm-element-link>]
+      </span>
+    </div>
+  </span>
 </div>

--- a/src/app/utility/new-data-type-inline/new-data-type-inline.component.html
+++ b/src/app/utility/new-data-type-inline/new-data-type-inline.component.html
@@ -100,7 +100,7 @@ SPDX-License-Identifier: Apache-2.0
                         [idProperty]="'id'"
                         [displayProperty]="'label'"
                         [searchProperty]="'label'"
-                        (selectEvent)="onTerminologySelect($event[0])">
+                        (selectEvent)="modelDataTypeSelected($event[0])">
 							<ng-template #lineContent let-item>
 								<div>{{item.label}}</div>
 							</ng-template>
@@ -117,7 +117,7 @@ SPDX-License-Identifier: Apache-2.0
                         [idProperty]="'id'"
                         [displayProperty]="'label'"
                         [searchProperty]="'label'"
-                        (selectEvent)="onTerminologySelect($event[0])">
+                        (selectEvent)="modelDataTypeSelected($event[0])">
 							<ng-template #lineContent let-item>
 								<div>{{item.label}}</div>
 							</ng-template>
@@ -134,7 +134,7 @@ SPDX-License-Identifier: Apache-2.0
                         [idProperty]="'id'"
                         [displayProperty]="'label'"
                         [searchProperty]="'label'"
-                        (selectEvent)="onTerminologySelect($event[0])">
+                        (selectEvent)="modelDataTypeSelected($event[0])">
 							<ng-template #lineContent let-item>
 								<div>{{item.label}}</div>
 							</ng-template>

--- a/src/app/utility/new-data-type-inline/new-data-type-inline.component.ts
+++ b/src/app/utility/new-data-type-inline/new-data-type-inline.component.ts
@@ -21,7 +21,7 @@ import { MdmResourcesService } from '@mdm/modules/resources';
 import { ElementTypesService } from '@mdm/services/element-types.service';
 import { NgForm } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { CodeSet, CodeSetIndexResponse, ReferenceDataModel, ReferenceDataModelIndexResponse, Terminology, TerminologyIndexResponse } from '@maurodatamapper/mdm-resources';
+import { CatalogueItemDomainType, CodeSet, CodeSetIndexResponse, ReferenceDataModel, ReferenceDataModelIndexResponse, Terminology, TerminologyIndexResponse } from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-data-type-inline',
@@ -114,15 +114,15 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit {
       isValid = true;
     }
     // Check if for TerminologyType, the terminology is selected
-    if (this.model.domainType === 'TerminologyType' && (!this.model.referencedTerminology || this.model.referencedTerminology.id === '')) {
+    if (this.model.domainType === 'TerminologyType' && (!this.model.referencedModel || this.model.referencedModel.id === '')) {
       isValid = false;
     }
 
-    if (this.model.domainType === 'CodeSetType' && (!this.model.referencedTerminology || this.model.referencedTerminology.id === '')) {
+    if (this.model.domainType === 'CodeSetType' && (!this.model.referencedModel || this.model.referencedModel.id === '')) {
       isValid = false;
     }
 
-    if (this.model.domainType === 'ReferenceDataModelType' && (!this.model.referencedTerminology || this.model.referencedTerminology.id === '')) {
+    if (this.model.domainType === 'ReferenceDataModelType' && (!this.model.referencedModel || this.model.referencedModel.id === '')) {
       isValid = false;
     }
     this.isValid = isValid;
@@ -150,9 +150,15 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit {
     });
   }
 
-  onTerminologySelect(terminology: any) {
-    this.model.referencedTerminology = terminology;
-    this.model.terminology = terminology;
+  // onTerminologySelect(terminology: any) {
+  //   this.model.referencedTerminology = terminology;
+  //   this.model.terminology = terminology;
+  //   this.validate();
+  //   this.sendValidationStatus();
+  // }
+
+  modelDataTypeSelected(value: any) {
+    this.model.referencedModel = value;
     this.validate();
     this.sendValidationStatus();
   }

--- a/src/app/utility/new-data-type-inline/new-data-type-inline.component.ts
+++ b/src/app/utility/new-data-type-inline/new-data-type-inline.component.ts
@@ -21,7 +21,7 @@ import { MdmResourcesService } from '@mdm/modules/resources';
 import { ElementTypesService } from '@mdm/services/element-types.service';
 import { NgForm } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { CatalogueItemDomainType, CodeSet, CodeSetIndexResponse, ReferenceDataModel, ReferenceDataModelIndexResponse, Terminology, TerminologyIndexResponse } from '@maurodatamapper/mdm-resources';
+import { CodeSet, CodeSetIndexResponse, ReferenceDataModel, ReferenceDataModelIndexResponse, Terminology, TerminologyIndexResponse } from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-data-type-inline',

--- a/src/app/wizards/dataElement/data-element-main/data-element-main.component.ts
+++ b/src/app/wizards/dataElement/data-element-main/data-element-main.component.ts
@@ -75,7 +75,6 @@ export class DataElementMainComponent implements OnInit {
       classifiers: [],
       organisation: '',
       referencedDataType: { id: '' },
-      //referencedTerminology: { id: '' },
       referencedDataClass: { id: '' },
       referencedModel: { id: '', domainType: '' }
     },

--- a/src/app/wizards/dataType/data-type-step2/data-type-step2.component.ts
+++ b/src/app/wizards/dataType/data-type-step2/data-type-step2.component.ts
@@ -85,7 +85,6 @@ export class DataTypeStep2Component implements OnInit, AfterViewInit, OnDestroy 
   pageSizeOptions = [5, 10, 20, 50];
 
   constructor(
-    private validator: ValidatorService,
     private resourceService: MdmResourcesService,
     private messageHandler: MessageHandlerService,
     private changeRef: ChangeDetectorRef,

--- a/src/app/wizards/dataType/data-type-step2/data-type-step2.component.ts
+++ b/src/app/wizards/dataType/data-type-step2/data-type-step2.component.ts
@@ -30,7 +30,6 @@ import {
 } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { Subscription, merge } from 'rxjs';
-import { ValidatorService } from '@mdm/services/validator.service';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { MessageHandlerService } from '@mdm/services/utility/message-handler.service';
 import { catchError, map, startWith, switchMap } from 'rxjs/operators';


### PR DESCRIPTION
Fixes #241
Fixes #157 

* Fixed issue when creating a new data type at the same time as a data element. If choosing a `ModelDataType`, the incorrect payload was sent to the `POST` endpoint.
* Updated the `mdm-element-data-type` component to correctly display `ModelDataType` details and their linked models as links

![image](https://user-images.githubusercontent.com/3219480/127346846-8d44b043-a577-4342-93c8-4a85dccc5cf6.png)
