### PR TITLE
gh-499 Add user preference for content editing format

### DIFF
--- a/src/app/constants/ui.types.ts
+++ b/src/app/constants/ui.types.ts
@@ -1,0 +1,26 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+/**
+ * Defines the possible formats for using a content editor.
+ *
+ * * `auto` - Automatically attempt to determine the format of content based on the text entered.
+ * * `markdown` - Assume that content is in Markdown format.
+ * * `html` - Assume that content is in HTML format.
+ */
+export type ContentEditorFormat = 'auto' | 'markdown' | 'html';

--- a/src/app/constants/ui.types.ts
+++ b/src/app/constants/ui.types.ts
@@ -19,8 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 /**
  * Defines the possible formats for using a content editor.
  *
- * * `auto` - Automatically attempt to determine the format of content based on the text entered.
  * * `markdown` - Assume that content is in Markdown format.
  * * `html` - Assume that content is in HTML format.
  */
-export type ContentEditorFormat = 'auto' | 'markdown' | 'html';
+export type ContentEditorFormat = 'markdown' | 'html';

--- a/src/app/services/utility/user-settings-handler.service.ts
+++ b/src/app/services/utility/user-settings-handler.service.ts
@@ -51,7 +51,7 @@ export class UserSettingsHandlerService {
     includeDocumentSuperseded: false,
     includeDeleted: false,
     dataFlowDiagramsSetting: {},
-    editorFormat: 'auto'
+    editorFormat: 'markdown'
   };
 
   constructor(

--- a/src/app/services/utility/user-settings-handler.service.ts
+++ b/src/app/services/utility/user-settings-handler.service.ts
@@ -18,14 +18,31 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { SecurityHandlerService } from '@mdm/services/handlers/security-handler.service';
+import { map } from 'rxjs/operators';
+import { MdmResponse } from '@maurodatamapper/mdm-resources';
+import { ContentEditorFormat } from '@mdm/constants/ui.types';
+
+export interface UserSettings {
+  countPerTable?: number;
+  counts?: number[];
+  expandMoreDescription?: boolean;
+  favourites?: any[];
+  includeModelSuperseded?: boolean;
+  includeDocumentSuperseded?: boolean;
+  includeDeleted?: boolean;
+  showSupersededModels?: boolean;
+  includeSupersededDocModels?: boolean;
+  dataFlowDiagramsSetting?: any;
+  editorFormat?: ContentEditorFormat;
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserSettingsHandlerService {
-  defaultSettings = {
+  defaultSettings: UserSettings = {
     countPerTable: 20,
     counts: [5, 10, 20, 50],
     expandMoreDescription: false,
@@ -33,15 +50,17 @@ export class UserSettingsHandlerService {
     includeModelSuperseded: true,
     includeDocumentSuperseded: false,
     includeDeleted: false,
-    dataFlowDiagramsSetting: {}
+    dataFlowDiagramsSetting: {},
+    editorFormat: 'auto'
   };
+
   constructor(
     private resources: MdmResourcesService,
     private securityHandler: SecurityHandlerService
   ) { }
 
   getUserSettings() {
-    let settings = JSON.parse(localStorage.getItem('userSettings'));
+    let settings = JSON.parse(localStorage.getItem('userSettings')) as UserSettings;
     if (!settings) {
       this.updateUserSettings(this.defaultSettings);
       settings = this.defaultSettings;
@@ -49,54 +68,55 @@ export class UserSettingsHandlerService {
     return settings;
   }
 
-  updateUserSettings(setting) {
-    localStorage.setItem('userSettings', JSON.stringify(setting));
+  updateUserSettings(settings: UserSettings) {
+    localStorage.setItem('userSettings', JSON.stringify(settings));
   }
 
-  initUserSettings() {
-
-    const promise = new Promise((resolve, reject) => {
-      this.resources.catalogueUser.userPreferences(localStorage.getItem('userId')).subscribe(res => {
-        const result = res.body;
-        let settings = null;
-        if (!result) {
-          settings = this.defaultSettings;
-        } else {
-          // check if we have added new items but they don't exists already, then add them
-          for (const property in this.defaultSettings) {
-            if (this.defaultSettings.hasOwnProperty(property) && !result[property]) {
-              result[property] = this.defaultSettings[property];
-            }
-          }
-            // save them into the localStorage
-          settings = result;
-        }
-        // save it locally
-        this.updateUserSettings(settings);
-        resolve(settings);
-      }, error => {
-          reject(error);
-        }
-      );
-    });
-    return promise;
-  }
-
-  init() {
-    if (this.securityHandler.isLoggedIn()) {
-      return this.initUserSettings();
+  loadForCurrentUser(): Observable<UserSettings> {
+    const user = this.securityHandler.getCurrentUser();
+    if (!user) {
+      return of({});
     }
+
+    return this.resources.catalogueUser.userPreferences(user.id)
+      .pipe(
+        map((response: MdmResponse<any>) => {
+          const body = response.body;
+
+          let settings: UserSettings = null;
+          if (!body) {
+            settings = this.defaultSettings;
+          } else {
+            // check if we have added new items but they don't exists already, then add them
+            for (const property in this.defaultSettings) {
+              if (this.defaultSettings.hasOwnProperty(property) && !body[property]) {
+                body[property] = this.defaultSettings[property];
+              }
+            }
+              // save them into the localStorage
+            settings = body;
+          }
+
+          // save it locally
+          this.updateUserSettings(settings);
+          return settings;
+        })
+      );
   }
 
-  update(setting, value) {
+  update(setting: keyof UserSettings, value: any) {
     const storage = this.getUserSettings();
-    storage[setting] = value;
-    this.updateUserSettings(storage);
+    const next = {
+      ...storage,
+      ...{ [setting]: value }
+    };
+
+    this.updateUserSettings(next);
   }
 
-  get(setting) {
+  get<T = any>(setting: keyof UserSettings): T {
     const storage = this.getUserSettings();
-    return storage[setting];
+    return storage[setting] as T;
   }
 
   removeAll() {
@@ -104,14 +124,11 @@ export class UserSettingsHandlerService {
   }
 
   saveOnServer(): Observable<any> {
-    return this.resources.catalogueUser.updateUserPreferences(localStorage.getItem('userId'), this.getUserSettings());
-  }
-
-  handleCountPerTable(items) {
-    let counts = this.get('counts');
-    if (items && items.length < 5) {
-      counts = [];
+    const user = this.securityHandler.getCurrentUser();
+    if (!user) {
+      return of({});
     }
-    return counts;
+
+    return this.resources.catalogueUser.updateUserPreferences(user.id, this.getUserSettings());
   }
 }

--- a/src/app/userArea/settings/settings.component.html
+++ b/src/app/userArea/settings/settings.component.html
@@ -22,15 +22,24 @@ SPDX-License-Identifier: Apache-2.0
 </div>
 <form class="mdm--form" name="settingForm" (ngSubmit)="saveSettings()" novalidate enctype="multipart/form-data">
     <div class="mb-2">
-        <span id="countPerTableLabel">Number of records per table:</span>
-        <mat-radio-group aria-label="countPerTableLabel" name="countPerTable" [(ngModel)]="countPerTable" class="mt-1">
+        <label id="countPerTableLabel">Number of records per table</label>
+        <mat-radio-group aria-labelledby="countPerTableLabel" name="countPerTable" [(ngModel)]="countPerTable" class="mt-1">
             <mat-radio-button [checked]="countPerTable == 5" [value]="5">5</mat-radio-button>
             <mat-radio-button [checked]="countPerTable == 10" [value]="10">10</mat-radio-button>
             <mat-radio-button [checked]="countPerTable == 20" [value]="20">20</mat-radio-button>
             <mat-radio-button [checked]="countPerTable == 50" [value]="50">50</mat-radio-button>
         </mat-radio-group>
     </div>
-
+    <div class="mb-2">
+      <label id="contentEditorFormat">Content editor format</label>
+      <mat-form-field appearance="outline" aria-labelledby="contentEditorFormat">
+        <mat-select name="editorFormat" [(ngModel)]="editorFormat">
+          <mat-option value="auto">Automatic</mat-option>
+          <mat-option value="markdown">Markdown</mat-option>
+          <mat-option value="html">HTML</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
     <div class="mb-2">
         <div>
             <mat-checkbox name="expandMoreDescription" [(ngModel)]="expandMoreDescription" labelPosition="after">

--- a/src/app/userArea/settings/settings.component.html
+++ b/src/app/userArea/settings/settings.component.html
@@ -31,10 +31,9 @@ SPDX-License-Identifier: Apache-2.0
         </mat-radio-group>
     </div>
     <div class="mb-2">
-      <label id="contentEditorFormat">Content editor format</label>
+      <label id="contentEditorFormat">Preferred content editor format</label>
       <mat-form-field appearance="outline" aria-labelledby="contentEditorFormat">
         <mat-select name="editorFormat" [(ngModel)]="editorFormat">
-          <mat-option value="auto">Automatic</mat-option>
           <mat-option value="markdown">Markdown</mat-option>
           <mat-option value="html">HTML</mat-option>
         </mat-select>

--- a/src/app/userArea/settings/settings.component.ts
+++ b/src/app/userArea/settings/settings.component.ts
@@ -30,6 +30,7 @@ import { SecurityHandlerService } from '@mdm/services/handlers/security-handler.
 })
 export class SettingsComponent implements OnInit {
   countPerTable = this.userSettingsHandler.defaultSettings.countPerTable;
+  editorFormat = this.userSettingsHandler.defaultSettings.editorFormat;
   expandMoreDescription = this.userSettingsHandler.defaultSettings.expandMoreDescription;
   includeModelSuperseded = this.userSettingsHandler.defaultSettings.includeModelSuperseded;
   includeDocumentSuperseded = this.userSettingsHandler.defaultSettings.includeDocumentSuperseded;
@@ -56,6 +57,7 @@ export class SettingsComponent implements OnInit {
 
   loadSettings = () => {
     this.countPerTable = this.userSettingsHandler.get('countPerTable') || this.countPerTable;
+    this.editorFormat = this.userSettingsHandler.get('editorFormat') || this.editorFormat;
     this.expandMoreDescription = this.userSettingsHandler.get('expandMoreDescription') || this.expandMoreDescription;
     this.includeModelSuperseded = this.userSettingsHandler.get('includeModelSuperseded') || this.includeModelSuperseded;
     this.includeDocumentSuperseded = this.userSettingsHandler.get('includeDocumentSuperseded') || this.includeDocumentSuperseded;
@@ -66,6 +68,7 @@ export class SettingsComponent implements OnInit {
 
   saveSettings = () => {
     this.userSettingsHandler.update('countPerTable', this.countPerTable);
+    this.userSettingsHandler.update('editorFormat', this.editorFormat);
     this.userSettingsHandler.update('expandMoreDescription', this.expandMoreDescription);
     this.userSettingsHandler.update('includeModelSuperseded', this.includeModelSuperseded);
     this.userSettingsHandler.update('includeDocumentSuperseded', this.includeDocumentSuperseded);

--- a/src/app/utility/content-editor/content-editor.component.html
+++ b/src/app/utility/content-editor/content-editor.component.html
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <mdm-markdown-text-area
-  *ngIf="contentFormat === ContentFormatType.Markdown"
+  *ngIf="contentFormat === 'markdown'"
   [element]="element"
   [property]="property"
   [inEditMode]="inEditMode"
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
 </mdm-markdown-text-area>
 
 <mdm-html-editor
-  *ngIf="contentFormat === ContentFormatType.Html"
+  *ngIf="contentFormat === 'html'"
   [element]="element"
   [property]="property"
   [inEditMode]="inEditMode"
@@ -42,9 +42,9 @@ SPDX-License-Identifier: Apache-2.0
 >
 </mdm-html-editor>
 
-<div *ngIf="isInEditMode()">
+<div *ngIf="isInEditMode() && allowFormatChoice">
   <mat-button-toggle-group name="format" aria-label="Format" [(ngModel)]="contentFormat">
-    <mat-button-toggle [value]="ContentFormatType.Markdown">Markdown</mat-button-toggle>
-    <mat-button-toggle [value]="ContentFormatType.Html">HTML</mat-button-toggle>
+    <mat-button-toggle value="markdown">Markdown</mat-button-toggle>
+    <mat-button-toggle value="html">HTML</mat-button-toggle>
   </mat-button-toggle-group>
 </div>

--- a/src/app/utility/content-editor/content-editor.component.html
+++ b/src/app/utility/content-editor/content-editor.component.html
@@ -42,7 +42,7 @@ SPDX-License-Identifier: Apache-2.0
 >
 </mdm-html-editor>
 
-<div *ngIf="isInEditMode() && allowFormatChoice">
+<div *ngIf="isInEditMode()">
   <mat-button-toggle-group name="format" aria-label="Format" [(ngModel)]="contentFormat">
     <mat-button-toggle value="markdown">Markdown</mat-button-toggle>
     <mat-button-toggle value="html">HTML</mat-button-toggle>

--- a/src/app/utility/content-editor/content-editor.component.spec.ts
+++ b/src/app/utility/content-editor/content-editor.component.spec.ts
@@ -16,28 +16,30 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { UserSettingsHandlerService } from '@mdm/services';
+import { ComponentHarness, setupTestModuleForComponent } from '@mdm/testing/testing.helpers';
 
 import { ContentEditorComponent } from './content-editor.component';
 
 describe('ContentEditorComponent', () => {
-  let component: ContentEditorComponent;
-  let fixture: ComponentFixture<ContentEditorComponent>;
+  let harness: ComponentHarness<ContentEditorComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ContentEditorComponent ]
-    })
-    .compileComponents();
-  }));
+  const userSettingsStub = {
+    get: jest.fn()
+  };
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ContentEditorComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(ContentEditorComponent, {
+      providers: [
+        {
+          provide: UserSettingsHandlerService,
+          useValue: userSettingsStub
+        }
+      ]
+    });
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(harness.isComponentCreated).toBeTruthy();
   });
 });

--- a/src/app/utility/content-editor/content-editor.component.ts
+++ b/src/app/utility/content-editor/content-editor.component.ts
@@ -17,12 +17,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ContentEditorFormat } from '@mdm/constants/ui.types';
+import { UserSettingsHandlerService } from '@mdm/services';
 import { HtmlButtonMode } from '../html-editor/html-editor.component';
-
-export enum ContentEditorFormat {
-  Markdown,
-  Html
-}
 
 export interface ContentEditorMarkdownOptions {
   showHelpText: boolean;
@@ -39,7 +36,7 @@ export interface ContentEditorHtmlOptions {
 })
 export class ContentEditorComponent implements OnInit {
 
-  @Input() contentFormat: ContentEditorFormat = ContentEditorFormat.Html;
+  @Input() contentFormat: ContentEditorFormat = 'auto';
 
   /* Inputs/outputs for manual properties */
   @Input() inEditMode: boolean;
@@ -54,24 +51,23 @@ export class ContentEditorComponent implements OnInit {
   @Input() htmlOptions: ContentEditorHtmlOptions;
 
   ButtonModeTypes = HtmlButtonMode;
-  ContentFormatType = ContentEditorFormat;
+  allowFormatChoice = true;
 
-  constructor() { }
+  constructor(private userSettings: UserSettingsHandlerService) { }
 
   ngOnInit(): void {
     this.markdownOptions = this.markdownOptions ?? { showHelpText: true };
     this.htmlOptions = this.htmlOptions ?? { useBasicButtons: false };
 
-    this.contentFormat = this.isHtmlContent() ? ContentEditorFormat.Html : ContentEditorFormat.Markdown;
-  }
+    const formatPreference = this.userSettings.get<ContentEditorFormat>('editorFormat')
+      ?? this.userSettings.defaultSettings.editorFormat;
 
-  getContentFormatName() {
-    switch (this.contentFormat)
-    {
-      case ContentEditorFormat.Markdown: return 'Markdown';
-      case ContentEditorFormat.Html: return 'HTML';
-      default: return '';
+    this.contentFormat = formatPreference;
+    if (this.contentFormat === 'auto') {
+      this.contentFormat = this.isHtmlContent() ? 'html' : 'markdown';
     }
+
+    this.allowFormatChoice = formatPreference === 'auto';
   }
 
   isInEditMode() : boolean {

--- a/src/app/utility/content-editor/content-editor.component.ts
+++ b/src/app/utility/content-editor/content-editor.component.ts
@@ -79,7 +79,7 @@ export class ContentEditorComponent implements OnInit {
   }
 
   isEmptyContent() {
-    return !this.content
+    return !this.content;
   }
 
 

--- a/src/app/utility/content-editor/content-editor.component.ts
+++ b/src/app/utility/content-editor/content-editor.component.ts
@@ -36,7 +36,7 @@ export interface ContentEditorHtmlOptions {
 })
 export class ContentEditorComponent implements OnInit {
 
-  @Input() contentFormat: ContentEditorFormat = 'auto';
+  @Input() contentFormat: ContentEditorFormat = 'markdown';
 
   /* Inputs/outputs for manual properties */
   @Input() inEditMode: boolean;
@@ -51,7 +51,6 @@ export class ContentEditorComponent implements OnInit {
   @Input() htmlOptions: ContentEditorHtmlOptions;
 
   ButtonModeTypes = HtmlButtonMode;
-  allowFormatChoice = true;
 
   constructor(private userSettings: UserSettingsHandlerService) { }
 
@@ -62,12 +61,12 @@ export class ContentEditorComponent implements OnInit {
     const formatPreference = this.userSettings.get<ContentEditorFormat>('editorFormat')
       ?? this.userSettings.defaultSettings.editorFormat;
 
-    this.contentFormat = formatPreference;
-    if (this.contentFormat === 'auto') {
+    if(this.isEmptyContent()) {
+      this.contentFormat = formatPreference;
+    } else {
       this.contentFormat = this.isHtmlContent() ? 'html' : 'markdown';
     }
 
-    this.allowFormatChoice = formatPreference === 'auto';
   }
 
   isInEditMode() : boolean {
@@ -78,6 +77,11 @@ export class ContentEditorComponent implements OnInit {
     this.content = value;
     this.contentChange.emit(value);
   }
+
+  isEmptyContent() {
+    return !this.content
+  }
+
 
   isHtmlContent() {
 

--- a/src/app/utility/html-editor/html-editor.component.html
+++ b/src/app/utility/html-editor/html-editor.component.html
@@ -18,24 +18,24 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <div *ngIf="!element">
-   <jodit-editor *ngIf="inEditMode" 
-                  [(ngModel)]="description" 
+   <jodit-editor *ngIf="inEditMode"
+                  [(ngModel)]="description"
                   name="{{property}}"
                   [config]="editorConfig"
                   (onChange)="onHtmlEditorChanged($event)">
    </jodit-editor>
    <div style="clear: both;">
-      <span [innerHTML]="description | safe:'html'" *ngIf="!inEditMode"></span>
+      <span [innerHTML]="description ?? '' | safe:'html'" *ngIf="!inEditMode"></span>
   </div>
 </div>
 
 <div *ngIf="element">
-   <jodit-editor *ngIf="inEditMode" 
-                  [(ngModel)]="element[property]" 
+   <jodit-editor *ngIf="inEditMode"
+                  [(ngModel)]="element[property]"
                   name="{{property}}"
                   [config]="editorConfig">
    </jodit-editor>
    <div style="clear: both;">
-      <span [innerHTML]="element[property] | safe:'html'" *ngIf="!inEditMode"></span>
+      <span [innerHTML]="element[property] ?? '' | safe:'html'" *ngIf="!inEditMode"></span>
    </div>
 </div>


### PR DESCRIPTION
Resolves #499 

* Add type definitions to UserSettingsHandlerService. Add missing properties that were used and refactor to not mix promises
* Update user preferences page
* Update content editor to respect user preferences. If no preference is set, or is "auto", revert back to original behaviour of guessing appropriate format

User has choice between forcing content to be Markdown or HTML. If they pick "Automatic" (or don't make a choice), behaviour reverts to original, where format is best-guessed from existing text values.

![image](https://user-images.githubusercontent.com/3219480/162726474-bbfdd1c8-8d37-4ab7-a1bc-ce13f784e022.png)
