### PR TITLE
Resolves #316 by removing the unnecessary lines and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ $ git clone git@github.com:MauroDataMapper/mdm-ui.git
 # This will use the `.nvmrc` file to install the node versions we need and update to the latest version of npm
 $ nvm install --latest-npm
 
-# Install Angular CLI
-$ npm i @angular/cli
+# Install Angular CLI globally
+$ npm install -g @angular/cli
 
 # Install the code dependencies
 $ npm install

--- a/angular.json
+++ b/angular.json
@@ -41,12 +41,9 @@
               }
             ],
             "styles": [
-              "src/styles.scss",
-              "node_modules/jodit/build/jodit.min.css"
+              "src/styles.scss"
             ],
-            "scripts": [
-              "node_modules/jodit/build/jodit.min.js"
-            ],
+            "scripts": [],
             "stylePreprocessorOptions": {
               "includePaths": [
                 "src/style",


### PR DESCRIPTION
App function was tested with and without the jodit references in angular.json. Proper functionality was present in both cases. 

The only notable difference was that including the references resulted in the jodit stylesheet being loaded from the get go (home page), whereas without the references it was added dynamically upon first opening an editor that uses jodit. 

Update README.md to include a global flag during installation of angular/cli. This is because global installations are generally preferred when the package offers additional command line functionality. 