### PR TITLE
#314 Make API key field optional for subscribed catalogue setup

### DIFF
--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
@@ -41,9 +41,9 @@ SPDX-License-Identifier: Apache-2.0
             {{errors.url}}
         </mat-error>
     </mat-form-field>
-    <mat-form-field appearance="outline" [hintLabel]="isCreating ? 'Must be provided when creating a new subscribed catalogue' : 'Enter API key again to modify (optional)'">
+    <mat-form-field appearance="outline" hintLabel="An API key is required to view non-public models in the subscribed catalogue">
         <mat-label>API Key</mat-label>
-        <input matInput name="apiKey" [(ngModel)]="catalogue.apiKey" [required]="isCreating" />
+        <input matInput name="apiKey" [(ngModel)]="catalogue.apiKey" />
         <mat-error *ngIf="errors && errors.apiKey">
             {{errors.apiKey}}
         </mat-error>

--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.ts
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.ts
@@ -132,11 +132,6 @@ export class SubscribedCatalogueComponent implements OnInit {
       isValid = false;
     }
 
-    if (this.isCreating && (this.catalogue.apiKey?.trim()?.length ?? 0) === 0) {
-      this.errors.apiKey = 'API key cannot be empty when creating a subscribed catalogue';
-      isValid = false;
-    }
-
     return isValid;
   }
 

--- a/src/app/admin/subscribed-catalogues/subscribed-catalogues.component.html
+++ b/src/app/admin/subscribed-catalogues/subscribed-catalogues.component.html
@@ -36,7 +36,7 @@ SPDX-License-Identifier: Apache-2.0
         <table mat-table [dataSource]="dataSource" matSort class="mdm--mat-table table table-striped marginless">
             <ng-container matColumnDef="label">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header style="cursor: pointer; max-width: 40%;" columnName="label">
-                    <span>Label</span>                    
+                    <span>Label</span>
                 </th>
                 <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
                     {{record.label}}
@@ -44,7 +44,7 @@ SPDX-License-Identifier: Apache-2.0
             </ng-container>
             <ng-container matColumnDef="description">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header style="cursor: pointer; max-width: 40%;" columnName="description">
-                    <span>Description</span>                    
+                    <span>Description</span>
                 </th>
                 <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
                     {{record.description}}
@@ -52,21 +52,21 @@ SPDX-License-Identifier: Apache-2.0
             </ng-container>
             <ng-container matColumnDef="connection">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header style="cursor: pointer; max-width: 40%;" columnName="connection">
-                    <span>Connection</span>                    
+                    <span>Connection</span>
                 </th>
                 <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
                     <p><strong>URL:</strong> {{record.url}}</p>
-                    <p><strong>Key:</strong> {{record.apiKey}}</p>
+                    <p *ngIf="record.apiKey"><strong>Key:</strong> {{record.apiKey}}</p>
                 </td>
-            </ng-container>      
+            </ng-container>
             <ng-container matColumnDef="refreshPeriod">
                 <th mat-header-cell *matHeaderCellDef mat-sort-header style="width: 20%; cursor: pointer; max-width: 40%;" columnName="refreshPeriod">
-                    <span>Refresh period (days)</span>                    
+                    <span>Refresh period (days)</span>
                 </th>
                 <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
                     {{record.refreshPeriod}}
                 </td>
-            </ng-container>      
+            </ng-container>
             <ng-container matColumnDef="icons">
                 <td mat-header-cell *matHeaderCellDef columnName="icons" style="width: 7%; text-align: center;"></td>
                 <td mat-cell *matCellDef="let record; let i = index" style="text-align: center; word-wrap: break-word;">


### PR DESCRIPTION
Without an API key, the subscribed catalogue can only return publicly readable models.

With the API key, the subscribed catalogue can return non-public models.

Resolves #314 