### PR TITLE
MC-9642 Add data attributes to top-level catalogue item containers

### DIFF
--- a/src/app/code-set/code-set/code-set.component.html
+++ b/src/app/code-set/code-set/code-set.component.html
@@ -16,8 +16,16 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="full-width">
-  <mdm-code-set-details *ngIf="codeSetModel" [codeSetDetail]="codeSetModel"></mdm-code-set-details>
+<div
+  class="full-width"
+  data-cy="catalogue-item-container"
+  [attr.data-catalogue-item-id]="codeSetModel.id"
+  [attr.data-catalogue-item-domain]="codeSetModel.domainType"
+>
+  <mdm-code-set-details
+    *ngIf="codeSetModel"
+    [codeSetDetail]="codeSetModel"
+  ></mdm-code-set-details>
 </div>
 
 <div>

--- a/src/app/dataModel/data-model.component.html
+++ b/src/app/dataModel/data-model.component.html
@@ -16,7 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="full-width">
+<div
+  class="full-width"
+  data-cy="catalogue-item-container"
+  [attr.data-catalogue-item-id]="dataModel.id"
+  [attr.data-catalogue-item-domain]="dataModel.domainType"
+>
   <div style="clear: both" *ngIf="!dataModel">
     <mat-progress-bar
       value="50"

--- a/src/app/folder/folder.component.html
+++ b/src/app/folder/folder.component.html
@@ -16,11 +16,14 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="full-width mb-1 mdm--shadow-block">
+<div
+  class="full-width mb-1 mdm--shadow-block"
+  data-cy="catalogue-item-container"
+  [attr.data-catalogue-item-id]="folder.id"
+  [attr.data-catalogue-item-domain]="folder.domainType"
+>
   <div class="panel">
-    <mdm-folder-detail *ngIf="folder"
-      [folder]="folder"
-    ></mdm-folder-detail>
+    <mdm-folder-detail *ngIf="folder" [folder]="folder"></mdm-folder-detail>
   </div>
 
   <div class="mdm--shadow-block" *ngIf="showSearch">

--- a/src/app/referenceData/reference-data.component.html
+++ b/src/app/referenceData/reference-data.component.html
@@ -16,8 +16,16 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="full-width">
-  <mdm-reference-data-details *ngIf="referenceModel" [refDataModel]="referenceModel"></mdm-reference-data-details>
+<div
+  class="full-width"
+  data-cy="catalogue-item-container"
+  [attr.data-catalogue-item-id]="referenceModel.id"
+  [attr.data-catalogue-item-domain]="referenceModel.domainType"
+>
+  <mdm-reference-data-details
+    *ngIf="referenceModel"
+    [refDataModel]="referenceModel"
+  ></mdm-reference-data-details>
 </div>
 
 <mat-tab-group

--- a/src/app/terminology/terminology.component.html
+++ b/src/app/terminology/terminology.component.html
@@ -17,7 +17,12 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-<div class="full-width mb-1 mdm--shadow-block">
+<div
+  class="full-width mb-1 mdm--shadow-block"
+  data-cy="catalogue-item-container"
+  [attr.data-catalogue-item-id]="terminology.id"
+  [attr.data-catalogue-item-domain]="terminology.domainType"
+>
   <div style="clear: both" *ngIf="!terminology">
     <mat-progress-bar
       value="50"
@@ -30,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
     <mdm-terminology-details
       *ngIf="terminology"
       [mcTerminology]="terminology"
-   ></mdm-terminology-details>
+    ></mdm-terminology-details>
 
     <div class="panel-body" *ngIf="showSearch">
       <h4 class="marginless">Find Terms</h4>


### PR DESCRIPTION
Required for Cypress tests to understand low level details of current item displayed, such as ID and domain type.