### PR TITLE
#419 Fix 40X HTTP issues when requesting newer versions of models in subscribed catalogues

### DIFF
--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.html
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.html
@@ -21,11 +21,12 @@ SPDX-License-Identifier: Apache-2.0
     </mdm-federated-data-model-detail>
     <mat-tab-group *ngIf="dataModel && catalogueId" #tab animationDuration="0ms" [selectedIndex]="activeTab"
         (selectedIndexChange)="tabSelected($event)">
-        <mat-tab label="Newer Versions">
+        <mat-tab *ngIf="showNewerVersionsTab" label="Newer Versions">
             <ng-template matTabContent>
               <mdm-newer-versions
                 [catalogueItem]="dataModel"
                 [catalogueId]="catalogueId"
+                (hasErrored)="onNewerVersionsHasErrored()"
               >
               </mdm-newer-versions>
             </ng-template>

--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
@@ -39,6 +39,7 @@ export class FederatedDataModelMainComponent extends BaseComponent implements On
   tabs = new TabCollection([
     'newVersion'
   ]);
+  showNewerVersionsTab = true;
 
   constructor(
     private uiRouterGlobals: UIRouterGlobals,
@@ -82,6 +83,10 @@ export class FederatedDataModelMainComponent extends BaseComponent implements On
     this.stateHandler.Go('dataModel', { tabView: tab.name }, { notify: false });
   }
 
+  onNewerVersionsHasErrored() {
+    this.showNewerVersionsTab = false;
+  }
+
   private getFederatedDataModel(reloadView?: boolean) {
     this.subscribedCatalogues
       .getFederatedDataModels(this.catalogueId)
@@ -94,8 +99,6 @@ export class FederatedDataModelMainComponent extends BaseComponent implements On
         },
         errors => this.messageHandler.showError('There was a problem getting the Federated Data Model', errors));
   }
-
-
 
   private reloadView() {
     this.stateHandler.Go(

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
@@ -16,111 +16,109 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<ng-container *ngIf="isLoadingResults || totalNewVersionCount > 0">
-  <div class="heading-container">
-    <h4 class="marginless">
-      <span>Newer Versions</span>
-      <span *ngIf="isLoadingResults" class="mdm--skeleton-badge">
-        <ngx-skeleton-loader
-          count="1"
-          appearance="circle"
-          [theme]="{
-            'border-radius': '5px',
-            height: '31px',
-            width: '28px',
-            'background-color': '#b7bbc5'
-          }"
-        >
-        </ngx-skeleton-loader>
-      </span>
-      <span
-        class="mdm--badge mdm--element-count"
-        *ngIf="!isLoadingResults && totalNewVersionCount"
-        >{{ totalNewVersionCount }}</span
+<div class="heading-container">
+  <h4 class="marginless">
+    <span>Newer Versions</span>
+    <span *ngIf="isLoadingResults" class="mdm--skeleton-badge">
+      <ngx-skeleton-loader
+        count="1"
+        appearance="circle"
+        [theme]="{
+          'border-radius': '5px',
+          height: '31px',
+          width: '28px',
+          'background-color': '#b7bbc5'
+        }"
       >
-    </h4>
-  </div>
-  <div class="table-responsive">
-    <table
-      mat-table
-      #tableDataElements
-      matSort
-      [dataSource]="newVersionsRecords"
-      class="mdm--mat-table table-striped"
+      </ngx-skeleton-loader>
+    </span>
+    <span
+      class="mdm--badge mdm--element-count"
+      *ngIf="!isLoadingResults && totalNewVersionCount"
+      >{{ totalNewVersionCount }}</span
     >
-      <ng-container matColumnDef="label">
-        <th
-          mat-header-cell
-          *matHeaderCellDef
-          mat-sort-header="label"
-          style="max-width: 35%; width: 35%"
-          columnName="label"
+  </h4>
+</div>
+<div class="table-responsive">
+  <table
+    mat-table
+    #tableDataElements
+    matSort
+    [dataSource]="newVersionsRecords"
+    class="mdm--mat-table table-striped"
+  >
+    <ng-container matColumnDef="label">
+      <th
+        mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header="label"
+        style="max-width: 35%; width: 35%"
+        columnName="label"
+      >
+        Label
+      </th>
+      <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
+        <div>
+          {{ record.label }}
+        </div>
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="version">
+      <th
+        mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header="version"
+        style="max-width: 45%; width: 45%"
+        columnName="version"
+      >
+        Version
+      </th>
+      <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
+        {{ record.version }}
+      </td>
+    </ng-container>
+    <ng-container matColumnDef="navigate">
+      <th
+        mat-header-cell
+        *matHeaderCellDef
+        mat-sort-header="version"
+        style="max-width: 5%; width: 5%"
+        columnName="navigate"
+      ></th>
+      <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
+        <button
+          type="button"
+          mat-icon-button
+          (click)="navigateToNewerVersion(record)"
+          style="position: relative; float: right; margin-right: 4px"
         >
-          Label
-        </th>
-        <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
-          <div>
-            {{ record.label }}
-          </div>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="version">
-        <th
-          mat-header-cell
-          *matHeaderCellDef
-          mat-sort-header="version"
-          style="max-width: 45%; width: 45%"
-          columnName="version"
-        >
-          Version
-        </th>
-        <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
-          {{ record.version }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="navigate">
-        <th
-          mat-header-cell
-          *matHeaderCellDef
-          mat-sort-header="version"
-          style="max-width: 5%; width: 5%"
-          columnName="navigate"
-        ></th>
-        <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
-          <button
-            type="button"
-            mat-icon-button
-            (click)="navigateToNewerVersion(record)"
-            style="position: relative; float: right; margin-right: 4px"
-          >
-            <i class="fas fa-external-link-alt"></i>
-          </button>
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: displayedColumns"
-        [ngClass]="{ 'mdm--active-row ': row.checked }"
-      ></tr>
-    </table>
-  </div>
+          <i class="fas fa-external-link-alt"></i>
+        </button>
+      </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr
+      mat-row
+      *matRowDef="let row; columns: displayedColumns"
+      [ngClass]="{ 'mdm--active-row ': row.checked }"
+    ></tr>
+  </table>
+</div>
 
-  <div
-    class="bordered is-hidden pxy-2"
-    [ngClass]="{ block: !totalNewVersionCount && !isLoadingResults }"
-  >
-    <p class="marginless">There are no Newer Versions in this repository.</p>
-  </div>
-  <div
-    class="mdm--mat-pagination"
-    [ngClass]="{
-      'is-hidden': !totalNewVersionCount || totalNewVersionCount < 6
-    }"
-  >
-    <mdm-paginator
-      [length]="totalNewVersionCount"
-      showFirstLastButtons
-    ></mdm-paginator>
-  </div>
-</ng-container>
+<div
+  class="bordered is-hidden pxy-2"
+  [ngClass]="{ block: !totalNewVersionCount && !isLoadingResults }"
+>
+  <p class="marginless">There are no Newer Versions in this repository.</p>
+</div>
+<div
+  class="mdm--mat-pagination"
+  [ngClass]="{
+    'is-hidden': !totalNewVersionCount || totalNewVersionCount < 6
+  }"
+>
+  <mdm-paginator
+    [length]="totalNewVersionCount"
+    showFirstLastButtons
+  ></mdm-paginator>
+</div>

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
@@ -16,80 +16,111 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<!--
-Copyright 2020-2021 University of Oxford
-and Health and Social Care Information Centre, also known as NHS Digital
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-SPDX-License-Identifier: Apache-2.0
--->
-<div class="heading-container">
+<ng-container *ngIf="isLoadingResults || totalNewVersionCount > 0">
+  <div class="heading-container">
     <h4 class="marginless">
-        <span>Newer Versions</span>
-        <span *ngIf="isLoadingResults" class="mdm--skeleton-badge">
-            <ngx-skeleton-loader count="1" appearance="circle"
-                [theme]="{'border-radius': '5px', 'height':'31px', 'width':'28px', 'background-color': '#b7bbc5'}">
-            </ngx-skeleton-loader>
-        </span>
-        <span class="mdm--badge mdm--element-count"
-            *ngIf="!isLoadingResults && totalNewVersionCount">{{totalNewVersionCount}}</span>
+      <span>Newer Versions</span>
+      <span *ngIf="isLoadingResults" class="mdm--skeleton-badge">
+        <ngx-skeleton-loader
+          count="1"
+          appearance="circle"
+          [theme]="{
+            'border-radius': '5px',
+            height: '31px',
+            width: '28px',
+            'background-color': '#b7bbc5'
+          }"
+        >
+        </ngx-skeleton-loader>
+      </span>
+      <span
+        class="mdm--badge mdm--element-count"
+        *ngIf="!isLoadingResults && totalNewVersionCount"
+        >{{ totalNewVersionCount }}</span
+      >
     </h4>
-
-</div>
-<div class="table-responsive">
-    <table mat-table #tableDataElements matSort [dataSource]="newVersionsRecords" class="mdm--mat-table table-striped">
-        <ng-container matColumnDef="label">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="label" style="max-width: 35%;width: 35%;"
-                columnName="label">
-                Label
-            </th>
-            <td mat-cell *matCellDef="let record" style="word-wrap: break-word;">
-                <div>
-                    {{record.label}}
-                </div>
-            </td>
-        </ng-container>
-        <ng-container matColumnDef="version">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="version" style="max-width: 45%;width: 45%;"
-                columnName="version">
-                Version
-            </th>
-            <td mat-cell *matCellDef="let record" style="word-wrap: break-word;">
-                {{record.version}}
-            </td>
-        </ng-container>
-        <ng-container matColumnDef="navigate">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="version" style="max-width: 5%;width: 5%;"
-                columnName="navigate">
-            
-            </th>
-            <td mat-cell *matCellDef="let record" style="word-wrap: break-word;">
-                <button type="button" mat-icon-button (click)="navigateToNewerVersion(record)"
-                    style="position: relative; float: right; margin-right: 4px">
-                    <i class="fas fa-external-link-alt"></i>
-                </button>
-            </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"
-            [ngClass]="{ 'mdm--active-row ' : row.checked }"></tr>
+  </div>
+  <div class="table-responsive">
+    <table
+      mat-table
+      #tableDataElements
+      matSort
+      [dataSource]="newVersionsRecords"
+      class="mdm--mat-table table-striped"
+    >
+      <ng-container matColumnDef="label">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header="label"
+          style="max-width: 35%; width: 35%"
+          columnName="label"
+        >
+          Label
+        </th>
+        <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
+          <div>
+            {{ record.label }}
+          </div>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="version">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header="version"
+          style="max-width: 45%; width: 45%"
+          columnName="version"
+        >
+          Version
+        </th>
+        <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
+          {{ record.version }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="navigate">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header="version"
+          style="max-width: 5%; width: 5%"
+          columnName="navigate"
+        ></th>
+        <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
+          <button
+            type="button"
+            mat-icon-button
+            (click)="navigateToNewerVersion(record)"
+            style="position: relative; float: right; margin-right: 4px"
+          >
+            <i class="fas fa-external-link-alt"></i>
+          </button>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr
+        mat-row
+        *matRowDef="let row; columns: displayedColumns"
+        [ngClass]="{ 'mdm--active-row ': row.checked }"
+      ></tr>
     </table>
-</div>
+  </div>
 
-<div class="bordered is-hidden pxy-2" [ngClass]="{'block':!totalNewVersionCount && !isLoadingResults}">
+  <div
+    class="bordered is-hidden pxy-2"
+    [ngClass]="{ block: !totalNewVersionCount && !isLoadingResults }"
+  >
     <p class="marginless">There are no Newer Versions in this repository.</p>
-</div>
-<div class="mdm--mat-pagination" [ngClass]="{'is-hidden':!totalNewVersionCount || totalNewVersionCount < 6}">
-    <mdm-paginator [length]="totalNewVersionCount" showFirstLastButtons></mdm-paginator>
-</div>
+  </div>
+  <div
+    class="mdm--mat-pagination"
+    [ngClass]="{
+      'is-hidden': !totalNewVersionCount || totalNewVersionCount < 6
+    }"
+  >
+    <mdm-paginator
+      [length]="totalNewVersionCount"
+      showFirstLastButtons
+    ></mdm-paginator>
+  </div>
+</ng-container>

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
@@ -69,15 +69,14 @@ export class NewerVersionsComponent implements AfterViewInit {
         catchError(() => {
           this.isLoadingResults = false;
           this.hasFailed = true;
+          this.hasErrored.emit();
           return [];
         })
       )
       .subscribe(data => {
         this.newVersionsRecords = data;
 
-        if (this.hasFailed) {
-          this.hasErrored.emit();
-        }
+
       });
   }
 

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { AfterViewInit, Component, Input, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { MatSort } from '@angular/material/sort';
 import { QueryParameters, Uuid } from '@maurodatamapper/mdm-resources';
 import { FederatedDataModel } from '@mdm/model/federated-data-model';
@@ -39,9 +39,12 @@ export class NewerVersionsComponent implements AfterViewInit {
   @Input('catalogueItem') catalogueItem: FederatedDataModel;
   @Input() catalogueId: Uuid;
 
+  @Output() hasErrored = new EventEmitter<void>();
+
   displayedColumns = ['label', 'version', 'navigate'];
 
   isLoadingResults: boolean;
+  hasFailed = false;
   totalNewVersionCount: number;
   newVersionsRecords: any;
 
@@ -65,11 +68,16 @@ export class NewerVersionsComponent implements AfterViewInit {
         }),
         catchError(() => {
           this.isLoadingResults = false;
+          this.hasFailed = true;
           return [];
         })
       )
       .subscribe(data => {
         this.newVersionsRecords = data;
+
+        if (this.hasFailed) {
+          this.hasErrored.emit();
+        }
       });
   }
 

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
@@ -21,9 +21,9 @@ import { MatSort } from '@angular/material/sort';
 import { QueryParameters, Uuid } from '@maurodatamapper/mdm-resources';
 import { FederatedDataModel } from '@mdm/model/federated-data-model';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { GridService, MessageHandlerService, StateHandlerService } from '@mdm/services';
+import { GridService, StateHandlerService } from '@mdm/services';
 import { MdmPaginatorComponent } from '@mdm/shared/mdm-paginator/mdm-paginator';
-import { EMPTY, merge } from 'rxjs';
+import { merge } from 'rxjs';
 import { catchError, map, startWith, switchMap } from 'rxjs/operators';
 
 @Component({
@@ -45,25 +45,31 @@ export class NewerVersionsComponent implements AfterViewInit {
   totalNewVersionCount: number;
   newVersionsRecords: any;
 
-  constructor(private resouces: MdmResourcesService, private messagingServer: MessageHandlerService, private gridService: GridService, private stateHandler: StateHandlerService) { }
+  constructor(
+    private resouces: MdmResourcesService,
+    private gridService: GridService,
+    private stateHandler: StateHandlerService) { }
 
   ngAfterViewInit(): void {
-    merge(this.sort.sortChange, this.paginator.page).pipe(startWith({}), switchMap(() => {
-      this.isLoadingResults = true;
-      return this.fetchNewerVersions(this.paginator.pageSize, this.paginator.pageOffset, this.sort.active, this.sort.direction);
-    }),
-      map((data: any) => {
-        this.totalNewVersionCount = data.body.newerPublishedModels.length;
-        this.isLoadingResults = false;
-        return data.body.newerPublishedModels;
-
-      }),
-      catchError(() => {
-        this.isLoadingResults = false;
-        return [];
-      })).subscribe(data => {
+    merge(this.sort.sortChange, this.paginator.page)
+      .pipe(
+        startWith({}),
+        switchMap(() => {
+          this.isLoadingResults = true;
+          return this.fetchNewerVersions(this.paginator.pageSize, this.paginator.pageOffset, this.sort.active, this.sort.direction);
+        }),
+        map((data: any) => {
+          this.totalNewVersionCount = data.body.newerPublishedModels.length;
+          this.isLoadingResults = false;
+          return data.body.newerPublishedModels;
+        }),
+        catchError(() => {
+          this.isLoadingResults = false;
+          return [];
+        })
+      )
+      .subscribe(data => {
         this.newVersionsRecords = data;
-
       });
   }
 
@@ -76,12 +82,7 @@ export class NewerVersionsComponent implements AfterViewInit {
         this.catalogueId,
         this.catalogueItem.modelId,
         {},
-        { handleGetErrors: false })
-      .pipe(
-        catchError(error => {
-          this.messagingServer.showError(error);
-          return EMPTY;
-        }));
+        { handleGetErrors: false });
   }
 
   navigateToNewerVersion(record: FederatedDataModel) {

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
@@ -33,13 +33,13 @@ import { catchError, map, startWith, switchMap } from 'rxjs/operators';
 })
 export class NewerVersionsComponent implements AfterViewInit {
 
-  @ViewChild(MdmPaginatorComponent, {static:false}) paginator : MdmPaginatorComponent;
+  @ViewChild(MdmPaginatorComponent, { static: false }) paginator: MdmPaginatorComponent;
   @ViewChild(MatSort, { static: false }) sort: MatSort;
 
   @Input('catalogueItem') catalogueItem: FederatedDataModel;
   @Input() catalogueId: Uuid;
 
-  displayedColumns = ['label','version','navigate'];
+  displayedColumns = ['label', 'version', 'navigate'];
 
   isLoadingResults: boolean;
   totalNewVersionCount: number;
@@ -67,19 +67,25 @@ export class NewerVersionsComponent implements AfterViewInit {
       });
   }
 
-  fetchNewerVersions(pageSize? : number, pageIndex? : number, sortBy? : string, sortType? :string) {
+  fetchNewerVersions(pageSize?: number, pageIndex?: number, sortBy?: string, sortType?: string) {
     // Future proofing to enable paging if number of versions increases
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const options : QueryParameters = this.gridService.constructOptions(pageSize, pageIndex, sortBy, sortType);
-    return this.resouces.subscribedCatalogues.newerVersions(this.catalogueId, this.catalogueItem.modelId).pipe(catchError(error => {
-      this.messagingServer.showError(error);
-      return EMPTY;
-    }));
+    const options: QueryParameters = this.gridService.constructOptions(pageSize, pageIndex, sortBy, sortType);
+    return this.resouces.subscribedCatalogues
+      .newerVersions(
+        this.catalogueId,
+        this.catalogueItem.modelId,
+        {},
+        { handleGetErrors: false })
+      .pipe(
+        catchError(error => {
+          this.messagingServer.showError(error);
+          return EMPTY;
+        }));
   }
 
-  navigateToNewerVersion(record: FederatedDataModel)
-  {
-    this.stateHandler.Go('appContainer.mainApp.twoSidePanel.catalogue.federatedDataModel', {parentId:this.catalogueId, id:record.modelId});
+  navigateToNewerVersion(record: FederatedDataModel) {
+    this.stateHandler.Go('appContainer.mainApp.twoSidePanel.catalogue.federatedDataModel', { parentId: this.catalogueId, id: record.modelId });
   }
 
 }


### PR DESCRIPTION
If the API is not present in older instances, the UI will ignore.

Fixes #419 