### PR TITLE
#407 Choose terminology for codeset now returns full ordered list

### DIFF
--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
@@ -117,9 +117,11 @@ export class MultipleTermsSelectorComponent {
   }
 
   loadTerminologies() {
-    this.resources.terminology.list().subscribe((data: TerminologyIndexResponse) => {
-      this.selectorSection.terminologies = data.body.items;
-    });
+    this.resources.terminology
+      .list({ all: true, sort: 'label' })
+      .subscribe((data: TerminologyIndexResponse) => {
+        this.selectorSection.terminologies = data.body.items;
+      });
   }
 
   onTerminologySelect(terminology: Terminology) {


### PR DESCRIPTION
Resolves #407 

The call to fetch the available terminologies was simply missing query parameters to return all (no pagination) and set correct sort order of results.