### PR TITLE
gh-440 use modelId rather than model

### DIFF
--- a/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.ts
+++ b/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.ts
@@ -126,7 +126,7 @@ export class DataElementStep2Component implements OnInit, AfterViewInit, OnDestr
   dataElementsFetch(pageSize, pageIndex, sortBy, sortType, filters) {
     const options = this.gridService.constructOptions(pageSize, pageIndex, sortBy, sortType, filters);
     const dataClass : DataClass = this.model.copyFromDataClass[0];
-    return this.resources.dataElement.list(dataClass.model, dataClass.id, options);
+    return this.resources.dataElement.list(dataClass.modelId, dataClass.id, options);
   }
 
   onLoad() {


### PR DESCRIPTION
Closes #440 by reverting a previous change.

The Data Model ID was not being used when listing Data Elements.