### PR TITLE
Change requests to get administrator status of user

### DIFF
--- a/src/app/admin/app-container/app-container.component.html
+++ b/src/app/admin/app-container/app-container.component.html
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
                 </li>
             </ul>
 
-            <ul class="menu-list" *ngIf="isAdmin">
+            <ul class="menu-list" *ngIf="isAdministrator">
                 <p class="marginless pl-2 text-muted">Admin settings</p>
                 <li>
                     <a role="menuitem" uiSref="appContainer.adminArea.home" uiSrefActive="active">

--- a/src/app/admin/app-container/app-container.component.ts
+++ b/src/app/admin/app-container/app-container.component.ts
@@ -29,6 +29,7 @@ import { takeUntil } from 'rxjs/operators';
   styleUrls: ['./app-container.component.sass']
 })
 export class AdminAppContainerComponent implements OnInit, OnDestroy {
+  isAdministrator = false;
   pendingUsersCount = 0;
   features = this.sharedService.features;
 
@@ -40,23 +41,27 @@ export class AdminAppContainerComponent implements OnInit, OnDestroy {
     private broadcast: BroadcastService) {}
 
   ngOnInit() {
-    if (this.isAdmin()) {
-      this.getPendingUsers();
-      this.broadcast
-        .on('pendingUserUpdated')
-        .pipe(takeUntil(this.unsubscribe$))
-        .subscribe(() => this.getPendingUsers());
-    }
+    this.securityHandler
+      .isAdministrator()
+      .subscribe(isAdministrator => {
+        this.isAdministrator = isAdministrator;
+
+        if (!isAdministrator) {
+          return;
+        }
+
+        this.getPendingUsers();
+        this.broadcast
+          .on('pendingUserUpdated')
+          .pipe(takeUntil(this.unsubscribe$))
+          .subscribe(() => this.getPendingUsers());
+      })
   }
 
   ngOnDestroy(): void {
     this.unsubscribe$.next();
     this.unsubscribe$.complete();
   }
-
-  isAdmin = () => {
-    return this.securityHandler.isAdmin();
-  };
 
   getPendingUsers = () => {
     this.sharedService.pendingUsersCount().subscribe(data => {

--- a/src/app/admin/app-container/app-container.component.ts
+++ b/src/app/admin/app-container/app-container.component.ts
@@ -55,7 +55,7 @@ export class AdminAppContainerComponent implements OnInit, OnDestroy {
           .on('pendingUserUpdated')
           .pipe(takeUntil(this.unsubscribe$))
           .subscribe(() => this.getPendingUsers());
-      })
+      });
   }
 
   ngOnDestroy(): void {

--- a/src/app/admin/model-management/model-management.component.ts
+++ b/src/app/admin/model-management/model-management.component.ts
@@ -38,6 +38,7 @@ export class ModelManagementComponent implements OnInit {
   deleteInProgress = false;
   deleteSuccessMessage: string;
   folders: any;
+  isAdministrator = false;
 
   constructor(
     private resourcesService: MdmResourcesService,
@@ -54,6 +55,8 @@ export class ModelManagementComponent implements OnInit {
     this.filterElement = '';
     this.loadFolders();
     this.title.setTitle('Model management');
+
+    this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
   }
 
   onFilterChange = () => {
@@ -137,7 +140,7 @@ export class ModelManagementComponent implements OnInit {
   };
 
   askForPermanentDelete() {
-    if (!this.securityHandler.isAdmin()) {
+    if (!this.isAdministrator) {
       this.messageHandler.showError('Only Admins are allowed to delete records!');
       return;
     }
@@ -209,7 +212,7 @@ export class ModelManagementComponent implements OnInit {
   }
 
   askForSoftDelete() {
-    if (!this.securityHandler.isAdmin()) {
+    if (!this.isAdministrator) {
       this.messageHandler.showError('Only Admins are allowed to delete records!');
       return;
     }

--- a/src/app/app-container/app-container.component.ts
+++ b/src/app/app-container/app-container.component.ts
@@ -17,30 +17,10 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component } from '@angular/core';
-import { SecurityHandlerService } from '../services/handlers/security-handler.service';
-import { SharedService } from '../services/shared.service';
 
 @Component({
   selector: 'mdm-app-container',
   templateUrl: './app-container.component.html',
   styleUrls: ['./app-container.component.sass']
 })
-export class AppContainerComponent {
-  constructor(
-    private securityHandler: SecurityHandlerService,
-    private sharedService: SharedService
-  ) {}
-
-
-  isLoggedOn = () => {
-    return this.securityHandler.isLoggedIn();
-  };
-
-  isAdminUser = () => {
-    return this.sharedService.isAdminUser();
-  };
-
-  logout = () => {
-    return this.sharedService.logout();
-  };
-}
+export class AppContainerComponent { }

--- a/src/app/classification/classification-details/classification-details.component.ts
+++ b/src/app/classification/classification-details/classification-details.component.ts
@@ -91,7 +91,7 @@ export class ClassificationDetailsComponent implements OnInit {
   }
 
   askForSoftDelete() {
-    if (!this.securityHandler.isAdmin()) {
+    if (!this.access.showSoftDelete) {
       return;
     }
 

--- a/src/app/code-set/code-set-details/code-set-details.component.html
+++ b/src/app/code-set/code-set-details/code-set-details.component.html
@@ -78,7 +78,7 @@ SPDX-License-Identifier: Apache-2.0
             type="button"
             data-cy="restore"
             class="has-text-green"
-            *ngIf="codeSetDetail.deleted && isAdminUser"
+            *ngIf="codeSetDetail.deleted && isAdministrator"
             (click)="restore()"
           >
             <i class="fas fa-trash-restore has-text-green"></i> Restore

--- a/src/app/code-set/code-set-details/code-set-details.component.ts
+++ b/src/app/code-set/code-set-details/code-set-details.component.ts
@@ -52,7 +52,7 @@ export class CodeSetDetailsComponent implements OnInit {
   editMode = false;
   originalCodeSetDetail: CodeSetDetail;
   showSecuritySection: boolean;
-  isAdminUser: boolean;
+  isAdministrator = false;
   deleteInProgress: boolean;
   processing = false;
   access: Access;
@@ -69,9 +69,7 @@ export class CodeSetDetailsComponent implements OnInit {
     private dialog: MatDialog,
     private title: Title,
     private editingService: EditingService
-  ) {
-    this.isAdminUser = this.sharedService.isAdmin;
-  }
+  ) { }
 
   public showAddElementToMarkdown() {
     // Remove from here & put in markdown
@@ -79,6 +77,7 @@ export class CodeSetDetailsComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
     this.codeSetDetails();
     this.originalCodeSetDetail = Object.assign({}, this.codeSetDetail);
   }
@@ -175,7 +174,7 @@ export class CodeSetDetailsComponent implements OnInit {
   }
 
   restore() {
-    if (!this.isAdminUser || !this.codeSetDetail.deleted) {
+    if (!this.isAdministrator || !this.codeSetDetail.deleted) {
       return;
     }
 

--- a/src/app/data-type/data-type-detail/data-type-detail.component.ts
+++ b/src/app/data-type/data-type-detail/data-type-detail.component.ts
@@ -106,7 +106,7 @@ export class DataTypeDetailComponent implements OnInit {
   };
 
   askToDelete(){
-    if (!this.sharedService.isAdminUser()) {
+    if (!this.access.showDelete) {
       return;
     }
 

--- a/src/app/dataClass/data-class-details/data-class-details.component.ts
+++ b/src/app/dataClass/data-class-details/data-class-details.component.ts
@@ -221,9 +221,4 @@ export class DataClassDetailsComponent implements OnInit {
     this.editMode = false;
     this.editingService.stop();
   }
-
-
-  isAdmin() {
-    return this.securityHandler.isAdmin();
-  }
 }

--- a/src/app/dataModel/data-model-detail.component.html
+++ b/src/app/dataModel/data-model-detail.component.html
@@ -74,7 +74,7 @@ SPDX-License-Identifier: Apache-2.0
             data-cy="compare"
             type="button"
             [matMenuTriggerFor]="compareMenu"
-            *ngIf="isAdminUser"
+            *ngIf="isAdministrator"
           >
             <i class="fas fa-balance-scale-right" aria-hidden="true"></i>
             Compare
@@ -111,7 +111,7 @@ SPDX-License-Identifier: Apache-2.0
             data-cy="restore"
             type="button"
             class="has-text-green"
-            *ngIf="dataModel.deleted && isAdminUser"
+            *ngIf="dataModel.deleted && isAdministrator"
             (click)="restore()"
           >
             <i class="fas fa-trash-restore has-text-green"></i> Restore

--- a/src/app/dataModel/data-model-detail.component.ts
+++ b/src/app/dataModel/data-model-detail.component.ts
@@ -59,7 +59,7 @@ export class DataModelDetailComponent implements OnInit {
   @Input() dataModel: DataModelDetail;
   originalDataModel: DataModelDetail;
   editMode = false;
-  isAdminUser: boolean;
+  isAdministrator = false;
   isLoggedIn: boolean;
   deleteInProgress: boolean;
   exporting: boolean;
@@ -81,13 +81,11 @@ export class DataModelDetailComponent implements OnInit {
     private exportHandler: ExportHandlerService,
     private title: Title,
     private editingService: EditingService,
-    private validatorService: ValidatorService,
-    private mergeDiffService: MergeDiffAdapterService
-  ) { }
+    private validatorService: ValidatorService  ) { }
 
   ngOnInit() {
-    this.isAdminUser = this.sharedService.isAdmin;
     this.isLoggedIn = this.securityHandler.isLoggedIn();
+    this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
     this.loadExporterList();
     this.dataModelDetails();
     this.access = this.securityHandler.elementAccess(this.dataModel);
@@ -204,7 +202,7 @@ export class DataModelDetailComponent implements OnInit {
   }
 
   restore() {
-    if (!this.isAdminUser || !this.dataModel.deleted) {
+    if (!this.isAdministrator || !this.dataModel.deleted) {
       return;
     }
 

--- a/src/app/dataModel/data-model-detail.component.ts
+++ b/src/app/dataModel/data-model-detail.component.ts
@@ -46,7 +46,6 @@ import {
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 import { ValidatorService } from '@mdm/services';
 import { Access } from '@mdm/model/access';
-import { MergeDiffAdapterService } from '@mdm/merge-diff/merge-diff-adapter/merge-diff-adapter.service';
 import { VersioningGraphModalConfiguration } from '@mdm/modals/versioning-graph-modal/versioning-graph-modal.model';
 
 @Component({

--- a/src/app/folder/folder-detail.component.ts
+++ b/src/app/folder/folder-detail.component.ts
@@ -47,7 +47,6 @@ export class FolderDetailComponent implements OnInit {
   originalFolder: FolderDetail;
 
   editMode = false;
-  isAdminUser: boolean;
   isLoggedIn: boolean;
   deleteInProgress: boolean;
   showEditMode = false;
@@ -68,7 +67,6 @@ export class FolderDetailComponent implements OnInit {
     private title: Title,
     private editingService: EditingService,
     private dialog: MatDialog) {
-    this.isAdminUser = this.sharedService.isAdmin;
     this.isLoggedIn = this.securityHandler.isLoggedIn();
   }
 

--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -594,10 +594,6 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
     return this.favouriteHandler.isAdded(fnode);
   }
 
-  get isUserAdmin() {
-    return this.securityHandler.isAdmin();
-  }
-
   isNodeFinalised(node: FlatNode) {
     return node.finalised;
   }

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -43,7 +43,7 @@ SPDX-License-Identifier: Apache-2.0
                             </div>
                             <div fxFlex="60" fxFlex.sm="100" fxFlex.xs="100">
                                 <div class="profile-name">{{profile.firstName}} {{profile.lastName}}</div>
-                                <div class="profile-role" *ngIf="profile.isAdmin">Administrator</div>
+                                <div class="profile-role" *ngIf="isAdministrator">Administrator</div>
                             </div>
                             <div fxFlex="10" fxFlex.sm="100" fxFlex.xs="100">
                                 <i class="fas fa-chevron-down"></i>
@@ -69,7 +69,7 @@ SPDX-License-Identifier: Apache-2.0
                                   <span>API keys</span>
                                 </a>
                             </div>
-                            <div *ngIf="isAdmin()">
+                            <div *ngIf="isAdministrator">
                                 <h5 class="marginless text-muted menu-label">Admin settings</h5>
                                 <a mat-menu-item uiSref="appContainer.adminArea.home">
                                     <i class="fas fa-tachometer-alt"></i>
@@ -182,7 +182,7 @@ SPDX-License-Identifier: Apache-2.0
                   <span>API keys</span>
                 </a>
             </div>
-            <div *ngIf="isLoggedIn && isAdmin()">
+            <div *ngIf="isLoggedIn && isAdministrator">
                 <h5 class="menu-label text-muted pt-0 marginless">Admin settings</h5>
                 <a mat-menu-item uiSref="appContainer.adminArea.home" (click)="sidenav.toggle()" uiSrefActive="active">
                     <i class="fas fa-tachometer-alt"></i>

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -49,7 +49,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
   HDFLink: any;
   sideNav: any;
   pendingUsersCount = 0;
-  isLoggedIn = this.securityHandler.isLoggedIn();
+  isLoggedIn = false;
+  isAdministrator = false;
   features = this.sharedService.features;
 
   private unsubscribe$ = new Subject();
@@ -68,18 +69,24 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.broadcast
       .onUserLoggedIn()
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => this.isLoggedIn = true);
+      .subscribe(() => {
+        this.isLoggedIn = true;
+        this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
+      });
 
     this.broadcast
       .onUserLoggedOut()
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(() => this.isLoggedIn = false);
+      .subscribe(() => {
+        this.isLoggedIn = false;
+        this.isAdministrator = false;
+      });
+
+    this.isLoggedIn = this.securityHandler.isLoggedIn();
+    this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
 
     if (this.isLoggedIn) {
       this.profile = this.securityHandler.getCurrentUser();
-      // if (this.isAdmin()) {
-      //   this.getPendingUsers();
-      // }
     }
     this.backendURL = this.sharedService.backendURL;
 
@@ -139,11 +146,6 @@ export class NavbarComponent implements OnInit, OnDestroy {
       this.pendingUsersCount = data.body.count;
     });
   };
-
-  isAdmin = () => {
-    return this.securityHandler.isAdmin();
-  };
-
 
   login = () => {
     this.dialog.open(LoginModalComponent, {}).afterClosed().subscribe((user) => {

--- a/src/app/referenceData/reference-data-details/reference-data-details.component.html
+++ b/src/app/referenceData/reference-data-details/reference-data-details.component.html
@@ -64,7 +64,7 @@ SPDX-License-Identifier: Apache-2.0
             type="button"
             data-cy="compare"
             [matMenuTriggerFor]="compareMenu"
-            *ngIf="isAdminUser"
+            *ngIf="isAdministrator"
           >
             <i class="fas fa-balance-scale-right" aria-hidden="true"></i>
             Compare
@@ -88,7 +88,7 @@ SPDX-License-Identifier: Apache-2.0
             type="button"
             data-cy="restore"
             class="has-text-green"
-            *ngIf="refDataModel.deleted && isAdminUser"
+            *ngIf="refDataModel.deleted && isAdministrator"
             (click)="restore()"
           >
             <i class="fas fa-trash-restore has-text-green"></i> Restore

--- a/src/app/referenceData/reference-data-details/reference-data-details.component.ts
+++ b/src/app/referenceData/reference-data-details/reference-data-details.component.ts
@@ -53,8 +53,8 @@ export class ReferenceDataDetailsComponent implements OnInit {
   @Input() refDataModel: ReferenceDataModelDetail;
   originalRefDataModel: ReferenceDataModelDetail;
   showEdit = false;
-  isAdminUser: boolean;
   isLoggedIn: boolean;
+  isAdministrator = false;
   deleteInProgress: boolean;
   exporting: boolean;
   errorMessage = '';
@@ -80,8 +80,8 @@ export class ReferenceDataDetailsComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.isAdminUser = this.sharedService.isAdmin;
     this.isLoggedIn = this.securityHandler.isLoggedIn();
+    this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
     this.loadExporterList();
     this.ReferenceModelDetails();
     this.originalRefDataModel = Object.assign({}, this.refDataModel);
@@ -111,7 +111,7 @@ export class ReferenceDataDetailsComponent implements OnInit {
   }
 
   restore() {
-    if (!this.isAdminUser || !this.refDataModel.deleted) {
+    if (!this.isAdministrator || !this.refDataModel.deleted) {
       return;
     }
 

--- a/src/app/services/handlers/security-handler.model.ts
+++ b/src/app/services/handlers/security-handler.model.ts
@@ -77,6 +77,5 @@ export interface UserDetails {
   userName: string;
   email: string;
   role?: string;
-  isAdmin?: boolean;
   needsToResetPassword?: boolean;
 }

--- a/src/app/services/handlers/security-handler.service.spec.ts
+++ b/src/app/services/handlers/security-handler.service.spec.ts
@@ -80,9 +80,9 @@ describe('SecurityHandlerService', () => {
   });
 
   it.each([
-    ['123', 'user@test.com', false],
-    ['456', 'admin@test.com', true]
-  ])('should sign in user %s %s when admin = %o', (id, userName, isAdmin) => {
+    ['123', 'user@test.com'],
+    ['456', 'admin@test.com']
+  ])('should sign in user %s %s', (id, userName) => {
     const credentials: LoginPayload = { username: userName, password: 'test' };
     const expectedUser: UserDetails = {
       id,
@@ -90,7 +90,6 @@ describe('SecurityHandlerService', () => {
       email: userName,
       firstName: 'first',
       lastName: 'last',
-      isAdmin,
       needsToResetPassword: false,
       role: '',
       token: undefined
@@ -105,17 +104,9 @@ describe('SecurityHandlerService', () => {
           lastName: expectedUser.lastName
         }
       }
-    }));
+  }));
 
-    resourcesStub.session.isApplicationAdministration.mockImplementationOnce(() => cold('--a|', {
-      a: {
-        body: {
-          applicationAdministrationSession: expectedUser.isAdmin
-        }
-      }
-    }));
-
-    const expected$ = cold('----a|', { a: expectedUser });
+    const expected$ = cold('--a|', { a: expectedUser });
     const actual$ = service.signIn(credentials);
 
     expect(actual$).toBeObservable(expected$);

--- a/src/app/services/handlers/security-handler.service.ts
+++ b/src/app/services/handlers/security-handler.service.ts
@@ -368,7 +368,7 @@ export class SecurityHandlerService {
   }
 
   private addAdministratorStateToLocalStorage(state: boolean) {
-    localStorage.setItem('isAdmin', String(state))
+    localStorage.setItem('isAdmin', String(state));
   }
 
   private getAdministratorStateFromLocalStorage(): boolean | undefined {

--- a/src/app/services/handlers/security-handler.service.ts
+++ b/src/app/services/handlers/security-handler.service.ts
@@ -29,7 +29,7 @@ import {
 } from './security-handler.model';
 import { Observable, of, throwError } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
-import { catchError, map, switchMap } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import {
   AdminSessionResponse,
   AuthenticatedResponse,
@@ -67,6 +67,7 @@ export class SecurityHandlerService {
     localStorage.removeItem('needsToResetPassword');
     localStorage.removeItem('email');
     localStorage.removeItem('userSettings');
+    localStorage.removeItem('isAdmin');
   }
 
   getUserFromLocalStorage(): UserDetails | null {
@@ -85,8 +86,7 @@ export class SecurityHandlerService {
       role: localStorage.getItem('role'),
       needsToResetPassword: Boolean(
         localStorage.getItem('needsToResetPassword')
-      ),
-      isAdmin: JSON.parse(localStorage.getItem('isAdmin'))
+      )
     };
   }
 
@@ -114,8 +114,6 @@ export class SecurityHandlerService {
       JSON.stringify({ username: user.username, expiry: expireDate })
     );
     localStorage.setItem('userId', user.id);
-    localStorage.setItem('isAdmin', user.isAdmin);
-
     localStorage.setItem(
       'email',
       JSON.stringify({ email: user.username, expiry: expireDate })
@@ -138,27 +136,21 @@ export class SecurityHandlerService {
       catchError((error: HttpErrorResponse) =>
         throwError(new SignInError(error))
       ),
-      switchMap((signInResponse: LoginResponse) =>
-        this.resources.session.isApplicationAdministration().pipe(
-          map((adminResponse: AdminSessionResponse) => {
-            const signIn = signInResponse.body;
-            const admin = adminResponse.body;
-            const user: UserDetails = {
-              id: signIn.id,
-              token: signIn.token,
-              firstName: signIn.firstName,
-              lastName: signIn.lastName,
-              email: signIn.emailAddress,
-              userName: signIn.emailAddress,
-              role: signIn.userRole?.toLowerCase() ?? '',
-              isAdmin: admin.applicationAdministrationSession ?? false,
-              needsToResetPassword: signIn.needsToResetPassword ?? false
-            };
-            this.addToLocalStorage(user);
-            return user;
-          })
-        )
-      )
+      map((response: LoginResponse) => {
+        const signIn = response.body;
+        const user: UserDetails = {
+          id: signIn.id,
+          token: signIn.token,
+          firstName: signIn.firstName,
+          lastName: signIn.lastName,
+          email: signIn.emailAddress,
+          userName: signIn.emailAddress,
+          role: signIn.userRole?.toLowerCase() ?? '',
+          needsToResetPassword: signIn.needsToResetPassword ?? false
+        };
+        this.addToLocalStorage(user);
+        return user;
+      })
     );
   }
 
@@ -245,11 +237,26 @@ export class SecurityHandlerService {
     return !!this.getUserFromLocalStorage();
   }
 
-  isAdmin() {
-    if (this.getCurrentUser()) {
-      return this.getCurrentUser().isAdmin;
+  isAdministrator(): Observable<boolean> {
+    if (!this.isLoggedIn()) {
+      return of(false);
     }
-    return false;
+
+    // Attempt to fetch from local storage first to avoid multiple network calls
+    const localState = this.getAdministratorStateFromLocalStorage();
+    if (localState !== undefined) {
+      return of(localState);
+    }
+
+    return this.resources.session
+      .isApplicationAdministration()
+      .pipe(
+        map((response: AdminSessionResponse) => {
+          const state = response.body.applicationAdministrationSession;
+          this.addAdministratorStateToLocalStorage(state);
+          return state;
+        })
+      );
   }
 
   getCurrentUser(): UserDetails | null {
@@ -313,7 +320,7 @@ export class SecurityHandlerService {
       showEdit: element.availableActions?.includes('update'),
       canEditDescription: element.availableActions?.includes('editDescription'),
       showFinalise: element.availableActions?.includes('finalise'),
-      showPermission: element.availableActions?.includes('update') || this.isAdmin(),
+      showPermission: element.availableActions?.includes('update'),
       showSoftDelete: element.availableActions?.includes('softDelete'),
       showPermanentDelete: element.availableActions?.includes('delete'),
       canAddAnnotation: element.availableActions?.includes('comment'),
@@ -358,5 +365,14 @@ export class SecurityHandlerService {
     const authorizationUrl = '/redirects/open-id-connect-redirect.html';
     const baseUrl = window.location.href.slice(0, window.location.href.indexOf('/#/'));
     return new URL(baseUrl + authorizationUrl);
+  }
+
+  private addAdministratorStateToLocalStorage(state: boolean) {
+    localStorage.setItem('isAdmin', String(state))
+  }
+
+  private getAdministratorStateFromLocalStorage(): boolean | undefined {
+    const state = localStorage.getItem('isAdmin');
+    return state ? JSON.parse(state) : undefined;
   }
 }

--- a/src/app/services/model-tree.service.ts
+++ b/src/app/services/model-tree.service.ts
@@ -311,7 +311,7 @@ export class ModelTreeService implements OnDestroy {
                 btnType: 'warn',
                 message: '<strong>Note: </strong> This item and all its contents will be deleted <span class=\'warning\'>permanently</span>.'
               }
-            })
+            });
         }),
         switchMap(() => this.deleteCatalogueItem(item, true))
       );

--- a/src/app/services/model-tree.service.ts
+++ b/src/app/services/model-tree.service.ts
@@ -288,28 +288,31 @@ export class ModelTreeService implements OnDestroy {
   }
 
   deleteCatalogueItemPermanent(item: Modelable): Observable<void> {
-    if (!this.securityHandler.isAdmin()) {
-      this.messageHandler.showWarning('Only administrators may permanently delete catalogue items.');
-      return of();
-    }
-
-    return this.dialog
-      .openDoubleConfirmationAsync({
-        data: {
-          title: 'Permanent deletion',
-          okBtnTitle: 'Yes, delete',
-          btnType: 'warn',
-          message: `Are you sure you want to <span class=\'warning\'>permanently</span> delete '${item.label}'?`
-        }
-      }, {
-        data: {
-          title: 'Confirm permanent deletion',
-          okBtnTitle: 'Confirm deletion',
-          btnType: 'warn',
-          message: '<strong>Note: </strong> This item and all its contents will be deleted <span class=\'warning\'>permanently</span>.'
-        }
-      })
+    return this.securityHandler.isAdministrator()
       .pipe(
+        switchMap(isAdministrator => {
+          if (!isAdministrator) {
+            this.messageHandler.showWarning('Only administrators may permanently delete catalogue items.');
+            return of();
+          }
+
+          return this.dialog
+            .openDoubleConfirmationAsync({
+              data: {
+                title: 'Permanent deletion',
+                okBtnTitle: 'Yes, delete',
+                btnType: 'warn',
+                message: `Are you sure you want to <span class=\'warning\'>permanently</span> delete '${item.label}'?`
+              }
+            }, {
+              data: {
+                title: 'Confirm permanent deletion',
+                okBtnTitle: 'Confirm deletion',
+                btnType: 'warn',
+                message: '<strong>Note: </strong> This item and all its contents will be deleted <span class=\'warning\'>permanently</span>.'
+              }
+            })
+        }),
         switchMap(() => this.deleteCatalogueItem(item, true))
       );
   }

--- a/src/app/services/shared.service.ts
+++ b/src/app/services/shared.service.ts
@@ -36,7 +36,7 @@ export class SharedService {
   documentation: { url: string; pages: { [key: string]: string }; importers: { [key: string]: string } } = environment.documentation;
   checkSessionExpiryTimeout = environment.checkSessionExpiryTimeout;
   HDFLink = environment.HDFLink;
-  isAdmin;
+  //isAdmin;
   applicationOffline = new Subject<any>();
   current;
 
@@ -49,9 +49,7 @@ export class SharedService {
     private securityHandler: SecurityHandlerService,
     private toaster: ToastrService,
     private resources: MdmResourcesService
-  ) {
-    this.isAdmin = this.securityHandler.isAdmin();
-  }
+  ) { }
 
   logout() {
     this.securityHandler.logout();
@@ -68,10 +66,6 @@ export class SharedService {
       this.handleExpiredSession();
     }
     return this.securityHandler.isLoggedIn();
-  };
-
-  isAdminUser = () => {
-    return this.securityHandler.isAdmin();
   };
 
   handleExpiredSession(firstTime?) {

--- a/src/app/services/shared.service.ts
+++ b/src/app/services/shared.service.ts
@@ -36,7 +36,7 @@ export class SharedService {
   documentation: { url: string; pages: { [key: string]: string }; importers: { [key: string]: string } } = environment.documentation;
   checkSessionExpiryTimeout = environment.checkSessionExpiryTimeout;
   HDFLink = environment.HDFLink;
-  //isAdmin;
+  // isAdmin;
   applicationOffline = new Subject<any>();
   current;
 

--- a/src/app/shared/models/models.component.html
+++ b/src/app/shared/models/models.component.html
@@ -43,7 +43,7 @@ SPDX-License-Identifier: Apache-2.0
                                                 Show Superseded Models
                                             </mat-checkbox>
                                         </div> -->
-                                        <div *ngIf="isAdmin" mat-menu-item>
+                                        <div *ngIf="isAdministrator" mat-menu-item>
                                             <mat-checkbox name="includeDeleted" (ngModelChange)="toggleFilters('includeDeleted')" [(ngModel)]="includeDeleted">
                                                 Show Deleted Models
                                             </mat-checkbox>

--- a/src/app/shared/models/models.component.ts
+++ b/src/app/shared/models/models.component.ts
@@ -65,7 +65,7 @@ export class ModelsComponent implements OnInit, OnDestroy {
   activeTab = 0;
   allModels: MdmTreeItem = null;
   filteredModels = null;
-  isAdmin = this.securityHandler.isAdmin();
+  isAdministrator = false;
   inSearchMode = false;
   folder = '';
   searchboxFocused = false;
@@ -202,6 +202,8 @@ export class ModelsComponent implements OnInit, OnDestroy {
         this.userSettingsHandler.get('showSupersededModels') || false;
       this.includeDeleted =
         this.userSettingsHandler.get('includeDeleted') || false;
+
+      this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
     }
 
     if (

--- a/src/app/terminology/terminology-details/terminology-details.component.ts
+++ b/src/app/terminology/terminology-details/terminology-details.component.ts
@@ -55,7 +55,6 @@ export class TerminologyDetailsComponent implements OnInit {
   processing = false;
   exportError = null;
   exportList = [];
-  isAdminUser = this.sharedService.isAdminUser();
   isLoggedIn = this.sharedService.isLoggedIn();
   exportedFileIsReady = false;
   deleteInProgress = false;

--- a/src/app/userArea/settings/settings.component.html
+++ b/src/app/userArea/settings/settings.component.html
@@ -52,7 +52,7 @@ SPDX-License-Identifier: Apache-2.0
         </mat-checkbox>
     </div>
 
-    <div class="mb-2" *ngIf="isAdmin()">
+    <div class="mb-2" *ngIf="isAdministrator">
       <mat-checkbox name="includeDeleted" [(ngModel)]="includeDeleted" labelPosition="after">
           Show Deleted Models
       </mat-checkbox>

--- a/src/app/userArea/settings/settings.component.ts
+++ b/src/app/userArea/settings/settings.component.ts
@@ -62,7 +62,7 @@ export class SettingsComponent implements OnInit {
     if (this.isAdministrator) {
       this.includeDeleted = this.userSettingsHandler.get('includeDeleted') || this.includeDeleted;
     }
-  }
+  };
 
   saveSettings = () => {
     this.userSettingsHandler.update('countPerTable', this.countPerTable);

--- a/src/app/userArea/settings/settings.component.ts
+++ b/src/app/userArea/settings/settings.component.ts
@@ -34,6 +34,8 @@ export class SettingsComponent implements OnInit {
   includeModelSuperseded = this.userSettingsHandler.defaultSettings.includeModelSuperseded;
   includeDocumentSuperseded = this.userSettingsHandler.defaultSettings.includeDocumentSuperseded;
   includeDeleted = this.userSettingsHandler.defaultSettings.includeDeleted;
+  isAdministrator = false;
+
   constructor(
     private messageHandler: MessageHandlerService,
     private helpDialogueService: HelpDialogueHandlerService,
@@ -43,28 +45,31 @@ export class SettingsComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.loadSettings();
     this.title.setTitle('Preferences');
+
+    this.securityHandler.isAdministrator()
+      .subscribe(state => {
+        this.isAdministrator = state;
+        this.loadSettings();
+      });
   }
+
   loadSettings = () => {
     this.countPerTable = this.userSettingsHandler.get('countPerTable') || this.countPerTable;
     this.expandMoreDescription = this.userSettingsHandler.get('expandMoreDescription') || this.expandMoreDescription;
     this.includeModelSuperseded = this.userSettingsHandler.get('includeModelSuperseded') || this.includeModelSuperseded;
     this.includeDocumentSuperseded = this.userSettingsHandler.get('includeDocumentSuperseded') || this.includeDocumentSuperseded;
-    if (this.isAdmin()) {
+    if (this.isAdministrator) {
       this.includeDeleted = this.userSettingsHandler.get('includeDeleted') || this.includeDeleted;
     }
-  };
-  isAdmin = () => {
-    return this.securityHandler.isAdmin();
-  };
+  }
 
   saveSettings = () => {
     this.userSettingsHandler.update('countPerTable', this.countPerTable);
     this.userSettingsHandler.update('expandMoreDescription', this.expandMoreDescription);
     this.userSettingsHandler.update('includeModelSuperseded', this.includeModelSuperseded);
     this.userSettingsHandler.update('includeDocumentSuperseded', this.includeDocumentSuperseded);
-    if (this.isAdmin()) {
+    if (this.isAdministrator) {
       this.userSettingsHandler.update('includeDeleted', this.includeDeleted);
     }
 

--- a/src/app/users/users-app-container/users-app-container.component.html
+++ b/src/app/users/users-app-container/users-app-container.component.html
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
               </li>
           </ul>
 
-          <ul class="menu-list" *ngIf="isAdmin">
+          <ul class="menu-list" *ngIf="isAdministrator">
               <p class="marginless pl-2 text-muted">Admin settings</p>
               <li>
                   <a role="menuitem" uiSref="appContainer.adminArea.home" uiSrefActive="active">

--- a/src/app/users/users-app-container/users-app-container.component.ts
+++ b/src/app/users/users-app-container/users-app-container.component.ts
@@ -46,7 +46,7 @@ export class UsersAppContainerComponent implements OnInit {
             return EMPTY;
           }
 
-          return this.sharedService.pendingUsersCount()
+          return this.sharedService.pendingUsersCount();
         })
       )
       .subscribe((data: any) => this.pendingUsersCount = data.body.count);

--- a/src/app/users/users-app-container/users-app-container.component.ts
+++ b/src/app/users/users-app-container/users-app-container.component.ts
@@ -19,6 +19,8 @@ SPDX-License-Identifier: Apache-2.0
 import { Component, OnInit } from '@angular/core';
 import { SharedService } from '@mdm/services/shared.service';
 import { SecurityHandlerService } from '@mdm/services/handlers/security-handler.service';
+import { EMPTY } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'mdm-users-app-container',
@@ -28,17 +30,26 @@ import { SecurityHandlerService } from '@mdm/services/handlers/security-handler.
 export class UsersAppContainerComponent implements OnInit {
   deleteInProgress: boolean;
   pendingUsersCount = 0;
-  isAdmin = this.securityHandler.isAdmin();
+  isAdministrator = false;
   features = this.sharedService.features;
 
   constructor(private sharedService: SharedService, private securityHandler: SecurityHandlerService) {}
 
   ngOnInit() {
-    if (this.isAdmin) {
-      this.sharedService.pendingUsersCount().subscribe(data => {
-        this.pendingUsersCount = data.body.count;
-      });
-    }
+    this.securityHandler
+      .isAdministrator()
+      .pipe(
+        switchMap(isAdministrator => {
+          this.isAdministrator = isAdministrator;
+
+          if (!isAdministrator) {
+            return EMPTY;
+          }
+
+          return this.sharedService.pendingUsersCount()
+        })
+      )
+      .subscribe((data: any) => this.pendingUsersCount = data.body.count);
   }
 
   logout = () => {

--- a/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
+++ b/src/app/versioned-folder/versioned-folder-detail/versioned-folder-detail.component.ts
@@ -27,7 +27,7 @@ import { VersioningGraphModalComponent } from '@mdm/modals/versioning-graph-moda
 import { VersioningGraphModalConfiguration } from '@mdm/modals/versioning-graph-modal/versioning-graph-modal.model';
 import { Access } from '@mdm/model/access';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { BroadcastService, MessageHandlerService, MessageService, SecurityHandlerService, SharedService, StateHandlerService, ValidatorService } from '@mdm/services';
+import { BroadcastService, MessageHandlerService, MessageService, SecurityHandlerService, StateHandlerService, ValidatorService } from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
 import { EMPTY } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
@@ -45,7 +45,6 @@ export class VersionedFolderDetailComponent implements OnInit {
 
   isEditing = false;
   original: VersionedFolderDetail;
-  isAdminUser = false;
   processing = false;
   access: Access;
 
@@ -55,7 +54,6 @@ export class VersionedFolderDetailComponent implements OnInit {
     private messageHandler: MessageHandlerService,
     private securityHandler: SecurityHandlerService,
     private stateHandler: StateHandlerService,
-    private shared: SharedService,
     private broadcast: BroadcastService,
     private dialog: MatDialog,
     private title: Title,
@@ -63,7 +61,6 @@ export class VersionedFolderDetailComponent implements OnInit {
     private validator: ValidatorService) { }
 
   ngOnInit(): void {
-    this.isAdminUser = this.shared.isAdmin;
     this.access = this.securityHandler.elementAccess(this.detail);
     this.title.setTitle(`Versioned Folder - ${this.detail?.label}`);
     this.original = Object.assign({}, this.detail);


### PR DESCRIPTION
Resolves #484 

* Removed `api/session/isApplicationAdministration` endpoint request within login operation to speed up login. Backend will now do security work in the background and not block. This closes the Login dialog faster and speeds up the UI.
* Updated all call sites to use correct way of request is administrator state
* Cache `isAdmin` flag so subsequent requests will not send unnecessary network requests

You can test this on the MauroDataMapper/mdm-core branch `feature/mc-9803` to see the full speed benefit, though this change is not dependent on that - you can run the latest snapshot of `mdm-core` and the UI changes will still work. The key part is that all previous functionality that must check whether the user is an admin or not works exactly as before.