### PR TITLE
#412 Fix refresh of federated models after subscribing to an external model

### DIFF
--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
@@ -102,8 +102,7 @@ export class FederatedDataModelMainComponent extends BaseComponent implements On
       'federateddatamodel',
       {
         parentId: this.catalogueId,
-        id: this.modelId,
-        dataModel: this.dataModel
+        id: this.modelId
       },
       {
         reload: true


### PR DESCRIPTION
After subscribing, the router would navigate back to the same page and pass the loaded model as a route parameter. Because no other navigation sites pass this parameter, it hung around for subsequent calls causing the page to not to load the correct selection from the model tree.

Fixes #412 