### PR TITLE
gh-401 Updated schema diagrams to have unique reference ids

### DIFF
--- a/src/app/diagram/services/umlclass-diagram.service.ts
+++ b/src/app/diagram/services/umlclass-diagram.service.ts
@@ -80,7 +80,7 @@ export class UmlClassDiagramService extends BasicDiagramService {
     });
     this.referenceLinks.forEach(subClassLink => {
       const link = new joint.shapes.standard.Link({
-        id: `${subClassLink.source}-${subClassLink.label}`,
+        id: `${subClassLink.source}-${subClassLink.name}`,
         source: { id: subClassLink.source },
         target: { id: subClassLink.target },
         attrs: {


### PR DESCRIPTION
gh-401 Data Model Schema diagrams only showed one reference link between data classes when there were mutlitple links between classses. 

Solution: Updated the diagram to use unique reference ids.  
Original ids were created from the link source id and and link label, but label was always null. 
New ids are craeted from the link soruce id and the link name.