### PR TITLE
#281 Add static landing page/route for OpenID Connect redirect

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,7 +28,12 @@
             "aot": true,
             "assets": [
               "src/assets/favicon.ico",
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "open-id-connect-redirect.html",
+                "input": "src/static-pages",
+                "output": "/redirects"
+              }
             ],
             "styles": [
               "src/styles.scss",

--- a/src/app/services/handlers/security-handler.service.ts
+++ b/src/app/services/handlers/security-handler.service.ts
@@ -344,7 +344,17 @@ export class SecurityHandlerService {
   }
 
   public getOpenIdAuthorizeUrl() {
-    const authorizationUrl = this.stateHandler.getURL('appContainer.mainApp.openIdConnectAuthorizing');
+    // Redirect authorization URL refers to a static page route found in `/src/static-pages`. See the `assets`
+    // configuration in `angular.json`.
+    //
+    // The reason why a static page is used instead of a component route is to avoid the hash location strategy that all
+    // component routes use. An Angular component route would include a `#`, which represents a fragment in an absolute URI.
+    // URI fragments are not allowed according to [RFC3986] Section 4.3. This was discovered when adding Microsoft
+    // Azure Active Directory as an OpenID Connect endpoint.
+    //
+    // The static page is therefore a landing point so that it can immediately redirect to the correct authentication component
+    // route and do the real work.
+    const authorizationUrl = '/redirects/open-id-connect-redirect.html';
     const baseUrl = `${window.location.protocol}//${window.location.host}`;
     return new URL(authorizationUrl, baseUrl);
   }

--- a/src/static-pages/open-id-connect-redirect.html
+++ b/src/static-pages/open-id-connect-redirect.html
@@ -1,0 +1,44 @@
+<!--
+Copyright 2020-2021 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta contentType="text/html; charset=UTF-8" />
+        <meta charset="utf-8" />
+        <title>Mauro Data Mapper</title>
+        <!-- Chrome, Firefox OS and Opera -->
+        <meta name="theme-color" content="#002147">
+        <!-- Windows Phone -->
+        <meta name="msapplication-navbutton-color" content="#002147">
+        <!-- iOS Safari -->
+        <meta name="apple-mobile-web-app-status-bar-style" content="#002147">
+        <meta name="description" content="Use the Mauro Data Mapper platform to create shared documentation for your data, and to collaborate on the definition of new data models.  Developed by the University of Oxford in collaboration with NIHR and NHS Digital.">
+        <meta name="viewport" content="width=device-width">
+        <link rel="shortcut icon" type="image/png" href="assets/favicon.png" />
+    </head>
+    <body>
+        <p>Redirecting back to Mauro Data Mapper...</p>
+        <script lang="javascript">
+          const baseUrl = `${window.location.protocol}//${window.location.host}`;
+          const currentUrl = `#/open-id-connect/authorize${window.location.search}`;
+          const redirectUrl = new URL(currentUrl, baseUrl);
+          window.open(redirectUrl.toString(), '_self');
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Required because some OpenID Connect providers do not allow URI fragments (hashes) in their redirect URLs, against the standards.

* Add new "asset" to Angular app which is a static HTML page. This immediately redirects to the original route, and is only provided for external sites to use.
* Fix issues with the `OpenIdConnectAuthorizeComponent`

Fixes #281 