### PR TITLE
gh-438 Use the dataModelId when listing Data Types on a Data Model

### DIFF
--- a/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.ts
+++ b/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.ts
@@ -298,7 +298,7 @@ export class DataElementStep2Component implements OnInit, AfterViewInit, OnDestr
       delete options['label'];
     }
 
-    return this.resources.dataType.list(this.model.parent.id, options);
+    return this.resources.dataType.list(this.model.parentDataModel.id, options);
   };
 
   onTargetSelect = (selectedValue) => {


### PR DESCRIPTION
Closes #438 by reverting a change made in the previous commit.

The Data Class ID, rather than Data Model ID, was erroneously being used when listing Data Types on a Data Model.