### PR TITLE
Feature/gh 466

### DIFF
--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -584,9 +584,10 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
 
     if (fnode.domainType === CatalogueItemDomainType.DataClass) {
       parameters.dataModelId = fnode.modelId;
+        parameters.dataClassId = fnode.node.parentId || "";
     }
 
-    this.stateHandler.NewWindow(fnode.domainType.toLocaleLowerCase(), { id: fnode.id });
+    this.stateHandler.NewWindow(fnode.domainType.toLocaleLowerCase(), parameters);
   }
 
   isFavourited(fnode: FlatNode) {

--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -584,7 +584,7 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
 
     if (fnode.domainType === CatalogueItemDomainType.DataClass) {
       parameters.dataModelId = fnode.modelId;
-        parameters.dataClassId = fnode.node.parentId || "";
+        parameters.dataClassId = fnode.node.parentId || '';
     }
 
     this.stateHandler.NewWindow(fnode.domainType.toLocaleLowerCase(), parameters);


### PR DESCRIPTION
Url routing parameter dataClassId was not being extracted from the fnode, and the dataModelId was not being passed into the url matching anyway.
There was another bug which has also been fixed by this:
Expand a folder (folder 1) and another folder (folder 2)
Click on a data class in folder 2 so that it's shown in the right hand pane; then right click on a data class in folder 1 and click View => Open in new window. The result will be "not found".