### PR TITLE
Remove validation constraints on codeset creation (Fixes #429)

### DIFF
--- a/src/app/wizards/codeSet/code-set-main/code-set-main.component.html
+++ b/src/app/wizards/codeSet/code-set-main/code-set-main.component.html
@@ -39,20 +39,14 @@ SPDX-License-Identifier: Apache-2.0
     <div class="mdm--form-input">
         <mat-form-field appearance="outline" class="full-width">
             <mat-label>Author</mat-label>
-            <input matInput type="text" formControlName="author" name="author" required>
-            <mat-error *ngIf="setupForm && author.errors?.required">
-              Author is required
-            </mat-error>
+            <input matInput type="text" formControlName="author" name="author">
         </mat-form-field>
     </div>
 
     <div class="mdm--form-input">
         <mat-form-field appearance="outline" class="full-width">
             <mat-label>Organisation</mat-label>
-            <input matInput type="text" formControlName="organisation" name="organisation" required>
-            <mat-error *ngIf="setupForm && organisation.errors?.required">
-              Organisation is required
-            </mat-error>
+            <input matInput type="text" formControlName="organisation" name="organisation">
         </mat-form-field>
     </div>
 

--- a/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
+++ b/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
@@ -85,11 +85,11 @@ export class CodeSetMainComponent implements OnInit {
 
     this.setupForm = new FormGroup({
       label: new FormControl('', Validators.required),  // eslint-disable-line @typescript-eslint/unbound-method
-      author: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-      organisation: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+      author: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
+      organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
       description: new FormControl(''),
       classifiers: new FormControl([]),
-      terms: new FormControl([], Validators.required) // eslint-disable-line @typescript-eslint/unbound-method
+      terms: new FormControl([]) // eslint-disable-line @typescript-eslint/unbound-method
     });
 
     this.parentFolderId = this.uiRouterGlobals.params.parentFolderId;


### PR DESCRIPTION
Remove the constraint that a codeset must have at least one term.  Also remove requirement for author and organisation to be completed