### PR TITLE
Updates to mdm-resources

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,19 +1,3 @@
-# Copyright 2020-2021 University of Oxford
-# and Health and Social Care Information Centre, also known as NHS Digital
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
 # don't lint node_modules
 node_modules
 # don't lint build output (make sure it's set to your correct build folder name)

--- a/.npmrc
+++ b/.npmrc
@@ -1,20 +1,2 @@
-/*
-Copyright 2020-2021 University of Oxford
-and Health and Social Care Information Centre, also known as NHS Digital
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-SPDX-License-Identifier: Apache-2.0
-*/
 registry=https://registry.npmjs.org
 @maurodatamapper:registry=https://npm.pkg.github.com

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry=https://registry.npmjs.org
-@maurodatamapper:registry=https://npm.pkg.github.com

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,6 @@ pipeline {
     stage('Tool Versions') {
       steps {
         nvm('') {
-          // Currently npm v6 is packaged with node and we need v7+
-          sh 'npm install -g npm@^7.10.0'
           sh 'node --version'
           sh 'npm --version'
         }
@@ -30,12 +28,39 @@ pipeline {
       }
     }
 
-    stage('Install') {
+    stage('Install Global') {
       steps {
         nvm('') {
           sh 'npm install -g npm-check'
           sh 'npm install -g @angular/cli'
+          sh 'npm install -g symlinked'
+        }
+      }
+    }
+
+    stage('Install Dependencies') {
+      when {
+        not {
+          branch 'main'
+        }
+      }
+      steps {
+        nvm('') {
+          sh 'npm install'
+          sh 'npm link @maurodatamapper/mdm-resources'
+          sh 'symlinked names'
+        }
+      }
+    }
+
+    stage('Clean Install Dependencies') {
+      when {
+        branch 'main'
+      }
+      steps {
+        nvm('') {
           sh 'npm ci'
+          sh 'symlinked names'
         }
       }
     }
@@ -82,6 +107,12 @@ pipeline {
     }
 
     stage('Distribution Build') {
+      when{
+        anyOf{
+          branch 'develop'
+          branch 'main'
+        }
+      }
       steps {
         nvm('') {
           catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {

--- a/README.md
+++ b/README.md
@@ -54,37 +54,48 @@ Therefore if you change any dependency versions you must make sure the `package-
 
 ## MDM-Resources
 
-We have a dependency on another repository ([mdm-resources](https://github.com/MauroDataMapper/mdm-resources)) 
-which is not currently published to NPM .
+We have a dependency on another repository ([mdm-resources](https://github.com/MauroDataMapper/mdm-resources)) which we develop.
 
-* The `develop` branch of this repo tracks the develop branch of mdm-resources
-* The `main` branch of this repo tracks a specific tagged release of mdm-resources
+The package.json file is configured to use the latest release of this module into the NPM registry,
+however if you are developing mdm-resources alongside mdm-ui or you know there are changes which have not yet been released you will need to 
+do the following
 
-If any updates are made to the mdm-resources repo then to allow Jenkins to build successfully you will need to update the
-`package-lock.json` which points to a specific commit hash for mdm-resources.
-This can be done by running
+1. Clone the mdm-resources repository
+2. Link the mdm-resources repository into your global npm
+3. Link mdm-resources into mdm-ui
+
+Once you have linked the mdm-resources repo into the global npm it will remain there until you unlink it,
+you will have to re-build (`npm run build`) mdm-resources with each change for those changes to be picked up by mdm-ui,
+however you dont have to re-link after the rebuild.
+
+### Linking to mdm-resources
+
+If you run `npm install` inside mdm-ui you will have to re-run the final link step below to re-link mdm-resources into mdm-ui.
 
 ```shell
-$ npm update @maurodatamapper/mdm-resources
+# Clone mdm-resources
+$ git clone git@github.com:MauroDataMapper/mdm-resources.git
+
+# Link mdm-resources to global npm
+$ cd mdm-resources
+$ npm install
+$ npm run build
+$ npm link
+
+# Link mdm-resources into mdm-ui
+$ cd mdm-ui
+$ npm link @maurodatamapper/mdm-resources
 ```
 
-### `develop` branch
+### Unlinking from mdm-resources
 
-We have the `develop` branch set with a dependency of:
+This is surprisingly simple just run `npm install` or `npm ci`
 
-```json
- "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#develop",
-```
+### Useful Tool for Links
 
-### `main` branch
-
-We have the `main` branch set with a dependency of:
-
-```json
- "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#<RELEASE_TAG>",
-```
-
-Where the `RELEASE_TAG` is the stable tagged release of mdm-resources we need for the release of mdm-ui.
+There is a useful npm package ([symlinked](https://www.npmjs.com/package/symlinked)) which can list what modules are linked into your repository.
+This is helpful if you want to check if mdm-resources is currently linked to mdm-ui.
+We recommend installing this globally with `npm i -g symlinked` then you can call it inside mdm-ui using `symlinked names`.
 
 ## Build the application
 

--- a/license-check-and-add-config.json
+++ b/license-check-and-add-config.json
@@ -14,6 +14,8 @@
     ".gitattributes",
     ".gitignore",
     ".nvmrc",
+    ".npmrc",
+    ".eslintignore",
     "NOTICE",
     "Jenkinsfile",
     "**/*.xml",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@bpmn-io/dmn-migrate": "^0.4.3",
         "@ctrl/ngx-codemirror": "4.0.1",
         "@fortawesome/fontawesome-free": "5.15.1",
-        "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#develop",
+        "@maurodatamapper/mdm-resources": "4.10.1",
         "@uirouter/angular": "7.0.0",
         "@uirouter/core": "6.0.6",
         "@uirouter/rx": "0.6.5",
@@ -3012,9 +3012,9 @@
       }
     },
     "node_modules/@maurodatamapper/mdm-resources": {
-      "version": "4.11.0-SNAPSHOT",
-      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#a65fe966646823c29f96a463eab16848c02b315a",
-      "license": "Apache-2.0"
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@maurodatamapper/mdm-resources/-/mdm-resources-4.10.1.tgz",
+      "integrity": "sha512-EL3QgU9HYeZvzqTX91XS50RrfjQkC06fTAJO+Cvubg5EAWhWcxCFi9fPUVvGrYoJ7R21u5C5mSY/naSCmVbVOA=="
     },
     "node_modules/@ngtools/webpack": {
       "version": "9.1.12",
@@ -25407,8 +25407,9 @@
       }
     },
     "@maurodatamapper/mdm-resources": {
-      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#a65fe966646823c29f96a463eab16848c02b315a",
-      "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#develop"
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@maurodatamapper/mdm-resources/-/mdm-resources-4.10.1.tgz",
+      "integrity": "sha512-EL3QgU9HYeZvzqTX91XS50RrfjQkC06fTAJO+Cvubg5EAWhWcxCFi9fPUVvGrYoJ7R21u5C5mSY/naSCmVbVOA=="
     },
     "@ngtools/webpack": {
       "version": "9.1.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "mdm-ui",
       "version": "6.7.0-SNAPSHOT",
       "hasInstallScript": true,
       "dependencies": {
@@ -108,6 +109,32 @@
         "tslib": "2.0.2",
         "tslint": "6.1.3",
         "typescript": "3.8.3"
+      }
+    },
+    "../mdm-resources": {
+      "name": "@maurodatamapper/mdm-resources",
+      "version": "4.11.0-SNAPSHOT",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/jest": "^26.0.10",
+        "@types/node": "^14.6.0",
+        "@typescript-eslint/eslint-plugin": "4.4.0",
+        "@typescript-eslint/eslint-plugin-tslint": "4.4.0",
+        "@typescript-eslint/parser": "4.4.0",
+        "eslint": "7.10.0",
+        "eslint-config-prettier": "6.12.0",
+        "eslint-plugin-import": "2.22.1",
+        "eslint-plugin-jsdoc": "30.6.3",
+        "eslint-plugin-prefer-arrow": "1.2.2",
+        "eslint-plugin-prettier": "3.1.4",
+        "jest": "^26.4.2",
+        "license-check-and-add": "^4.0.2",
+        "prettier": "2.1.2",
+        "prettier-eslint": "11.0.0",
+        "ts-jest": "^26.2.0",
+        "typedoc": "^0.20.32",
+        "typescript": "^3.9.6"
       }
     },
     "node_modules/@angular-builders/custom-webpack": {
@@ -2197,6 +2224,7 @@
     },
     "node_modules/@ctrl/ngx-codemirror": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/codemirror": "^0.0.96",
@@ -2210,6 +2238,7 @@
     },
     "node_modules/@ctrl/ngx-codemirror/node_modules/tslib": {
       "version": "2.0.3",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/@eslint/eslintrc": {
@@ -2984,7 +3013,7 @@
     },
     "node_modules/@maurodatamapper/mdm-resources": {
       "version": "4.11.0-SNAPSHOT",
-      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#3e92133211e5aa8b15becc87fa8737ee2bfd782c",
+      "resolved": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#a65fe966646823c29f96a463eab16848c02b315a",
       "license": "Apache-2.0"
     },
     "node_modules/@ngtools/webpack": {
@@ -3309,6 +3338,7 @@
     },
     "node_modules/@types/codemirror": {
       "version": "0.0.96",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/tern": "*"
@@ -3331,6 +3361,7 @@
     },
     "node_modules/@types/estree": {
       "version": "0.0.45",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/glob": {
@@ -3574,6 +3605,7 @@
     },
     "node_modules/@types/tern": {
       "version": "0.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
@@ -6124,7 +6156,6 @@
     "node_modules/codelyzer/node_modules/@angular/compiler": {
       "version": "9.0.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "tslib": "^1.10.0"
       }
@@ -6132,7 +6163,6 @@
     "node_modules/codelyzer/node_modules/@angular/core": {
       "version": "9.0.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "rxjs": "^6.5.3",
         "tslib": "^1.10.0",
@@ -13945,8 +13975,7 @@
     },
     "node_modules/jodit-angular/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/jointjs": {
       "version": "3.3.1",
@@ -24855,13 +24884,15 @@
     },
     "@ctrl/ngx-codemirror": {
       "version": "4.0.1",
+      "dev": true,
       "requires": {
         "@types/codemirror": "^0.0.96",
         "tslib": "^2.0.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.3"
+          "version": "2.0.3",
+          "dev": true
         }
       }
     },
@@ -25376,7 +25407,7 @@
       }
     },
     "@maurodatamapper/mdm-resources": {
-      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#3e92133211e5aa8b15becc87fa8737ee2bfd782c",
+      "version": "git+ssh://git@github.com/MauroDataMapper/mdm-resources.git#a65fe966646823c29f96a463eab16848c02b315a",
       "from": "@maurodatamapper/mdm-resources@git+https://github.com/MauroDataMapper/mdm-resources.git#develop"
     },
     "@ngtools/webpack": {
@@ -25606,6 +25637,7 @@
     },
     "@types/codemirror": {
       "version": "0.0.96",
+      "dev": true,
       "requires": {
         "@types/tern": "*"
       }
@@ -25623,7 +25655,8 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.45"
+      "version": "0.0.45",
+      "dev": true
     },
     "@types/glob": {
       "version": "7.1.3",
@@ -25809,6 +25842,7 @@
     },
     "@types/tern": {
       "version": "0.23.3",
+      "dev": true,
       "requires": {
         "@types/estree": "*"
       }
@@ -27470,6 +27504,8 @@
     "codelyzer": {
       "version": "6.0.1",
       "requires": {
+        "@angular/compiler": "9.0.0",
+        "@angular/core": "9.0.0",
         "app-root-path": "^3.0.0",
         "aria-query": "^3.0.0",
         "axobject-query": "2.0.2",
@@ -27486,12 +27522,10 @@
       "dependencies": {
         "@angular/compiler": {
           "version": "9.0.0",
-          "peer": true,
           "requires": {}
         },
         "@angular/core": {
           "version": "9.0.0",
-          "peer": true,
           "requires": {}
         },
         "tslib": {
@@ -32709,11 +32743,12 @@
     },
     "jodit-angular": {
       "version": "1.0.119",
-      "requires": {},
+      "requires": {
+        "tslib": "^1.9.0"
+      },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "peer": true
+          "version": "1.14.1"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@bpmn-io/dmn-migrate": "^0.4.3",
     "@ctrl/ngx-codemirror": "4.0.1",
     "@fortawesome/fontawesome-free": "5.15.1",
-    "@maurodatamapper/mdm-resources": "git+https://github.com/MauroDataMapper/mdm-resources.git#develop",
+    "@maurodatamapper/mdm-resources": "4.10.1",
     "@uirouter/angular": "7.0.0",
     "@uirouter/core": "6.0.6",
     "@uirouter/rx": "0.6.5",


### PR DESCRIPTION
Updates to use the published mdm-resources

* no reliance on github
* updated readme
* updated jenkinsfile to use linked mdm-resources develop branch for ALL branches other than main
* updated jenkinsfile to use published mdm-resources for main branch

This means the mdm-ui will now have a reliance on mdm-resources develop branch having run with any required changes before the mdm-ui develop branch will complete.

See MauroDataMapper/mdm-resources#33