### PR TITLE
#322 Fix OpenID Connect redirect issue with URL subdirectories

### DIFF
--- a/src/app/services/handlers/security-handler.service.ts
+++ b/src/app/services/handlers/security-handler.service.ts
@@ -356,7 +356,7 @@ export class SecurityHandlerService {
     // The static page is therefore a landing point so that it can immediately redirect to the correct authentication component
     // route and do the real work.
     const authorizationUrl = '/redirects/open-id-connect-redirect.html';
-    const baseUrl = `${window.location.protocol}//${window.location.host}`;
-    return new URL(authorizationUrl, baseUrl);
+    const baseUrl = window.location.href.slice(0, window.location.href.indexOf('/#/'));
+    return new URL(baseUrl + authorizationUrl);
   }
 }

--- a/src/static-pages/open-id-connect-redirect.html
+++ b/src/static-pages/open-id-connect-redirect.html
@@ -35,10 +35,8 @@ SPDX-License-Identifier: Apache-2.0
     <body>
         <p>Redirecting back to Mauro Data Mapper...</p>
         <script lang="javascript">
-          const baseUrl = `${window.location.protocol}//${window.location.host}`;
-          const currentUrl = `#/open-id-connect/authorize${window.location.search}`;
-          const redirectUrl = new URL(currentUrl, baseUrl);
-          window.open(redirectUrl.toString(), '_self');
+          const redirectUrl = window.location.href.replace('/redirects/open-id-connect-redirect.html', '/#/open-id-connect/authorize');
+          window.open(redirectUrl, '_self');
         </script>
     </body>
 </html>


### PR DESCRIPTION
If the server uses a subdirectory as well as the domain, the original redirect was failing because it was not accounted for.

* Update redirect static page to correctly build the URL for redirection to the angular route
* Update OIDC provider page to display correct redirect URL info

This can be tested locally by passing the `--base-ref` parameter to `ng serve`, e.g. `ng serve --base-href /nhsd-test/`

Fixes #322 