### PR TITLE
gh-278 Add dynamic cacheDirectory for jest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,8 @@ pipeline {
         nvm('') {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
             sh 'npm run test-with-coverage'
-            sh 'npm run test-clean'
+            sh 'npm run test-clearCache'
+            sh "rm -rf /tmp/jest_${JOB_BASE_NAME}"
           }
         }
       }

--- a/jest.config.js
+++ b/jest.config.js
@@ -33,7 +33,7 @@ module.exports = {
   },
   globals: {
     'ts - jest': {
-      tsConfig: 'tsconfig.spec.json',
+      tsconfig: 'tsconfig.spec.json',
       stringifyContentPathRegex: '\\.html'
     }
   },
@@ -53,5 +53,6 @@ module.exports = {
   ],
   transformIgnorePatterns: [
     'node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)' // Ignore files inside node_modules folder
-  ]
+  ],
+  cacheDirectory: '/tmp/jest_'+ (process.env.BUILD_TAG || 'cache')
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -54,5 +54,5 @@ module.exports = {
   transformIgnorePatterns: [
     'node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)' // Ignore files inside node_modules folder
   ],
-  cacheDirectory: '/tmp/jest_'+ (process.env.BUILD_TAG || 'cache')
+  cacheDirectory: '/tmp/jest_'+ (process.env.JOB_BASE_NAME || 'cache')
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "test-with-coverage": "jest --coverage",
     "test-watch": "jest --watch",
-    "test-clean": "jest --clearCache",
+    "test-clearCache": "jest --clearCache",
     "lint": "ng lint",
     "eslint": "tsc --noEmit && eslint . --ext ts --quiet --fix",
     "eslint-nofix": "tsc --noEmit && eslint . --ext ts --quiet",


### PR DESCRIPTION
* If the env variable BUILD_TAG exists then the cache dir should use that, otherwise defaults to "cache".
The full path is /tmp/jest_<BUILD_TAG> or /tmp/jest_cache.

fixes #278