### PR TITLE
gh-523 Initial setup for new Catalogue Search

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,10 +16,17 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { APP_BASE_HREF, HashLocationStrategy, LocationStrategy } from '@angular/common';
+import {
+  APP_BASE_HREF,
+  HashLocationStrategy,
+  LocationStrategy
+} from '@angular/common';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { LOCALE_ID, NgModule } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
+import {
+  MatDialogRef,
+  MAT_DIALOG_DEFAULT_OPTIONS
+} from '@angular/material/dialog';
 import { MAT_TABS_CONFIG } from '@angular/material/tabs';
 import { BrowserModule } from '@angular/platform-browser';
 import { environment } from '@env/environment';
@@ -39,6 +46,7 @@ import '@mdm/utility/extensions/mat-dialog.extensions';
 import { HttpRequestProgressInterceptor } from './services/http-request-progress.interceptor';
 import { MergeDiffModule } from './merge-diff/merge-diff.module';
 import { BulkEditModule } from './bulk-edit/bulk-edit.module';
+import { CatalogueSearchModule } from './catalogue-search/catalogue-search.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -57,7 +65,8 @@ import { BulkEditModule } from './bulk-edit/bulk-edit.module';
       defaultHttpRequestOptions: { withCredentials: true },
       apiEndpoint: environment.apiEndpoint
     }),
-    MergeDiffModule
+    MergeDiffModule,
+    CatalogueSearchModule
   ],
   providers: [
     { provide: MAT_TABS_CONFIG, useValue: { animationDuration: '0ms' } },
@@ -66,8 +75,15 @@ import { BulkEditModule } from './bulk-edit/bulk-edit.module';
     { provide: APP_BASE_HREF, useValue: '/' },
     { provide: LocationStrategy, useClass: HashLocationStrategy },
     { provide: MatDialogRef, useValue: {} },
-    { provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: { hasBackdrop: true, autoFocus: false } },
-    { provide: HTTP_INTERCEPTORS, useClass: HttpRequestProgressInterceptor, multi: true }
+    {
+      provide: MAT_DIALOG_DEFAULT_OPTIONS,
+      useValue: { hasBackdrop: true, autoFocus: false }
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: HttpRequestProgressInterceptor,
+      multi: true
+    }
   ],
   bootstrap: [UiViewComponent]
 })

--- a/src/app/catalogue-search/catalogue-search.module.ts
+++ b/src/app/catalogue-search/catalogue-search.module.ts
@@ -1,0 +1,31 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedModule } from '@mdm/modules/shared/shared.module';
+import { MaterialModule } from '@mdm/modules/material/material.module';
+import { CatalogueSearchComponent } from './catalogue-search/catalogue-search.component';
+
+@NgModule({
+  declarations: [
+    CatalogueSearchComponent
+  ],
+  imports: [CommonModule, SharedModule, MaterialModule]
+})
+export class CatalogueSearchModule {}

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.html
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.html
@@ -1,0 +1,21 @@
+<!--
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div class="container">
+  <p>catalogue-search works!</p>
+</div>

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.scss
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.spec.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent
+} from '@mdm/testing/testing.helpers';
+import { CatalogueSearchComponent } from './catalogue-search.component';
+
+describe('CatalogueSearchComponent', () => {
+  let harness: ComponentHarness<CatalogueSearchComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(CatalogueSearchComponent, {
+      providers: [Title]
+    });
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+
+  describe('initialisation', () => {
+    it('should set the page title', () => {
+      harness.component.ngOnInit();
+      const title = TestBed.inject(Title);
+      expect(title.getTitle()).toBe('Catalogue search');
+    });
+  });
+});

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.ts
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+
+/**
+ * Top-level component that represents the overall Catalogue Search page.
+ *
+ * This acts as the landing page to the catalogue search, holding just the form for
+ * entering search criteria.
+ */
+@Component({
+  selector: 'mdm-catalogue-search',
+  templateUrl: './catalogue-search.component.html',
+  styleUrls: ['./catalogue-search.component.scss']
+})
+export class CatalogueSearchComponent implements OnInit {
+  constructor(private title: Title) {}
+
+  ngOnInit(): void {
+    this.title.setTitle('Catalogue search');
+  }
+}

--- a/src/app/model/api-properties.ts
+++ b/src/app/model/api-properties.ts
@@ -280,5 +280,13 @@ export const propertyMetadata: ApiPropertyMetadata[] = [
     isSystem: true,
     publiclyVisible: true,
     requiresReload: true
+  },
+  {
+    key: 'feature.use_catalogue_search',
+    category: 'Features',
+    editType: ApiPropertyEditType.Boolean,
+    isSystem: true,
+    publiclyVisible: true,
+    requiresReload: true
   }
 ];

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -17,221 +17,426 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <header id="mdm--header">
-    <div class="container">
-        <mat-toolbar id="mdm--navbar" color="primary" class="mb-0">
-            <nav id="mdm--navbar-desktop" flex fxLayout="row" fxLayoutAlign="space-between">
-                <div class="mdm--navbar-brand">
-                    <a id="mdm-logo" class="mdm-navbar__brand--logo" uiSref="appContainer.mainApp.home">
-                        <img [src]="logoUrl" [style.width]="logoWidth" alt="logo">
-                    </a>
-                </div>
-                <div class="mdm--navbar-items">
-                    <a class="nav-item nav-link" uiSref="appContainer.mainApp.home" uiSrefActive="active">Home</a>
-                    <a class="nav-item nav-link" uiSref="appContainer.mainApp.twoSidePanel.catalogue.allDataModel" uiSrefActive="active">Browse</a>
-                    <a class="nav-item nav-link" uiSref="appContainer.mainApp.twoSidePanel.catalogue.search" uiSrefActive="active">Search</a>
-                    <a class="nav-item nav-link" uiSref="appContainer.mainApp.about" uiSrefActive="active">About</a>
-                </div>
-                <div class="mdm--navbar-user">
-                    <div *ngIf="!isLoggedIn">
-                        <!-- <button (click)="register()" mat-button class="custom inverted-button" color="primary-A700">Register</button> TODO -->
-                        <button (click)="login()" mat-stroked-button class="custom inverted-button" color="primary-A700">Log in</button>
-                    </div>
-                    <div *ngIf="isLoggedIn">
-                        <div *ngIf="profile" [matMenuTriggerFor]="menu" flex fxLayout="row" fxLayout.sm="column" fxLayout.xs="column" fxLayoutAlign="space-between" fxLayoutGap="8px" fxLayoutAlign="center center" style="width: 185px;">
-                            <div class="profile-img" fxFlex="30" fxFlex.sm="100" fxFlex.xs="100">
-                                <img class="img-rounded"  *ngIf="!imgChanged" src="{{backendURL}}/catalogueUsers/{{profile.id}}/image" alt="User profile">
-                            </div>
-                            <div fxFlex="60" fxFlex.sm="100" fxFlex.xs="100">
-                                <div class="profile-name">{{profile.firstName}} {{profile.lastName}}</div>
-                                <div class="profile-role" *ngIf="isAdministrator">Administrator</div>
-                            </div>
-                            <div fxFlex="10" fxFlex.sm="100" fxFlex.xs="100">
-                                <span class="fas fa-chevron-down"></span>
-                            </div>
-                        </div>
-                        <mat-menu #menu="matMenu" yPosition="below" xPosition="before">
-                            <div *ngIf="isLoggedIn">
-                                <h5 class="marginless text-muted menu-label">Account settings</h5>
-                                <a mat-menu-item uiSref="appContainer.userArea.profile">
-                                    <span class="fas fa-id-card"></span>
-                                    <span>My profile</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.userArea.settings">
-                                    <span class="fas fa-sliders-h"></span>
-                                    <span>Preferences</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.userArea.changePassword">
-                                  <span class="fas fa-unlock-alt"></span>
-                                    <span>Change password</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.userArea.apiKeys">
-                                  <span class="fas fa-key"></span>
-                                  <span>API keys</span>
-                                </a>
-                            </div>
-                            <div *ngIf="isAdministrator">
-                                <h5 class="marginless text-muted menu-label">Admin settings</h5>
-                                <a mat-menu-item uiSref="appContainer.adminArea.home">
-                                    <span class="fas fa-tachometer-alt"></span>
-                                    <span>Dashboard</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.adminArea.modelManagement">
-                                    <span class="fas fa-list" aria-hidden="true"></span>
-                                    <span>Model management</span>
-                                </a>
-                                <a mat-menu-item *ngIf="features.useSubscribedCatalogues" uiSref="appContainer.adminArea.subscribedCatalogues">
-                                    <span class="fas fa-rss" aria-hidden="true"></span>
-                                    <span>Subscribed catalogues</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.adminArea.emails">
-                                    <span class="fas fa-envelope" aria-hidden="true"></span>
-                                    <span>Emails</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.adminArea.users">
-                                    <span class="fas fa-user" aria-hidden="true"></span>
-                                    <span>Manage users</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.adminArea.pendingUsers">
-                                  <span class="fas fa-user-clock"></span>
-                                  <span matBadge="{{pendingUsersCount}}" matBadgeOverlap="false" matBadgeColor="warn" [matBadgeHidden]="!pendingUsersCount">Pending users</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.adminArea.groups">
-                                    <span class="fas fa-users" aria-hidden="true"></span>
-                                    <span>Manage groups</span>
-                                </a>
-                                <a mat-menu-item *ngIf="features.useOpenIdConnect" uiSref="appContainer.adminArea.openIdConnectProviders">
-                                    <span class="fab fa-openid" aria-hidden="true"></span>
-                                    <span>OpenID Connect</span>
-                                </a>
-                                <a mat-menu-item uiSref="appContainer.adminArea.configuration">
-                                    <span class="fas fa-cog" aria-hidden="true"></span>
-                                    <span>Configuration</span>
-                                </a>
-                            </div>
-                            <button *ngIf="isLoggedIn" (click)="logout()" id="navbar-logout">
-                                <span class="fas fa-sign-out-alt"></span>
-                                <span>Log out</span>
-                            </button>
-                        </mat-menu>
-                    </div>
-                </div>
-            </nav>
-            <button mat-button id="mobile-trigger" (click)="sidenav.toggle()" aria-label="Toggle mobile menu">
-                <span class="fas fa-bars"></span>
+  <div class="container">
+    <mat-toolbar id="mdm--navbar" color="primary" class="mb-0">
+      <nav
+        id="mdm--navbar-desktop"
+        flex
+        fxLayout="row"
+        fxLayoutAlign="space-between"
+      >
+        <div class="mdm--navbar-brand">
+          <a
+            id="mdm-logo"
+            class="mdm-navbar__brand--logo"
+            uiSref="appContainer.mainApp.home"
+          >
+            <img [src]="logoUrl" [style.width]="logoWidth" alt="logo" />
+          </a>
+        </div>
+        <div class="mdm--navbar-items">
+          <a
+            class="nav-item nav-link"
+            uiSref="appContainer.mainApp.home"
+            uiSrefActive="active"
+            >Home</a
+          >
+          <a
+            class="nav-item nav-link"
+            uiSref="appContainer.mainApp.twoSidePanel.catalogue.allDataModel"
+            uiSrefActive="active"
+            >Browse</a
+          >
+          <a
+            class="nav-item nav-link"
+            *ngIf="!features.useCatalogueSearch"
+            uiSref="appContainer.mainApp.twoSidePanel.catalogue.search"
+            uiSrefActive="active"
+            >Search</a
+          >
+          <a
+            class="nav-item nav-link"
+            *ngIf="features.useCatalogueSearch"
+            uiSref="appContainer.mainApp.catalogueSearch"
+            uiSrefActive="active"
+            >Search</a
+          >
+          <a
+            class="nav-item nav-link"
+            uiSref="appContainer.mainApp.about"
+            uiSrefActive="active"
+            >About</a
+          >
+        </div>
+        <div class="mdm--navbar-user">
+          <div *ngIf="!isLoggedIn">
+            <!-- <button (click)="register()" mat-button class="custom inverted-button" color="primary-A700">Register</button> TODO -->
+            <button
+              (click)="login()"
+              mat-stroked-button
+              class="custom inverted-button"
+              color="primary-A700"
+            >
+              Log in
             </button>
-        </mat-toolbar>
-    </div>
-</header>
-
-
-
-<mat-sidenav-container id="mdm--navbar-mobile" class="aside-container">
-    <mat-sidenav #sidenav mode="over" id="sidenav" fixedInViewport="fixed" fixedTopGap="0" fixedBottomGap="0" opened="false" position="end" [autoFocus]="false">
-        <nav id="sidenav-content">
-            <div *ngIf="isLoggedIn">
-                <div *ngIf="profile" class="mdm--navbar-user">
-                    <div class="profile-img">
-                      <img class="img-rounded" *ngIf="!imgChanged" src="{{backendURL}}/catalogueUsers/{{profile.id}}/image" alt="User profile">
-                    </div>
-                    <div class="profile-details">
-                        <div class="profile-name">{{profile.firstName}} {{profile.lastName}}</div>
-                        <div class="profile-role" *ngIf="profile.isAdmin">Administrator</div>
-                        <!-- <div class="profile-role text-muted">{{profile.email}} </div> -->
-                    </div>
+          </div>
+          <div *ngIf="isLoggedIn">
+            <div
+              *ngIf="profile"
+              [matMenuTriggerFor]="menu"
+              flex
+              fxLayout="row"
+              fxLayout.sm="column"
+              fxLayout.xs="column"
+              fxLayoutAlign="space-between"
+              fxLayoutGap="8px"
+              fxLayoutAlign="center center"
+              style="width: 185px"
+            >
+              <div
+                class="profile-img"
+                fxFlex="30"
+                fxFlex.sm="100"
+                fxFlex.xs="100"
+              >
+                <img
+                  class="img-rounded"
+                  *ngIf="!imgChanged"
+                  src="{{ backendURL }}/catalogueUsers/{{ profile.id }}/image"
+                  alt="User profile"
+                />
+              </div>
+              <div fxFlex="60" fxFlex.sm="100" fxFlex.xs="100">
+                <div class="profile-name">
+                  {{ profile.firstName }} {{ profile.lastName }}
                 </div>
-                <hr>
+                <div class="profile-role" *ngIf="isAdministrator">
+                  Administrator
+                </div>
+              </div>
+              <div fxFlex="10" fxFlex.sm="100" fxFlex.xs="100">
+                <span class="fas fa-chevron-down"></span>
+              </div>
             </div>
-
-            <div class="aside-main-navigation">
-                <div *ngIf="!isLoggedIn" class="aside-separator"></div>
-                <h5 class="menu-label text-muted pt-0 marginless">Main navigation</h5>
-                <a mat-menu-item uiSref="appContainer.mainApp.home" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-home"></span>
-                    <span>Home</span>
+            <mat-menu #menu="matMenu" yPosition="below" xPosition="before">
+              <div *ngIf="isLoggedIn">
+                <h5 class="marginless text-muted menu-label">
+                  Account settings
+                </h5>
+                <a mat-menu-item uiSref="appContainer.userArea.profile">
+                  <span class="fas fa-id-card"></span>
+                  <span>My profile</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.mainApp.twoSidePanel.catalogue.allDataModel"  (click)="sidenav.toggle()"uiSrefActive="active">
-                    <span class="fas fa-folder-open"></span>
-                    <span>Browse</span>
+                <a mat-menu-item uiSref="appContainer.userArea.settings">
+                  <span class="fas fa-sliders-h"></span>
+                  <span>Preferences</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.mainApp.twoSidePanel.catalogue.search" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-search"></span>
-                    <span>Search</span>
-                </a>
-                <a mat-menu-item uiSref="appContainer.mainApp.about" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-info-circle"></span>
-                    <span>About</span>
-                </a>
-            </div>
-
-            <div *ngIf="isLoggedIn">
-                <h5 class="menu-label text-muted pt-0 marginless">Account settings</h5>
-                <a mat-menu-item uiSref="appContainer.userArea.profile" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-id-card"></span>
-                    <span>My profile</span>
-                </a>
-                <a mat-menu-item uiSref="appContainer.userArea.settings" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-sliders-h"></span>
-                    <span>Preferences</span>
-                </a>
-                <a mat-menu-item uiSref="appContainer.userArea.changePassword" (click)="sidenav.toggle()" uiSrefActive="active">
+                <a mat-menu-item uiSref="appContainer.userArea.changePassword">
                   <span class="fas fa-unlock-alt"></span>
-                    <span>Change password</span>
+                  <span>Change password</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.userArea.apiKeys" (click)="sidenav.toggle()" uiSrefActive="active">
+                <a mat-menu-item uiSref="appContainer.userArea.apiKeys">
                   <span class="fas fa-key"></span>
                   <span>API keys</span>
                 </a>
-            </div>
-            <div *ngIf="isLoggedIn && isAdministrator">
-                <h5 class="menu-label text-muted pt-0 marginless">Admin settings</h5>
-                <a mat-menu-item uiSref="appContainer.adminArea.home" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-tachometer-alt"></span>
-                    <span>Dashboard</span>
+              </div>
+              <div *ngIf="isAdministrator">
+                <h5 class="marginless text-muted menu-label">Admin settings</h5>
+                <a mat-menu-item uiSref="appContainer.adminArea.home">
+                  <span class="fas fa-tachometer-alt"></span>
+                  <span>Dashboard</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.adminArea.modelManagement" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-list" aria-hidden="true"></span>
-                    <span>Model management</span>
+                <a
+                  mat-menu-item
+                  uiSref="appContainer.adminArea.modelManagement"
+                >
+                  <span class="fas fa-list" aria-hidden="true"></span>
+                  <span>Model management</span>
                 </a>
-                <a mat-menu-item *ngIf="features.useSubscribedCatalogues" uiSref="appContainer.adminArea.subscribedCatalogues" (click)="sidenav.toggle()" uiSrefActive="active">
+                <a
+                  mat-menu-item
+                  *ngIf="features.useSubscribedCatalogues"
+                  uiSref="appContainer.adminArea.subscribedCatalogues"
+                >
                   <span class="fas fa-rss" aria-hidden="true"></span>
                   <span>Subscribed catalogues</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.adminArea.emails" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-envelope" aria-hidden="true"></span>
-                    <span>Emails</span>
+                <a mat-menu-item uiSref="appContainer.adminArea.emails">
+                  <span class="fas fa-envelope" aria-hidden="true"></span>
+                  <span>Emails</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.adminArea.users" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-user" aria-hidden="true"></span>
-                    <span>Manage users</span>
+                <a mat-menu-item uiSref="appContainer.adminArea.users">
+                  <span class="fas fa-user" aria-hidden="true"></span>
+                  <span>Manage users</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.adminArea.pendingUsers" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-user-clock"></span>
-                    <span matBadge="{{pendingUsersCount}}" matBadgeOverlap="false" matBadgeColor="warn" [matBadgeHidden]="!pendingUsersCount">Pending users</span>
+                <a mat-menu-item uiSref="appContainer.adminArea.pendingUsers">
+                  <span class="fas fa-user-clock"></span>
+                  <span
+                    matBadge="{{ pendingUsersCount }}"
+                    matBadgeOverlap="false"
+                    matBadgeColor="warn"
+                    [matBadgeHidden]="!pendingUsersCount"
+                    >Pending users</span
+                  >
                 </a>
-                <a mat-menu-item uiSref="appContainer.adminArea.groups" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-users" aria-hidden="true"></span>
-                    <span>Manage groups</span>
+                <a mat-menu-item uiSref="appContainer.adminArea.groups">
+                  <span class="fas fa-users" aria-hidden="true"></span>
+                  <span>Manage groups</span>
                 </a>
-                <a mat-menu-item *ngIf="features.useOpenIdConnect" uiSref="appContainer.adminArea.openIdConnectProviders" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fab fa-openid" aria-hidden="true"></span>
-                    <span>OpenID Connect</span>
+                <a
+                  mat-menu-item
+                  *ngIf="features.useOpenIdConnect"
+                  uiSref="appContainer.adminArea.openIdConnectProviders"
+                >
+                  <span class="fab fa-openid" aria-hidden="true"></span>
+                  <span>OpenID Connect</span>
                 </a>
-                <a mat-menu-item uiSref="appContainer.adminArea.configuration" (click)="sidenav.toggle()" uiSrefActive="active">
-                    <span class="fas fa-cog" aria-hidden="true"></span>
-                    <span>Configuration</span>
+                <a mat-menu-item uiSref="appContainer.adminArea.configuration">
+                  <span class="fas fa-cog" aria-hidden="true"></span>
+                  <span>Configuration</span>
                 </a>
-            </div>
-        </nav>
-        <div *ngIf="!isLoggedIn" class="aside-user-actions mb-2">
-            <button (click)="login()" mat-flat-button class="custom" color="primary">Log in</button>
-            <!-- <button (click)="register()" mat-button class="custom" color="primary">Register an account</button> TODO -->
+              </div>
+              <button *ngIf="isLoggedIn" (click)="logout()" id="navbar-logout">
+                <span class="fas fa-sign-out-alt"></span>
+                <span>Log out</span>
+              </button>
+            </mat-menu>
+          </div>
         </div>
+      </nav>
+      <button
+        mat-button
+        id="mobile-trigger"
+        (click)="sidenav.toggle()"
+        aria-label="Toggle mobile menu"
+      >
+        <span class="fas fa-bars"></span>
+      </button>
+    </mat-toolbar>
+  </div>
+</header>
 
-        <button *ngIf="isLoggedIn" (click)="logout()" id="navbar-logout">
-            <span class="fas fa-sign-out-alt"></span>
-            <span>Log out</span>
-        </button>
-    </mat-sidenav>
+<mat-sidenav-container id="mdm--navbar-mobile" class="aside-container">
+  <mat-sidenav
+    #sidenav
+    mode="over"
+    id="sidenav"
+    fixedInViewport="fixed"
+    fixedTopGap="0"
+    fixedBottomGap="0"
+    opened="false"
+    position="end"
+    [autoFocus]="false"
+  >
+    <nav id="sidenav-content">
+      <div *ngIf="isLoggedIn">
+        <div *ngIf="profile" class="mdm--navbar-user">
+          <div class="profile-img">
+            <img
+              class="img-rounded"
+              *ngIf="!imgChanged"
+              src="{{ backendURL }}/catalogueUsers/{{ profile.id }}/image"
+              alt="User profile"
+            />
+          </div>
+          <div class="profile-details">
+            <div class="profile-name">
+              {{ profile.firstName }} {{ profile.lastName }}
+            </div>
+            <div class="profile-role" *ngIf="profile.isAdmin">
+              Administrator
+            </div>
+            <!-- <div class="profile-role text-muted">{{profile.email}} </div> -->
+          </div>
+        </div>
+        <hr />
+      </div>
 
-    <mat-sidenav-content></mat-sidenav-content>
+      <div class="aside-main-navigation">
+        <div *ngIf="!isLoggedIn" class="aside-separator"></div>
+        <h5 class="menu-label text-muted pt-0 marginless">Main navigation</h5>
+        <a
+          mat-menu-item
+          uiSref="appContainer.mainApp.home"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-home"></span>
+          <span>Home</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.mainApp.twoSidePanel.catalogue.allDataModel"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-folder-open"></span>
+          <span>Browse</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.mainApp.twoSidePanel.catalogue.search"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-search"></span>
+          <span>Search</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.mainApp.about"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-info-circle"></span>
+          <span>About</span>
+        </a>
+      </div>
+
+      <div *ngIf="isLoggedIn">
+        <h5 class="menu-label text-muted pt-0 marginless">Account settings</h5>
+        <a
+          mat-menu-item
+          uiSref="appContainer.userArea.profile"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-id-card"></span>
+          <span>My profile</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.userArea.settings"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-sliders-h"></span>
+          <span>Preferences</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.userArea.changePassword"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-unlock-alt"></span>
+          <span>Change password</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.userArea.apiKeys"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-key"></span>
+          <span>API keys</span>
+        </a>
+      </div>
+      <div *ngIf="isLoggedIn && isAdministrator">
+        <h5 class="menu-label text-muted pt-0 marginless">Admin settings</h5>
+        <a
+          mat-menu-item
+          uiSref="appContainer.adminArea.home"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-tachometer-alt"></span>
+          <span>Dashboard</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.adminArea.modelManagement"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-list" aria-hidden="true"></span>
+          <span>Model management</span>
+        </a>
+        <a
+          mat-menu-item
+          *ngIf="features.useSubscribedCatalogues"
+          uiSref="appContainer.adminArea.subscribedCatalogues"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-rss" aria-hidden="true"></span>
+          <span>Subscribed catalogues</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.adminArea.emails"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-envelope" aria-hidden="true"></span>
+          <span>Emails</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.adminArea.users"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-user" aria-hidden="true"></span>
+          <span>Manage users</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.adminArea.pendingUsers"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-user-clock"></span>
+          <span
+            matBadge="{{ pendingUsersCount }}"
+            matBadgeOverlap="false"
+            matBadgeColor="warn"
+            [matBadgeHidden]="!pendingUsersCount"
+            >Pending users</span
+          >
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.adminArea.groups"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-users" aria-hidden="true"></span>
+          <span>Manage groups</span>
+        </a>
+        <a
+          mat-menu-item
+          *ngIf="features.useOpenIdConnect"
+          uiSref="appContainer.adminArea.openIdConnectProviders"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fab fa-openid" aria-hidden="true"></span>
+          <span>OpenID Connect</span>
+        </a>
+        <a
+          mat-menu-item
+          uiSref="appContainer.adminArea.configuration"
+          (click)="sidenav.toggle()"
+          uiSrefActive="active"
+        >
+          <span class="fas fa-cog" aria-hidden="true"></span>
+          <span>Configuration</span>
+        </a>
+      </div>
+    </nav>
+    <div *ngIf="!isLoggedIn" class="aside-user-actions mb-2">
+      <button (click)="login()" mat-flat-button class="custom" color="primary">
+        Log in
+      </button>
+      <!-- <button (click)="register()" mat-button class="custom" color="primary">Register an account</button> TODO -->
+    </div>
+
+    <button *ngIf="isLoggedIn" (click)="logout()" id="navbar-logout">
+      <span class="fas fa-sign-out-alt"></span>
+      <span>Log out</span>
+    </button>
+  </mat-sidenav>
+
+  <mat-sidenav-content></mat-sidenav-content>
 </mat-sidenav-container>

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -29,7 +29,10 @@ import { EditingService } from '@mdm/services/editing.service';
 import { ThemingService } from '@mdm/services/theming.service';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { catchError, map, takeUntil } from 'rxjs/operators';
-import { ApiProperty, ApiPropertyIndexResponse } from '@maurodatamapper/mdm-resources';
+import {
+  ApiProperty,
+  ApiPropertyIndexResponse
+} from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-navbar',
@@ -37,7 +40,6 @@ import { ApiProperty, ApiPropertyIndexResponse } from '@maurodatamapper/mdm-reso
   styleUrls: ['./navbar.component.scss']
 })
 export class NavbarComponent implements OnInit, OnDestroy {
-
   profilePictureReloadIndex = 0;
   profile: any;
   logoUrl: string;
@@ -62,16 +64,18 @@ export class NavbarComponent implements OnInit, OnDestroy {
     private broadcast: BroadcastService,
     private editingService: EditingService,
     private theming: ThemingService,
-    private resources: MdmResourcesService) { }
+    private resources: MdmResourcesService
+  ) {}
 
   ngOnInit() {
-
     this.broadcast
       .onUserLoggedIn()
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(() => {
         this.isLoggedIn = true;
-        this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
+        this.securityHandler
+          .isAdministrator()
+          .subscribe((state) => (this.isAdministrator = state));
       });
 
     this.broadcast
@@ -83,7 +87,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
       });
 
     this.isLoggedIn = this.securityHandler.isLoggedIn();
-    this.securityHandler.isAdministrator().subscribe(state => this.isAdministrator = state);
+    this.securityHandler
+      .isAdministrator()
+      .subscribe((state) => (this.isAdministrator = state));
 
     if (this.isLoggedIn) {
       this.profile = this.securityHandler.getCurrentUser();
@@ -124,12 +130,14 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.resources.apiProperties
       .listPublic()
       .pipe(
-        map((response: ApiPropertyIndexResponse) => response.body.items.filter(p => p.key.startsWith('theme.logo.'))),
+        map((response: ApiPropertyIndexResponse) =>
+          response.body.items.filter((p) => p.key.startsWith('theme.logo.'))
+        ),
         catchError(() => [])
       )
       .subscribe((properties: ApiProperty[]) => {
-        const logoUrl = properties.find(p => p.key === 'theme.logo.url');
-        const logoWidth = properties.find(p => p.key === 'theme.logo.width');
+        const logoUrl = properties.find((p) => p.key === 'theme.logo.url');
+        const logoWidth = properties.find((p) => p.key === 'theme.logo.width');
 
         if (logoUrl) {
           this.logoUrl = logoUrl.value;
@@ -142,22 +150,30 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   getPendingUsers = () => {
-    this.sharedService.pendingUsersCount().subscribe(data => {
+    this.sharedService.pendingUsersCount().subscribe((data) => {
       this.pendingUsersCount = data.body.count;
     });
   };
 
   login = () => {
-    this.dialog.open(LoginModalComponent, {}).afterClosed().subscribe((user) => {
-      if (user) {
-        if (user.needsToResetPassword) {
-          this.broadcast.userLoggedIn({ nextRoute: 'appContainer.userArea.changePassword' });
-          return;
+    this.dialog
+      .open(LoginModalComponent, {})
+      .afterClosed()
+      .subscribe((user) => {
+        if (user) {
+          if (user.needsToResetPassword) {
+            this.broadcast.userLoggedIn({
+              nextRoute: 'appContainer.userArea.changePassword'
+            });
+            return;
+          }
+          this.profile = user;
+          this.broadcast.userLoggedIn({
+            nextRoute:
+              'appContainer.mainApp.twoSidePanel.catalogue.allDataModel'
+          });
         }
-        this.profile = user;
-        this.broadcast.userLoggedIn({ nextRoute: 'appContainer.mainApp.twoSidePanel.catalogue.allDataModel' });
-      }
-    });
+      });
   };
 
   logout = () => {
@@ -168,18 +184,24 @@ export class NavbarComponent implements OnInit, OnDestroy {
     this.dialog.open(ForgotPasswordModalComponent, {});
   };
   register = () => {
-    const dialog = this.dialog.open(RegisterModalComponent, { panelClass: 'register-modal' });
+    const dialog = this.dialog.open(RegisterModalComponent, {
+      panelClass: 'register-modal'
+    });
 
     this.editingService.configureDialogRef(dialog);
 
-    dialog.afterClosed().subscribe(user => {
+    dialog.afterClosed().subscribe((user) => {
       if (user) {
         if (user.needsToResetPassword) {
-          this.broadcast.userLoggedIn({ nextRoute: 'appContainer.userArea.change-password' });
+          this.broadcast.userLoggedIn({
+            nextRoute: 'appContainer.userArea.change-password'
+          });
           return;
         }
         this.profile = user;
-        this.broadcast.userLoggedIn({ nextRoute: 'appContainer.mainApp.twoSidePanel.catalogue.allDataModel' });
+        this.broadcast.userLoggedIn({
+          nextRoute: 'appContainer.mainApp.twoSidePanel.catalogue.allDataModel'
+        });
       }
     });
   };

--- a/src/app/services/features.service.ts
+++ b/src/app/services/features.service.ts
@@ -18,7 +18,10 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable, OnDestroy } from '@angular/core';
 import { environment } from '@env/environment';
-import { ApiProperty, ApiPropertyIndexResponse } from '@maurodatamapper/mdm-resources';
+import {
+  ApiProperty,
+  ApiPropertyIndexResponse
+} from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { EMPTY, Subject } from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
@@ -35,13 +38,15 @@ export class FeaturesService implements OnDestroy {
   useOpenIdConnect: boolean;
   useDigitalObjectIdentifiers: boolean;
   useIssueReporting: boolean;
+  useCatalogueSearch: boolean;
 
   private unsubscribe$ = new Subject();
 
   constructor(
     private resources: MdmResourcesService,
     private messageHandler: MessageHandlerService,
-    private broadcast: BroadcastService) {
+    private broadcast: BroadcastService
+  ) {
     this.setFeatures([]);
     this.loadFromServer();
 
@@ -60,13 +65,18 @@ export class FeaturesService implements OnDestroy {
     this.resources.apiProperties
       .listPublic()
       .pipe(
-        catchError(errors => {
-          this.messageHandler.showError('There was a problem getting the configuration properties for features.', errors);
+        catchError((errors) => {
+          this.messageHandler.showError(
+            'There was a problem getting the configuration properties for features.',
+            errors
+          );
           return EMPTY;
         })
       )
       .subscribe((response: ApiPropertyIndexResponse) => {
-        const featureFlags = response.body.items.filter(prop => prop.category === 'Features');
+        const featureFlags = response.body.items.filter(
+          (prop) => prop.category === 'Features'
+        );
         this.setFeatures(featureFlags);
       });
   }
@@ -75,36 +85,52 @@ export class FeaturesService implements OnDestroy {
     this.useSubscribedCatalogues = this.getBooleanValue(
       properties,
       'feature.use_subscribed_catalogues',
-      environment.features.useSubscribedCatalogues);
+      environment.features.useSubscribedCatalogues
+    );
 
     this.useVersionedFolders = this.getBooleanValue(
       properties,
       'feature.use_versioned_folders',
-      environment.features.useVersionedFolders);
+      environment.features.useVersionedFolders
+    );
 
     this.useMergeUiV2 = this.getBooleanValue(
       properties,
       'feature.use_merge_diff_ui',
-      environment.features.useMergeUiV2);
+      environment.features.useMergeUiV2
+    );
 
     this.useOpenIdConnect = this.getBooleanValue(
       properties,
       'feature.use_open_id_connect',
-      environment.features.useOpenIdConnect);
+      environment.features.useOpenIdConnect
+    );
 
     this.useDigitalObjectIdentifiers = this.getBooleanValue(
       properties,
       'feature.use_digital_object_identifiers',
-      environment.features.useDigitalObjectIdentifiers);
+      environment.features.useDigitalObjectIdentifiers
+    );
 
     this.useIssueReporting = this.getBooleanValue(
       properties,
       'feature.use_issue_reporting',
-      environment.features.useIssueReporting);
+      environment.features.useIssueReporting
+    );
+
+    this.useCatalogueSearch = this.getBooleanValue(
+      properties,
+      'feature.use_catalogue_search',
+      environment.features.useCatalogueSearch
+    );
   }
 
-  private getBooleanValue(properties: ApiProperty[], key: string, defaultValue: boolean): boolean {
-    const feature = properties.find(prop => prop.key === key);
+  private getBooleanValue(
+    properties: ApiProperty[],
+    key: string,
+    defaultValue: boolean
+  ): boolean {
+    const feature = properties.find((prop) => prop.key === key);
     return feature ? feature.value === 'true' : defaultValue;
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -25,20 +25,27 @@ export const environment = {
   HDFLink: '',
   themeName: $ENV.themeName ?? 'default',
   appTitle: 'Mauro Data Mapper',
-  appDescription: 'The Mauro Data Mapper is a toolkit for creating, sharing, and updating data models.',
+  appDescription:
+    'The Mauro Data Mapper is a toolkit for creating, sharing, and updating data models.',
   catalogueDisplayName: 'Mauro Data Mapper',
   issueReporting: {
     defaultUrl: 'https://github.com/MauroDataMapper/mdm-ui/issues/new/choose',
-    systemErrorUrl: 'https://github.com/MauroDataMapper/mdm-ui/issues/new?assignees=&labels=system%20error&template=system_error_report.md&title='
+    systemErrorUrl:
+      'https://github.com/MauroDataMapper/mdm-ui/issues/new?assignees=&labels=system%20error&template=system_error_report.md&title='
   },
   documentation: {
     url: 'https://maurodatamapper.github.io/',
     pages: {
-      Create_a_new_model: 'user-guides/create-a-data-model/create-a-data-model/',
-      Edit_model_details: 'user-guides/create-a-data-model/create-a-data-model/#3-complete-new-data-model-form',
-      Exporting_models: 'user-guides/exporting-data-models/exporting-data-models/',
-      Importing_DataModels_Using_Excel: 'user-guides/import-data-model-from-excel/import-data-model-from-excel/',
-      Preferences: 'user-guides/user-profile/user-profile/#3-update-preferences',
+      Create_a_new_model:
+        'user-guides/create-a-data-model/create-a-data-model/',
+      Edit_model_details:
+        'user-guides/create-a-data-model/create-a-data-model/#3-complete-new-data-model-form',
+      Exporting_models:
+        'user-guides/exporting-data-models/exporting-data-models/',
+      Importing_DataModels_Using_Excel:
+        'user-guides/import-data-model-from-excel/import-data-model-from-excel/',
+      Preferences:
+        'user-guides/user-profile/user-profile/#3-update-preferences',
       Search_Help: 'user-guides/how-to-search/how-to-search/',
       User_profile: 'user-guides/user-profile/user-profile/',
       Merge_conflicts: null
@@ -56,6 +63,7 @@ export const environment = {
     useMergeUiV2: true,
     useOpenIdConnect: false,
     useDigitalObjectIdentifiers: false,
-    useIssueReporting: false
+    useIssueReporting: false,
+    useCatalogueSearch: false
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -29,20 +29,27 @@ export const environment = {
   HDFLink: '',
   themeName: 'default',
   appTitle: 'Mauro Data Mapper',
-  appDescription: 'The Mauro Data Mapper is a toolkit for creating, sharing, and updating data models.',
+  appDescription:
+    'The Mauro Data Mapper is a toolkit for creating, sharing, and updating data models.',
   catalogueDisplayName: 'Mauro Data Mapper',
   issueReporting: {
     defaultUrl: 'https://github.com/MauroDataMapper/mdm-ui/issues/new/choose',
-    systemErrorUrl: 'https://github.com/MauroDataMapper/mdm-ui/issues/new?assignees=&labels=system%20error&template=system_error_report.md&title='
+    systemErrorUrl:
+      'https://github.com/MauroDataMapper/mdm-ui/issues/new?assignees=&labels=system%20error&template=system_error_report.md&title='
   },
   documentation: {
     url: 'https://maurodatamapper.github.io/',
     pages: {
-      Create_a_new_model: 'user-guides/create-a-data-model/create-a-data-model/',
-      Edit_model_details: 'user-guides/create-a-data-model/create-a-data-model/#3-complete-new-data-model-form',
-      Exporting_models: 'user-guides/exporting-data-models/exporting-data-models/',
-      Importing_DataModels_Using_Excel: 'user-guides/import-data-model-from-excel/import-data-model-from-excel/',
-      Preferences: 'user-guides/user-profile/user-profile/#3-update-preferences',
+      Create_a_new_model:
+        'user-guides/create-a-data-model/create-a-data-model/',
+      Edit_model_details:
+        'user-guides/create-a-data-model/create-a-data-model/#3-complete-new-data-model-form',
+      Exporting_models:
+        'user-guides/exporting-data-models/exporting-data-models/',
+      Importing_DataModels_Using_Excel:
+        'user-guides/import-data-model-from-excel/import-data-model-from-excel/',
+      Preferences:
+        'user-guides/user-profile/user-profile/#3-update-preferences',
       Search_Help: 'user-guides/how-to-search/how-to-search/',
       User_profile: 'user-guides/user-profile/user-profile/',
       Merge_conflicts: null
@@ -60,7 +67,8 @@ export const environment = {
     useMergeUiV2: true,
     useOpenIdConnect: true,
     useDigitalObjectIdentifiers: true,
-    useIssueReporting: true
+    useIssueReporting: true,
+    useCatalogueSearch: false
   }
 };
 


### PR DESCRIPTION
Resolves #523 

**Note:** this is the precursor to other new Catalogue Search tasks, namely:

* #524 
* #525 
* #526 
* #527 
* #528 
* #529 

This PR must be approved and merged before these issues can start. Also, this PR is designed to only produce a rudimentary skeleton for initial work to start, the landing page currently implemented will just show nothing at the moment.

To be able to see the new (initial) Catalogue Search page, you need to either:

* Add the `feature.use_catalogue_search` API property to your own Mauro instance (preferred), or
* Set the `useCatalogueSearch` boolean flag in `environment.ts`

# Changes

* New Angular module to contain future components created
* First landing component created, initially empty
* Add feature switch to control access to new Catalogue Search or continue using existing search page
* Update navigation to go to new search landing page
* Updating route transition hooks to pre-check for feature switches