### PR TITLE
Update profiles to support changes on backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@bpmn-io/dmn-migrate": "^0.4.3",
         "@ctrl/ngx-codemirror": "4.0.1",
         "@fortawesome/fontawesome-free": "5.15.1",
-        "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#develop",
+        "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#feature/profile-updates",
         "@uirouter/angular": "7.0.0",
         "@uirouter/core": "6.0.6",
         "@uirouter/rx": "0.6.5",
@@ -2984,7 +2984,7 @@
     },
     "node_modules/@maurodatamapper/mdm-resources": {
       "version": "4.9.0-SNAPSHOT",
-      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#b3a339ec81cdbca919e1440ccc3eca25cbee509c",
+      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#5b814208f3cc046f0dd422a1871098b402862d4e",
       "license": "Apache-2.0"
     },
     "node_modules/@ngtools/webpack": {
@@ -25376,8 +25376,8 @@
       }
     },
     "@maurodatamapper/mdm-resources": {
-      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#b3a339ec81cdbca919e1440ccc3eca25cbee509c",
-      "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#develop"
+      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#5b814208f3cc046f0dd422a1871098b402862d4e",
+      "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#feature/profile-updates"
     },
     "@ngtools/webpack": {
       "version": "9.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@bpmn-io/dmn-migrate": "^0.4.3",
         "@ctrl/ngx-codemirror": "4.0.1",
         "@fortawesome/fontawesome-free": "5.15.1",
-        "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#feature/profile-updates",
+        "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#develop",
         "@uirouter/angular": "7.0.0",
         "@uirouter/core": "6.0.6",
         "@uirouter/rx": "0.6.5",
@@ -2984,7 +2984,7 @@
     },
     "node_modules/@maurodatamapper/mdm-resources": {
       "version": "4.9.0-SNAPSHOT",
-      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#dae55ad984d767d05059968498c84078e2205ce5",
+      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#6477ac393a817872dd5e02f2f345d9b47e30c53d",
       "license": "Apache-2.0"
     },
     "node_modules/@ngtools/webpack": {
@@ -25376,8 +25376,8 @@
       }
     },
     "@maurodatamapper/mdm-resources": {
-      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#dae55ad984d767d05059968498c84078e2205ce5",
-      "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#feature/profile-updates"
+      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#6477ac393a817872dd5e02f2f345d9b47e30c53d",
+      "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#develop"
     },
     "@ngtools/webpack": {
       "version": "9.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2984,7 +2984,7 @@
     },
     "node_modules/@maurodatamapper/mdm-resources": {
       "version": "4.9.0-SNAPSHOT",
-      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#5b814208f3cc046f0dd422a1871098b402862d4e",
+      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#dae55ad984d767d05059968498c84078e2205ce5",
       "license": "Apache-2.0"
     },
     "node_modules/@ngtools/webpack": {
@@ -25376,7 +25376,7 @@
       }
     },
     "@maurodatamapper/mdm-resources": {
-      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#5b814208f3cc046f0dd422a1871098b402862d4e",
+      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#dae55ad984d767d05059968498c84078e2205ce5",
       "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#feature/profile-updates"
     },
     "@ngtools/webpack": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@bpmn-io/dmn-migrate": "^0.4.3",
     "@ctrl/ngx-codemirror": "4.0.1",
     "@fortawesome/fontawesome-free": "5.15.1",
-    "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#develop",
+    "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#feature/profile-updates",
     "@uirouter/angular": "7.0.0",
     "@uirouter/core": "6.0.6",
     "@uirouter/rx": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@bpmn-io/dmn-migrate": "^0.4.3",
     "@ctrl/ngx-codemirror": "4.0.1",
     "@fortawesome/fontawesome-free": "5.15.1",
-    "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#feature/profile-updates",
+    "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#develop",
     "@uirouter/angular": "7.0.0",
     "@uirouter/core": "6.0.6",
     "@uirouter/rx": "0.6.5",

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
@@ -39,10 +39,12 @@ SPDX-License-Identifier: Apache-2.0
         <tr *ngFor="let field of section.fields">
           <td class="detailsRowHeader" class="detailsRowHeader">
             {{ field.fieldName }}
+            <span *ngIf="field.minMultiplicity > 0">*</span>
             <i
               style="float: right"
-              (click)="showInfo(field)"
               class="fas fa-info-circle helpIcon"
+              [matTooltip]="field.description"
+              matTooltipPosition="after"
             ></i>
           </td>
           <td class="elementDetailDescription">
@@ -65,7 +67,7 @@ SPDX-License-Identifier: Apache-2.0
               [checked]="field.currentValue === 'true'"
               (change)="field.currentValue = $event.target.checked"
               name="{{ field.fieldName }} + {{ section.sectionName }}"
-              [required]="field.optional === false"
+              [required]="field.minMultiplicity > 0"
               [disabled]="field.uneditable"
 
             />
@@ -90,7 +92,7 @@ SPDX-License-Identifier: Apache-2.0
                 'outlined-input form-control':
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
-              [required]="field.optional === false"
+              [required]="field.minMultiplicity > 0"
               [disabled]="field.uneditable"
             />
             <input
@@ -104,7 +106,7 @@ SPDX-License-Identifier: Apache-2.0
                 'outlined-input form-control':
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
-              [required]="field.optional === false"
+              [required]="field.minMultiplicity > 0"
               [disabled]="field.uneditable"
             />
             <input
@@ -118,7 +120,7 @@ SPDX-License-Identifier: Apache-2.0
                 'outlined-input form-control':
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
-              [required]="field.optional === false"
+              [required]="field.minMultiplicity > 0"
               [disabled]="field.uneditable"
             />
             <div *ngIf="field.dataType === 'model'">
@@ -133,7 +135,7 @@ SPDX-License-Identifier: Apache-2.0
                   'outlined-input form-control':
                     formOptionsMap[field.dataType] != 'checkbox'
                 }"
-                [required]="field.optional === false"
+                [required]="field.minMultiplicity > 0"
                 [disabled]="field.uneditable"
               />
               <button
@@ -149,18 +151,20 @@ SPDX-License-Identifier: Apache-2.0
               </button>
             </div>
             <div *ngIf="field.dataType === 'enumeration'">
-              <mat-select
-                [(ngModel)]="field.currentValue"
-                name="{{ field.fieldName }} + {{ section.sectionName }}"
-                [disabled]="field.uneditable"
-              >
-                <mat-option
-                  *ngFor="let value of field.allowedValues"
-                  [value]="value"
+              <mat-form-field appearance="outline">
+                <mat-select
+                  [(ngModel)]="field.currentValue"
+                  name="{{ field.fieldName }} + {{ section.sectionName }}"
+                  [disabled]="field.uneditable"
                 >
-                  {{ value }}
-                </mat-option>
-              </mat-select>
+                  <mat-option
+                    *ngFor="let value of field.allowedValues"
+                    [value]="value"
+                  >
+                    {{ value }}
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
             </div>
             <div *ngIf="field.dataType === 'folder'">
               <mdm-model-selector-tree
@@ -171,8 +175,8 @@ SPDX-License-Identifier: Apache-2.0
                 (ngModelChange)="field.currentValue = $event"
                 [accepts]="['Folder']"
                 ngDefaultControl
-                [showValidationError]="field.optional === false"
-                [isRequired]="field.optional == false"
+                [showValidationError]="field.minMultiplicity > 0"
+                [isRequired]="field.minMultiplicity > 0"
                 [multiple]="true"
                 [hideSelectedElements]="false"
               >

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
@@ -49,8 +49,8 @@ SPDX-License-Identifier: Apache-2.0
             <mdm-content-editor
               [(content)]="field.currentValue"
               id="{{ field.fieldName }}"
-              [inEditMode]="true"
-              *ngIf="field.dataType === 'TEXT'"
+              [inEditMode]="!field.uneditable"
+              *ngIf="field.dataType === 'text'"
             ></mdm-content-editor>
 
             <input
@@ -66,18 +66,20 @@ SPDX-License-Identifier: Apache-2.0
               (change)="field.currentValue = $event.target.checked"
               name="{{ field.fieldName }} + {{ section.sectionName }}"
               [required]="field.optional === false"
+              [disabled]="field.uneditable"
+
             />
             <input
               *ngIf="
-                field.dataType !== 'FOLDER' &&
-                field.dataType !== 'DATAMODEL' &&
-                field.dataType != 'TEXT' &&
-                field.dataType != 'DATE' &&
-                field.dataType != 'DATETIME' &&
-                field.dataType != 'BOOLEAN' &&
-                field.dataType != 'FOLDER' &&
-                field.dataType != 'BOOLEAN' &&
-                field.dataType != 'ENUMERATION'
+                field.dataType !== 'folder' &&
+                field.dataType !== 'model' &&
+                field.dataType != 'text' &&
+                field.dataType != 'date' &&
+                field.dataType != 'datetime' &&
+                field.dataType != 'boolean' &&
+                field.dataType != 'folder' &&
+                field.dataType != 'boolean' &&
+                field.dataType != 'enumeration'
               "
               matInput
               type="{{ formOptionsMap[field.dataType] }}"
@@ -89,9 +91,10 @@ SPDX-License-Identifier: Apache-2.0
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
               [required]="field.optional === false"
+              [disabled]="field.uneditable"
             />
             <input
-              *ngIf="field.dataType === 'DATE'"
+              *ngIf="field.dataType === 'date'"
               matInput
               type="date"
               name="{{ field.fieldName }} + {{ section.sectionName }}"
@@ -102,9 +105,10 @@ SPDX-License-Identifier: Apache-2.0
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
               [required]="field.optional === false"
+              [disabled]="field.uneditable"
             />
             <input
-              *ngIf="field.dataType === 'DATETIME'"
+              *ngIf="field.dataType === 'datetime'"
               matInput
               type="datetime-local"
               name="{{ field.fieldName }} + {{ section.sectionName }}"
@@ -115,8 +119,9 @@ SPDX-License-Identifier: Apache-2.0
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
               [required]="field.optional === false"
+              [disabled]="field.uneditable"
             />
-            <div *ngIf="field.dataType === 'DATAMODEL'">
+            <div *ngIf="field.dataType === 'model'">
               <input
                 type="text"
                 matInput
@@ -129,8 +134,10 @@ SPDX-License-Identifier: Apache-2.0
                     formOptionsMap[field.dataType] != 'checkbox'
                 }"
                 [required]="field.optional === false"
+                [disabled]="field.uneditable"
               />
               <button
+                *ngIf="!field.uneditable"
                 mat-stroked-button
                 type="button"
                 color="primary"
@@ -141,10 +148,11 @@ SPDX-License-Identifier: Apache-2.0
                 Add Data Model
               </button>
             </div>
-            <div *ngIf="field.dataType === 'ENUMERATION'">
+            <div *ngIf="field.dataType === 'enumeration'">
               <mat-select
                 [(ngModel)]="field.currentValue"
                 name="{{ field.fieldName }} + {{ section.sectionName }}"
+                [disabled]="field.uneditable"
               >
                 <mat-option
                   *ngFor="let value of field.allowedValues"
@@ -154,7 +162,7 @@ SPDX-License-Identifier: Apache-2.0
                 </mat-option>
               </mat-select>
             </div>
-            <div *ngIf="field.dataType === 'FOLDER'">
+            <div *ngIf="field.dataType === 'folder'">
               <mdm-model-selector-tree
                 [treeSearchDomainType]="'Folder'"
                 [justShowFolders]="true"
@@ -170,9 +178,9 @@ SPDX-License-Identifier: Apache-2.0
               >
               </mdm-model-selector-tree>
             </div>
-            <mat-error *ngFor="let error of field.validationErrors">{{
-              error
-            }}</mat-error>
+            <mat-error *ngIf="getValidationError(field.fieldName)">
+              {{getValidationError(field.fieldName).message}}
+            </mat-error>
           </td>
         </tr>
       </tbody>

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
@@ -33,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0
       <tbody *ngFor="let section of this.profileData?.sections">
         <tr>
           <td [attr.colspan]="2" class="detailsRowHeader">
-            {{ section.sectionName }}
+            {{ section.name }}
           </td>
         </tr>
         <tr *ngFor="let field of section.fields">
@@ -66,7 +66,7 @@ SPDX-License-Identifier: Apache-2.0
               *ngIf="formOptionsMap[field.dataType] === 'checkbox'"
               [checked]="field.currentValue === 'true'"
               (change)="field.currentValue = $event.target.checked"
-              name="{{ field.fieldName }} + {{ section.sectionName }}"
+              name="{{ field.fieldName }} + {{ section.name }}"
               [required]="field.minMultiplicity > 0"
               [disabled]="field.uneditable"
 
@@ -85,7 +85,7 @@ SPDX-License-Identifier: Apache-2.0
               "
               matInput
               type="{{ formOptionsMap[field.dataType] }}"
-              name="{{ field.fieldName }} + {{ section.sectionName }}"
+              name="{{ field.fieldName }} + {{ section.name }}"
               [(ngModel)]="field.currentValue"
               value="field.currentValue"
               [ngClass]="{
@@ -99,7 +99,7 @@ SPDX-License-Identifier: Apache-2.0
               *ngIf="field.dataType === 'date'"
               matInput
               type="date"
-              name="{{ field.fieldName }} + {{ section.sectionName }}"
+              name="{{ field.fieldName }} + {{ section.name }}"
               [(ngModel)]="field.currentValue"
               value="{{ field.currentValue }}"
               [ngClass]="{
@@ -113,7 +113,7 @@ SPDX-License-Identifier: Apache-2.0
               *ngIf="field.dataType === 'datetime'"
               matInput
               type="datetime-local"
-              name="{{ field.fieldName }} + {{ section.sectionName }}"
+              name="{{ field.fieldName }} + {{ section.name }}"
               [(ngModel)]="field.currentValue"
               value="{{ field.currentValue }}"
               [ngClass]="{
@@ -128,7 +128,7 @@ SPDX-License-Identifier: Apache-2.0
                 type="text"
                 matInput
                 type="text"
-                name="{{ field.fieldName }} + {{ section.sectionName }}"
+                name="{{ field.fieldName }} + {{ section.name }}"
                 [(ngModel)]="field.currentValue"
                 value="{{ field.currentValue }}"
                 [ngClass]="{
@@ -154,7 +154,7 @@ SPDX-License-Identifier: Apache-2.0
               <mat-form-field appearance="outline">
                 <mat-select
                   [(ngModel)]="field.currentValue"
-                  name="{{ field.fieldName }} + {{ section.sectionName }}"
+                  name="{{ field.fieldName }} + {{ section.name }}"
                   [disabled]="field.uneditable"
                 >
                   <mat-option

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <h4 mat-dialog-title>Edit Profile - {{ data.profileName }}</h4>
 <p *ngIf="description">
-  {{description}}
+  {{ description }}
 </p>
 <mat-dialog-content class="mat-typography">
   <form
@@ -69,9 +69,8 @@ SPDX-License-Identifier: Apache-2.0
               name="{{ field.fieldName }} + {{ section.name }}"
               [required]="field.minMultiplicity > 0"
               [disabled]="field.uneditable"
-
             />
-            <input
+            <div
               *ngIf="
                 field.dataType !== 'folder' &&
                 field.dataType !== 'model' &&
@@ -83,18 +82,22 @@ SPDX-License-Identifier: Apache-2.0
                 field.dataType != 'boolean' &&
                 field.dataType != 'enumeration'
               "
-              matInput
-              type="{{ formOptionsMap[field.dataType] }}"
-              name="{{ field.fieldName }} + {{ section.name }}"
-              [(ngModel)]="field.currentValue"
-              value="field.currentValue"
-              [ngClass]="{
-                'outlined-input form-control':
-                  formOptionsMap[field.dataType] != 'checkbox'
-              }"
-              [required]="field.minMultiplicity > 0"
-              [disabled]="field.uneditable"
-            />
+            >
+              <span *ngIf="field.uneditable">{{field.currentValue}}</span>
+              <input
+                *ngIf="!field.uneditable"
+                matInput
+                type="{{ formOptionsMap[field.dataType] }}"
+                name="{{ field.fieldName }} + {{ section.name }}"
+                [(ngModel)]="field.currentValue"
+                value="field.currentValue"
+                [ngClass]="{
+                  'outlined-input form-control':
+                    formOptionsMap[field.dataType] != 'checkbox'
+                }"
+                [required]="field.minMultiplicity > 0"
+              />
+            </div>
             <input
               *ngIf="field.dataType === 'date'"
               matInput
@@ -183,7 +186,7 @@ SPDX-License-Identifier: Apache-2.0
               </mdm-model-selector-tree>
             </div>
             <mat-error *ngIf="getValidationError(field.fieldName)">
-              {{getValidationError(field.fieldName).message}}
+              {{ getValidationError(field.fieldName).message }}
             </mat-error>
           </td>
         </tr>

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.ts
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.ts
@@ -25,7 +25,7 @@ import {
   MatDialogRef,
   MAT_DIALOG_DATA
 } from '@angular/material/dialog';
-import { Profile, ProfileField, ProfileResponse, ProfileValidationError, ProfileValidationErrorList } from '@maurodatamapper/mdm-resources';
+import { Profile, ProfileField, ProfileValidationError, ProfileValidationErrorList } from '@maurodatamapper/mdm-resources';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { ElementSelectorComponent } from '@mdm/utility/element-selector.component';
@@ -128,12 +128,11 @@ export class EditProfileModalComponent implements OnInit {
       )
       .pipe(
         catchError((error: HttpErrorResponse) => {
-          this.validationErrors = error.error as ProfileValidationErrorList
+          this.validationErrors = error.error as ProfileValidationErrorList;
           return EMPTY;
         })
       )
-      .subscribe((response: ProfileResponse) => {
-        //this.profileData = response.body;
+      .subscribe(() => {
         this.validationErrors = {
           total: 0,
           errors: []

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.ts
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.ts
@@ -32,7 +32,6 @@ import { ElementSelectorComponent } from '@mdm/utility/element-selector.componen
 import { MarkdownParserService } from '@mdm/utility/markdown/markdown-parser/markdown-parser.service';
 import { EMPTY } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { MarkupDisplayModalComponent } from '../markup-display-modal/markup-display-modal.component';
 import { EditProfileModalConfiguration, EditProfileModalResult } from './edit-profile-modal.model';
 @Component({
   selector: 'mdm-edit-profile-modal',
@@ -116,15 +115,6 @@ export class EditProfileModalComponent implements OnInit {
 
   onCancel() {
     this.dialogRef.close({ status: ModalDialogStatus.Cancel });
-  }
-
-  showInfo(field: any) {
-    this.dialog.open(MarkupDisplayModalComponent, {
-      data: {
-        content: field.description,
-        title: field.fieldName
-      }
-    });
   }
 
   validate() {

--- a/src/app/shared/profile-details/profile-details.component.html
+++ b/src/app/shared/profile-details/profile-details.component.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
   <tbody *ngFor="let section of this.currentProfileDetails?.sections">
     <tr>
       <td [attr.colspan]="2" class="detailsRowHeader">
-        {{ section.sectionName }}
+        {{ section.name }}
       </td>
     </tr>
     <tr *ngFor="let field of section.fields">
@@ -50,7 +50,7 @@ SPDX-License-Identifier: Apache-2.0
           "
           [checked]="field.currentValue === 'true'"
           (click)="$event.preventDefault()"
-          name="{{ field.fieldName }} + {{ section.sectionName }}"
+          name="{{ field.fieldName }} + {{ section.name }}"
         />
 
         <input

--- a/src/app/shared/profile-details/profile-details.component.html
+++ b/src/app/shared/profile-details/profile-details.component.html
@@ -28,8 +28,9 @@ SPDX-License-Identifier: Apache-2.0
         {{ field.fieldName }}
         <i
           style="float: right"
-          (click)="showInfo(field)"
           class="fas fa-info-circle helpIcon"
+          [matTooltip]="field.description"
+          matTooltipPosition="after"
         ></i>
       </td>
       <td class="elementDetailDescription">
@@ -37,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
           [(content)]="field.currentValue"
           id="{{ field.fieldName }}"
           [inEditMode]="false"
-          *ngIf="field.dataType === 'TEXT'"
+          *ngIf="field.dataType === 'text'"
         ></mdm-content-editor>
         <input
           type="checkbox"
@@ -55,14 +56,14 @@ SPDX-License-Identifier: Apache-2.0
 
         <input
           *ngIf="
-            field.dataType !== 'FOLDER' &&
-            field.dataType !== 'DATAMODEL' &&
-            field.dataType != 'TEXT' &&
-            field.dataType != 'DATE' &&
-            field.dataType != 'DATETIME' &&
-            field.dataType != 'BOOLEAN' &&
-            field.dataType != 'FOLDER' &&
-            field.dataType != 'BOOLEAN'
+            field.dataType !== 'folder' &&
+            field.dataType !== 'model' &&
+            field.dataType != 'text' &&
+            field.dataType != 'date' &&
+            field.dataType != 'datetime' &&
+            field.dataType != 'boolean' &&
+            field.dataType != 'folder' &&
+            field.dataType != 'boolean'
           "
           style="background-color: #ffffff; width: 100%; border: hidden"
           [readonly]="true"
@@ -71,30 +72,28 @@ SPDX-License-Identifier: Apache-2.0
           value="field.currentValue"
         />
         <input
-          *ngIf="field.dataType === 'DATE'"
+          *ngIf="field.dataType === 'date'"
           style="background-color: #ffffff; border: hidden"
           [readonly]="true"
           type="date"
           [(ngModel)]="field.currentValue"
           value="{{ field.currentValue }}"
-          [required]="field.optional === false"
         />
         <input
           style="background-color: #ffffff; border: hidden"
-          *ngIf="field.dataType === 'DATETIME'"
+          *ngIf="field.dataType === 'datetime'"
           type="datetime-local"
           [readonly]="true"
           [(ngModel)]="field.currentValue"
           value="{{ field.currentValue }}"
-          [required]="field.optional === false"
         />
-        <div *ngIf="field.dataType === 'DATAMODEL'">
+        <div *ngIf="field.dataType === 'model'">
           <mdm-more-description
             [description]="field.currentValue"
             [length]="100"
           ></mdm-more-description>
         </div>
-        <div *ngIf="field.dataType === 'FOLDER'">
+        <div *ngIf="field.dataType === 'folder'">
           {{ field.currentValue }}
         </div>
       </td>

--- a/src/app/shared/profile-details/profile-details.component.ts
+++ b/src/app/shared/profile-details/profile-details.component.ts
@@ -18,9 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 /* eslint-disable id-blacklist */
 import { Component, Input } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
 import { Profile } from '@maurodatamapper/mdm-resources';
-import { MarkupDisplayModalComponent } from '@mdm/modals/markup-display-modal/markup-display-modal.component';
 
 @Component({
   selector: 'mdm-profile-details',
@@ -31,24 +29,13 @@ export class ProfileDetailsComponent {
   @Input() currentProfileDetails: Profile;
 
   readonly formOptionsMap = {
-    INTEGER: 'number',
-    STRING: 'text',
-    BOOLEAN: 'checkbox',
-    INT: 'number',
-    DATE: 'date',
-    TIME: 'time',
-    DATETIME: 'datetime',
-    DECIMAL: 'number'
+    integer: 'number',
+    string: 'text',
+    boolean: 'checkbox',
+    int: 'number',
+    date: 'date',
+    time: 'time',
+    datetime: 'datetime',
+    decimal: 'number'
   };
-
-  constructor(private dialog: MatDialog) { }
-
-  showInfo(field: any) {
-    this.dialog.open(MarkupDisplayModalComponent, {
-      data: {
-        content: field.description,
-        title: field.fieldName
-      }
-    });
-  }
 }


### PR DESCRIPTION
Fixes #284

* Uses correct property names and data types returned from profiles - names have been made more consistent
* Supports uneditable fields
* Validation endpoint now returns a collection of errors when a `422` is returned, so UI has been updated to reflect this
* Fixed required fields by looking at `minMultiplicity` field property