### PR TITLE
#465 Add external link option to Jodit editor

### DIFF
--- a/src/app/utility/html-editor/html-editor.component.ts
+++ b/src/app/utility/html-editor/html-editor.component.ts
@@ -96,11 +96,12 @@ export class HtmlEditorComponent implements OnInit {
       'paragraph',
       '|',
       'table',
+      'link',
       {
         name: 'linktoelement',
-        text: 'Link to Element',
-        tooltip: 'Add link to element',
-        icon: 'link',
+        text: 'Link to Catalogue Item',
+        tooltip: 'Add link to catalogue item',
+        icon: 'attachment',
         exec: (editor: any) => this.onAddElementLink(this, editor)
       },
       '|',


### PR DESCRIPTION
Add both toolbar options to insert internal (catalogue items) and external links.

Resolves #465 

![image](https://user-images.githubusercontent.com/3219480/159508200-bd6dbc1e-5d6d-42ce-8353-0e03cc8327ff.png)
