### PR TITLE
#481 Add term code to default profile to allow edits

### DIFF
--- a/src/app/model/defaultProfileModel.ts
+++ b/src/app/model/defaultProfileModel.ts
@@ -76,9 +76,19 @@ export  class DefaultProfileControls {
       'aliases',
       'dataType'
     ];
+
     const folder = ['description'];
     const dataType = ['description', 'aliases', 'classifications', 'dataType'];
-    const term = ['description', 'aliases',  'classifications', 'url','terminology'];
+
+    const term = [
+      'code',
+      'description',
+      'aliases',
+      'classifications',
+      'url',
+      'terminology'
+    ];
+
     const classification = ['description'];
 
 

--- a/src/app/shared/default-profile/default-profile.component.html
+++ b/src/app/shared/default-profile/default-profile.component.html
@@ -19,6 +19,19 @@ SPDX-License-Identifier: Apache-2.0
 
 <table *ngIf="controls" class="table table-bordered mdm--table-fixed">
   <tbody>
+    <tr *ngIf="isInControlList('code')" data-cy="code">
+      <td class="detailsRowHeader">Code</td>
+      <td data-cy="value" *ngIf="catalogueItem">
+        <mdm-inline-text-edit
+          [readOnly]="true"
+          [(ngModel)]="catalogueItem.code"
+          [name]="'moduleNameCode'"
+          size="20"
+          [styleCss]="'dataModelDetailsLabel'"
+        >
+        </mdm-inline-text-edit>
+      </td>
+    </tr>
     <tr *ngIf="isInControlList('aliases')" data-cy="aliases" >
       <td class="detailsRowHeader">Aliases</td>
       <td data-cy="value">

--- a/src/app/shared/profile-data-view/profile-data-view.model.ts
+++ b/src/app/shared/profile-data-view/profile-data-view.model.ts
@@ -54,6 +54,17 @@ export const getDefaultProfileData = (
   const items: DefaultProfileItem[] = [];
   const controls = DefaultProfileControls.renderControls(catalogueItem.domainType);
 
+  if (showControl(controls, 'code')) {
+    items.push(
+      createDefaultProfileItem(
+        catalogueItem.code,
+        'Code',
+        ProfileControlTypes.text,
+        'code'
+      )
+    );
+  }
+
   items.push(
     createDefaultProfileItem(
       catalogueItem.description,


### PR DESCRIPTION
By adding the term code to the default profile, selecting "Edit" allows the user to make changes to it.

Resolves #481 

![image](https://user-images.githubusercontent.com/3219480/159537614-f9906d4b-3db0-4e82-a146-bb6a15675d1a.png)
