### PR TITLE
gh-413 Fix to Data Elements sort

### DIFF
--- a/src/app/shared/data-elements-list/data-elements-list.component.ts
+++ b/src/app/shared/data-elements-list/data-elements-list.component.ts
@@ -116,9 +116,9 @@ export class DataElementsListComponent implements AfterViewInit {
       )
       .subscribe((data) => {
         this.dataElementRecords = data;
+        this.isLoadingResults = false;
       });
-
-    this.changeRef.detectChanges();
+      this.changeRef.detectChanges();
   }
 
   openEdit(dataClass: DataClass) {
@@ -223,7 +223,6 @@ export class DataElementsListComponent implements AfterViewInit {
     sortType?,
     filters?
   ): Observable<any> {
-    sortBy = 'idx';
     const options = this.gridService.constructOptions(
       pageSize,
       pageIndex,


### PR DESCRIPTION
gh-413 Removed hard-coded sort by idx for Data Elements, as it was overriding the sortBy parameter in the method. 