### PR TITLE
gh-525 Updated search results page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -76,6 +76,7 @@ import { BulkEditContainerComponent } from './bulk-edit/bulk-edit-container/bulk
 import { TerminologyMainComponent } from './wizards/terminology/terminology-main/terminology-main.component';
 import { CatalogueSearchComponent } from './catalogue-search/catalogue-search/catalogue-search.component';
 import { FeaturesService } from './services/features.service';
+import { CatalogueSearchListingComponent } from './catalogue-search/catalogue-search-listing/catalogue-search-listing.component';
 
 /**
  * Collection of all page state routes.
@@ -448,6 +449,22 @@ export const pageRoutes: { states: Ng2StateDeclaration[] } = {
       data: {
         allowAnonymous: true,
         featureSwitch: 'useCatalogueSearch'
+      }
+    },
+    {
+      name: 'appContainer.mainApp.catalogueSearchListing',
+      url:
+        '/search/listing?{search:string}&{page:int}&{sort:string}&{order:string}',
+      component: CatalogueSearchListingComponent,
+      data: {
+        allowAnonymous: true,
+        featureSwitch: 'useCatalogueSearch'
+      },
+      params: {
+        search: null,
+        page: null,
+        sort: null,
+        order: null
       }
     }
   ]

--- a/src/app/catalogue-search/breadcrumb/breadcrumb.component.html
+++ b/src/app/catalogue-search/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,26 @@
+<!--
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<ng-container *ngIf="item">
+  <ng-container *ngFor="let crumb of item.breadcrumbs">
+    <span> {{ crumb.label }} > </span>
+  </ng-container>
+  <span>
+    {{ item.label }}
+  </span>
+</ng-container>

--- a/src/app/catalogue-search/breadcrumb/breadcrumb.component.scss
+++ b/src/app/catalogue-search/breadcrumb/breadcrumb.component.scss
@@ -1,0 +1,18 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/

--- a/src/app/catalogue-search/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/catalogue-search/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,67 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent
+} from '@mdm/testing/testing.helpers';
+
+import { BreadcrumbComponent, TrailableItem } from './breadcrumb.component';
+
+describe('BreadcrumbComponent', () => {
+  let harness: ComponentHarness<BreadcrumbComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(BreadcrumbComponent);
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+    expect(harness.component.item).toBeUndefined();
+  });
+
+  it('should render a crumb per item in the breadcrumb', () => {
+    const dom = harness.fixture.nativeElement;
+
+    const item: TrailableItem = {
+      id: '1',
+      label: 'item',
+      domainType: CatalogueItemDomainType.DataElement,
+      breadcrumbs: [
+        {
+          id: '2',
+          label: 'root',
+          domainType: CatalogueItemDomainType.DataModel
+        },
+        {
+          id: '3',
+          label: 'parent',
+          domainType: CatalogueItemDomainType.DataClass
+        }
+      ]
+    };
+
+    harness.component.item = item;
+    harness.detectChanges();
+
+    const crumbSpans = dom.querySelectorAll('span');
+    // Note: don't display breadcrumb for the data model
+    expect(crumbSpans.length).toBe(item.breadcrumbs!.length + 1); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  });
+});

--- a/src/app/catalogue-search/breadcrumb/breadcrumb.component.ts
+++ b/src/app/catalogue-search/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,40 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, Input } from '@angular/core';
+import {
+  Breadcrumb,
+  CatalogueItemDomainType,
+  Uuid
+} from '@maurodatamapper/mdm-resources';
+
+export interface TrailableItem {
+  id?: Uuid;
+  label: string;
+  domainType?: CatalogueItemDomainType;
+  breadcrumbs?: Breadcrumb[];
+}
+
+@Component({
+  selector: 'mdm-breadcrumb',
+  templateUrl: './breadcrumb.component.html',
+  styleUrls: ['./breadcrumb.component.scss']
+})
+export class BreadcrumbComponent {
+  @Input() item?: TrailableItem;
+}

--- a/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.html
+++ b/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.html
@@ -1,0 +1,52 @@
+<!--
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div
+  *ngIf="item"
+  class="mdm-catalogue-item-search-result panel panel-default mdm--shadow-block"
+>
+  <div class="mdm-catalogue-item-search-result__header">
+    <span>
+      <h3>
+        {{ item.label }}
+      </h3>
+      <mdm-breadcrumb
+        *ngIf="showBreadcrumb"
+        class="mdm-data-element-search-result__header__breadcrumb"
+        [item]="item"
+      ></mdm-breadcrumb>
+    </span>
+    <span>
+      {{ item.domainType }}
+    </span>
+  </div>
+  <div class="panel-body">
+    <div
+      *ngIf="item.description"
+      class="mdm-catalogue-item-search-result__content"
+    >
+      <mdm-content-editor
+        [inEditMode]="false"
+        [content]="item.description"
+      ></mdm-content-editor>
+    </div>
+    <div class="mdm-catalogue-item-search-result__footer">
+      <a [href]="linkUrl">View Details</a>
+    </div>
+  </div>
+</div>

--- a/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.scss
+++ b/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.scss
@@ -1,0 +1,76 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+@use '~@angular/material' as mat;
+
+@mixin mdm-catalogue-item-search-result-theme($theme) {
+  $primary: map-get($theme, primary);
+
+  $search-result-heading-background-color: mat.get-color-from-palette($primary);
+  $search-result-heading-color: mat.get-color-from-palette(
+    $primary,
+    '500-contrast'
+  );
+
+  .mdm-catalogue-item-search-result {
+    &__header {
+      background-color: $search-result-heading-background-color;
+      color: $search-result-heading-color;
+    }
+  }
+}
+
+$search-result-header-padding: 0.5em 0.5em;
+$search-result-content-padding: 0.8em 1.2em;
+$search-result-border-radius: 4px;
+
+.mdm-catalogue-item-search-result {
+  margin-bottom: 2em;
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: $search-result-header-padding;
+    border-radius: $search-result-border-radius;
+
+    h3 {
+      display: inline-block;
+      font-weight: 500;
+      margin: 0 1em;
+      vertical-align: middle;
+    }
+
+    &__breadcrumb {
+      vertical-align: middle;
+      font-size: 13px;
+    }
+  }
+
+  &__content,
+  &__footer {
+    padding: $search-result-content-padding;
+    display: flex;
+    justify-content: space-between;
+    border-radius: $search-result-border-radius;
+  }
+
+  .panel-body {
+    padding: 0;
+  }
+}

--- a/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.spec.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  ComponentHarness,
+  setupTestModuleForComponent
+} from '@mdm/testing/testing.helpers';
+import { CatalogueItemSearchResultComponent } from './catalogue-item-search-result.component';
+
+describe('CatalogueItemSearchResultComponent', () => {
+  let harness: ComponentHarness<CatalogueItemSearchResultComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(
+      CatalogueItemSearchResultComponent
+    );
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+});

--- a/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.ts
+++ b/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.ts
@@ -1,0 +1,42 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { CatalogueItemSearchResult } from '@maurodatamapper/mdm-resources';
+import { ElementTypesService } from '@mdm/services';
+
+@Component({
+  selector: 'mdm-catalogue-item-search-result',
+  templateUrl: './catalogue-item-search-result.component.html',
+  styleUrls: ['./catalogue-item-search-result.component.scss']
+})
+export class CatalogueItemSearchResultComponent implements OnChanges {
+  @Input() item?: CatalogueItemSearchResult;
+
+  @Input() showBreadcrumb = false;
+
+  linkUrl = '';
+
+  constructor(private elementTypes: ElementTypesService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.item) {
+      this.linkUrl = this.elementTypes.getLinkUrl(this.item);
+    }
+  }
+}

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.html
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.html
@@ -1,0 +1,83 @@
+<!--
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div class="container">
+  <div class="mdm-search-listing__search">
+    <form role="form" name="search" (submit)="updateSearch()">
+      <mat-form-field
+        appearance="outline"
+        class="mdm-search-listing__search-input"
+      >
+        <input
+          matInput
+          placeholder="Search"
+          name="search"
+          [(ngModel)]="searchTerms"
+        />
+        <button mat-icon-button matSuffix type="submit">
+          <mat-icon fontSet="fas" fontIcon="fa-search"></mat-icon>
+        </button>
+      </mat-form-field>
+    </form>
+  </div>
+  <div *ngIf="status === 'loading'" class="mdm-search-listing__loading">
+    <mat-spinner color="primary" class="mat-spinner"></mat-spinner>
+    <p>Searching for matches...</p>
+  </div>
+  <div *ngIf="status === 'error'" class="mdm-search-listing__error">
+    <mdm-alert alertStyle="error" [showIcon]="true">
+      Unfortunately there was a problem finding any matches for your search.
+      Please try again.
+    </mdm-alert>
+  </div>
+  <div *ngIf="status === 'ready'">
+    <div class="row">
+      <div class="col">
+        <div class="mdm-search-listing__sort-row">
+          <div class="vertically-aligned">
+            {{ resultSet?.totalResults }} results found
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col">
+        <mdm-catalogue-item-search-result
+          *ngFor="let item of resultSet.items"
+          [item]="item"
+          [showBreadcrumb]="true"
+        ></mdm-catalogue-item-search-result>
+        <div
+          *ngIf="resultSet.totalResults === 0"
+          class="mdm-search-listing__no-results"
+        >
+          <mdm-alert alertStyle="info">
+            <p>
+              Unfortunately we could not find any matches based on this
+              criteria. Try:
+            </p>
+            <ul>
+              <li>Changing your search term to be less specific.</li>
+              <li>Removing some, or all, of the search filters.</li>
+            </ul>
+          </mdm-alert>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.scss
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.scss
@@ -1,0 +1,57 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+.mdm-search-listing {
+  &__search {
+    text-align: center;
+  }
+
+  &__sort-row {
+    display: flex;
+    justify-content: space-between;
+    margin: 1em 0;
+
+    .vertically-aligned {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  &__search-input {
+    width: 50%;
+  }
+
+  &__loading {
+    text-align: center;
+    padding-bottom: 2.5em;
+
+    .mat-spinner {
+      margin: 2em auto;
+    }
+  }
+
+  &__error {
+    margin: 0 2em;
+  }
+
+  &__no-results {
+    padding: 2em 3em;
+    margin: 0 auto;
+    border-radius: 4px;
+  }
+}

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.spec.ts
@@ -1,0 +1,183 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CatalogueItemDomainType,
+  CatalogueItemSearchResult
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent
+} from '@mdm/testing/testing.helpers';
+import { StateParams, UIRouterGlobals } from '@uirouter/core';
+import { of, throwError } from 'rxjs';
+import {
+  CatalogueSearchParameters,
+  mapSearchParametersToRawParams
+} from '../catalogue-search.types';
+
+import { CatalogueSearchListingComponent } from './catalogue-search-listing.component';
+
+interface MdmResourcesServiceStub {
+  catalogueItem: {
+    search: jest.Mock;
+  };
+}
+
+const resourcesStub: MdmResourcesServiceStub = {
+  catalogueItem: {
+    search: jest.fn()
+  }
+};
+
+describe('CatalogueSearchListingComponent', () => {
+  let harness: ComponentHarness<CatalogueSearchListingComponent>;
+
+  const setupComponentTest = async (parameters: CatalogueSearchParameters) => {
+    const params = mapSearchParametersToRawParams(parameters);
+
+    const routerGlobalsStub: UIRouterGlobals = {
+      params: new StateParams(params)
+    } as UIRouterGlobals;
+
+    return await setupTestModuleForComponent(CatalogueSearchListingComponent, {
+      providers: [
+        {
+          provide: UIRouterGlobals,
+          useValue: routerGlobalsStub
+        },
+        {
+          provide: MdmResourcesService,
+          useValue: resourcesStub
+        }
+      ]
+    });
+  };
+
+  describe('creation', () => {
+    beforeEach(async () => {
+      harness = await setupComponentTest({});
+    });
+
+    it('should create', () => {
+      expect(harness.isComponentCreated).toBeTruthy();
+      expect(harness.component.status).toBe('init');
+      expect(harness.component.parameters).toStrictEqual({});
+      expect(harness.component.resultSet).toBeUndefined();
+    });
+  });
+
+  describe('standard initialisation', () => {
+    const parameters: CatalogueSearchParameters = {
+      search: 'test'
+    };
+
+    beforeEach(async () => {
+      harness = await setupComponentTest(parameters);
+
+      // Don't care about what mock search returns for these scenarios
+      resourcesStub.catalogueItem.search.mockImplementationOnce(() => {
+        return of({});
+      });
+
+      harness.component.ngOnInit();
+    });
+
+    it('should set the parameters to the page', () => {
+      expect(harness.component.parameters.search).toBe(parameters.search);
+    });
+
+    it('should set the starting search term on the page', () => {
+      expect(harness.component.searchTerms).toBe(parameters.search);
+    });
+  });
+
+  describe('no search terms provided', () => {
+    const parameters: CatalogueSearchParameters = {
+      search: ''
+    };
+
+    beforeEach(async () => {
+      harness = await setupComponentTest(parameters);
+      harness.component.ngOnInit();
+    });
+
+    it('should render an empty state to the page', () => {
+      expect(harness.component.resultSet.totalResults).toBe(0);
+      expect(harness.component.status).toBe('ready');
+    });
+  });
+
+  describe('full catalogue search', () => {
+    const parameters: CatalogueSearchParameters = {
+      search: 'test'
+    };
+
+    beforeEach(async () => {
+      harness = await setupComponentTest(parameters);
+    });
+
+    it('should display the expected search results', () => {
+      const totalResults = 100;
+      const catalogueItems: CatalogueItemSearchResult[] = [
+        {
+          label: 'item 1',
+          domainType: CatalogueItemDomainType.DataModel,
+          breadcrumbs: []
+        },
+        {
+          label: 'item 2',
+          domainType: CatalogueItemDomainType.DataClass,
+          breadcrumbs: []
+        },
+        {
+          label: 'item 3',
+          domainType: CatalogueItemDomainType.DataElement,
+          breadcrumbs: []
+        }
+      ];
+
+      resourcesStub.catalogueItem.search.mockImplementationOnce(() => {
+        return of({
+          body: {
+            count: totalResults,
+            items: catalogueItems
+          }
+        });
+      });
+
+      harness.component.ngOnInit();
+
+      expect(harness.component.resultSet.totalResults).toBe(totalResults);
+      expect(harness.component.resultSet.items).toBe(catalogueItems);
+      expect(harness.component.status).toBe('ready');
+    });
+
+    it('should display an error when search fails', () => {
+      resourcesStub.catalogueItem.search.mockImplementation(() =>
+        throwError(new Error())
+      );
+
+      harness.component.ngOnInit();
+
+      expect(harness.component.status).toBe('error');
+      expect(harness.component.resultSet).toBeUndefined();
+    });
+  });
+});

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
@@ -1,0 +1,100 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, OnInit } from '@angular/core';
+import { MessageHandlerService, StateHandlerService } from '@mdm/services';
+import { UIRouterGlobals } from '@uirouter/core';
+import { EMPTY } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { CatalogueSearchService } from '../catalogue-search.service';
+import {
+  CatalogueSearchParameters,
+  CatalogueSearchResultSet,
+  mapStateParamsToSearchParameters
+} from '../catalogue-search.types';
+
+export type SearchListingStatus = 'init' | 'loading' | 'ready' | 'error';
+
+@Component({
+  selector: 'mdm-catalogue-search-listing',
+  templateUrl: './catalogue-search-listing.component.html',
+  styleUrls: ['./catalogue-search-listing.component.scss']
+})
+export class CatalogueSearchListingComponent implements OnInit {
+  status: SearchListingStatus = 'init';
+  parameters: CatalogueSearchParameters = {};
+  searchTerms?: string;
+  resultSet?: CatalogueSearchResultSet;
+
+  constructor(
+    private routerGlobals: UIRouterGlobals,
+    private stateRouter: StateHandlerService,
+    private catalogueSearch: CatalogueSearchService,
+    private messageHandler: MessageHandlerService
+  ) {}
+
+  ngOnInit(): void {
+    this.parameters = mapStateParamsToSearchParameters(
+      this.routerGlobals.params
+    );
+    this.searchTerms = this.parameters.search;
+
+    if (!this.parameters.search || this.parameters.search === '') {
+      this.setEmptyResultPage();
+      return;
+    }
+
+    this.performSearch();
+  }
+
+  updateSearch() {
+    this.stateRouter.Go('appContainer.mainApp.catalogueSearchListing', {
+      search: this.searchTerms
+    });
+  }
+
+  private setEmptyResultPage() {
+    this.resultSet = {
+      totalResults: 0,
+      page: 1,
+      pageSize: 10,
+      items: []
+    };
+    this.status = 'ready';
+  }
+
+  private performSearch() {
+    this.status = 'loading';
+    this.catalogueSearch
+      .search(this.parameters)
+      .pipe(
+        catchError((error) => {
+          this.status = 'error';
+          this.messageHandler.showError(
+            'A problem occurred when searching.',
+            error
+          );
+          return EMPTY;
+        })
+      )
+      .subscribe((resultSet) => {
+        this.resultSet = resultSet;
+        this.status = 'ready';
+      });
+  }
+}

--- a/src/app/catalogue-search/catalogue-search.module.ts
+++ b/src/app/catalogue-search/catalogue-search.module.ts
@@ -21,11 +21,18 @@ import { CommonModule } from '@angular/common';
 import { SharedModule } from '@mdm/modules/shared/shared.module';
 import { MaterialModule } from '@mdm/modules/material/material.module';
 import { CatalogueSearchComponent } from './catalogue-search/catalogue-search.component';
+import { CatalogueSearchListingComponent } from './catalogue-search-listing/catalogue-search-listing.component';
+import { CatalogueItemSearchResultComponent } from './catalogue-item-search-result/catalogue-item-search-result.component';
+import { CatalogueModule } from '@mdm/modules/catalogue/catalogue.module';
+import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
 
 @NgModule({
   declarations: [
-    CatalogueSearchComponent
+    CatalogueSearchComponent,
+    CatalogueSearchListingComponent,
+    CatalogueItemSearchResultComponent,
+    BreadcrumbComponent
   ],
-  imports: [CommonModule, SharedModule, MaterialModule]
+  imports: [CommonModule, SharedModule, MaterialModule, CatalogueModule]
 })
 export class CatalogueSearchModule {}

--- a/src/app/catalogue-search/catalogue-search.service.spec.ts
+++ b/src/app/catalogue-search/catalogue-search.service.spec.ts
@@ -1,0 +1,33 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+
+import { CatalogueSearchService } from './catalogue-search.service';
+
+describe('CatalogueSearchService', () => {
+  let service: CatalogueSearchService;
+
+  beforeEach(() => {
+    service = setupTestModuleForService(CatalogueSearchService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/catalogue-search/catalogue-search.service.ts
+++ b/src/app/catalogue-search/catalogue-search.service.ts
@@ -1,0 +1,92 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import {
+  CatalogueItemSearchResponse,
+  CatalogueItemSearchResult,
+  MdmIndexBody,
+  PageParameters,
+  SearchQueryParameters
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import {
+  CatalogueSearchParameters,
+  CatalogueSearchResultSet
+} from './catalogue-search.types';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CatalogueSearchService {
+  constructor(private resources: MdmResourcesService) {}
+
+  search(
+    params: CatalogueSearchParameters
+  ): Observable<CatalogueSearchResultSet> {
+    const [page, pageParams] = this.getPageParameters(params);
+    const query: SearchQueryParameters = {
+      ...this.getCommonQueryParameters(params),
+      ...pageParams,
+      searchTerm: params.search
+    };
+
+    return this.searchCatalogue(query).pipe(
+      map((searchResults) => {
+        return {
+          totalResults: searchResults.count,
+          pageSize: pageParams.max!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
+          page,
+          items: searchResults.items
+        };
+      })
+    );
+  }
+
+  private getPageParameters(
+    params: CatalogueSearchParameters
+  ): [number, PageParameters] {
+    const page = params.page ?? 1;
+    // TODO: add with pagination
+    // const pageParams = this.pagination.buildPageParameters(page, params.pageSize);
+    const pageParams: PageParameters = {
+      max: 10,
+      offset: 0
+    };
+    return [page, pageParams];
+  }
+
+  private getCommonQueryParameters(
+    params: CatalogueSearchParameters
+  ): SearchQueryParameters {
+    return {
+      sort: params.sort,
+      order: params.order
+    };
+  }
+
+  private searchCatalogue(
+    query: SearchQueryParameters
+  ): Observable<MdmIndexBody<CatalogueItemSearchResult>> {
+    return this.resources.catalogueItem
+      .search(query)
+      .pipe(map((response: CatalogueItemSearchResponse) => response.body));
+  }
+}

--- a/src/app/catalogue-search/catalogue-search.types.ts
+++ b/src/app/catalogue-search/catalogue-search.types.ts
@@ -1,0 +1,103 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { CatalogueItemSearchResult } from '@maurodatamapper/mdm-resources';
+import { RawParams, StateParams } from '@uirouter/core';
+
+export type SortOrder = 'asc' | 'desc';
+
+export type CatalogueSearchFilters = {
+  [key: string]: string | undefined;
+};
+
+/**
+ * Represents the parameters to drive a Catalogue Search.
+ */
+export interface CatalogueSearchParameters {
+  /**
+   * If provided, provides the search terms for full text search.
+   */
+  search?: string;
+
+  /**
+   * If provided, state which page of results to fetch. If not provided, the first page
+   * is assumed.
+   */
+  page?: number;
+
+  /**
+   * If provided, state how many results to return per page. If not provided, the default
+   * value is assumed.
+   */
+  pageSize?: number;
+
+  /**
+   * The field/property name to sort by.
+   */
+  sort?: string;
+
+  /**
+   * State what sort order to use. If supplied, must be either:
+   *
+   * * `'asc'` for ascending order, or
+   * * `'desc'` for descending order.
+   *
+   * If not supplied, the default value used will depend on the resource requested.
+   */
+  order?: SortOrder;
+
+  /**
+   * Optionally provide filter values to control what search results are returned.
+   */
+  filters?: CatalogueSearchFilters;
+}
+
+/**
+ * Maps query parameters from a route to a {@link CatalogueSearchParameters} object.
+ *
+ * @param query The {@link StateParams} containing the query parameters.
+ * @returns A {@link CatalogueSearchParameters} containing the mapped parameters.
+ */
+export const mapStateParamsToSearchParameters = (
+  query: StateParams
+): CatalogueSearchParameters => {
+  return {
+    search: query?.search ?? undefined,
+    page: query?.page ?? undefined,
+    sort: query?.sort ?? undefined,
+    order: query?.order ?? undefined
+  };
+};
+
+export const mapSearchParametersToRawParams = (
+  parameters: CatalogueSearchParameters
+): RawParams => {
+  return {
+    ...(parameters.search && { search: parameters.search }),
+    ...(parameters.page && { page: parameters.page }),
+    ...(parameters.sort && { sort: parameters.sort }),
+    ...(parameters.order && { order: parameters.order })
+  };
+};
+
+export interface CatalogueSearchResultSet {
+  totalResults: number;
+  pageSize: number;
+  page: number;
+  items: CatalogueItemSearchResult[];
+}

--- a/src/app/model-selector-tree/model-selector-tree.component.ts
+++ b/src/app/model-selector-tree/model-selector-tree.component.ts
@@ -25,14 +25,28 @@ import {
   ElementRef,
   HostListener,
   SimpleChanges,
-  ChangeDetectorRef, OnChanges, ViewChild
+  ChangeDetectorRef,
+  OnChanges,
+  ViewChild
 } from '@angular/core';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { SecurityHandlerService } from '../services/handlers/security-handler.service';
 import { UserSettingsHandlerService } from '../services/utility/user-settings-handler.service';
 import { fromEvent } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
-import { CatalogueItemDomainType, ContainerDomainType, FolderIndexResponse, MdmTreeItem, MdmTreeItemListResponse, TreeItemSearchQueryParameters } from '@maurodatamapper/mdm-resources';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  map
+} from 'rxjs/operators';
+import {
+  CatalogueItemDomainType,
+  ContainerDomainType,
+  FolderIndexResponse,
+  MdmTreeItem,
+  MdmTreeItemListResponse,
+  SearchQueryParameters
+} from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-model-selector-tree',
@@ -115,29 +129,40 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   }
 
   // eslint-disable-next-line @typescript-eslint/member-ordering
-  constructor(private resources: MdmResourcesService, private securityHandler: SecurityHandlerService, private userSettingsHandler: UserSettingsHandlerService, private changeRef: ChangeDetectorRef) {
-  }
+  constructor(
+    private resources: MdmResourcesService,
+    private securityHandler: SecurityHandlerService,
+    private userSettingsHandler: UserSettingsHandlerService,
+    private changeRef: ChangeDetectorRef
+  ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.defaultElements) {
       if (!this.multiple) {
-        this.searchCriteria = this.selectedElements[0] ? this.selectedElements[0].label : null;
+        this.searchCriteria = this.selectedElements[0]
+          ? this.selectedElements[0].label
+          : null;
       }
     }
 
     if (changes.searchCriteria) {
       if (!this.multiple) {
         if (this.selectedElements && this.selectedElements.length > 0) {
-          const label = this.selectedElements[0] ? this.selectedElements[0].label : '';
-          if (this.selectedElements &&
-            this.searchCriteria.trim().toLowerCase() === label.trim().toLowerCase() &&
-            label.trim().toLowerCase() !== '') {
+          const label = this.selectedElements[0]
+            ? this.selectedElements[0].label
+            : '';
+          if (
+            this.selectedElements &&
+            this.searchCriteria.trim().toLowerCase() ===
+              label.trim().toLowerCase() &&
+            label.trim().toLowerCase() !== ''
+          ) {
             return;
           }
         }
       }
 
-      const options: TreeItemSearchQueryParameters = {
+      const options: SearchQueryParameters = {
         searchTerm: this.searchCriteria,
         domainType: this.treeSearchDomainType,
         includeDocumentSuperseded: true,
@@ -147,12 +172,14 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
 
       if (this.searchCriteria.trim().length > 0) {
         this.inSearchMode = true;
-        this.resources.tree.search(ContainerDomainType.Folders, this.searchCriteria, options).subscribe((result: MdmTreeItemListResponse) => {
-          this.filteredRootNode = {
-            children: result.body,
-            isRoot: true
-          };
-        });
+        this.resources.tree
+          .search(ContainerDomainType.Folders, this.searchCriteria, options)
+          .subscribe((result: MdmTreeItemListResponse) => {
+            this.filteredRootNode = {
+              children: result.body,
+              isRoot: true
+            };
+          });
       } else {
         this.inSearchMode = false;
         this.reload();
@@ -165,97 +192,113 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
     this.placeholderStr = this.placeholder ? this.placeholder : 'Select';
     this.reload();
 
-    fromEvent(this.searchInputTreeControl.nativeElement, 'keyup').pipe(map((event: any) => {
-      return event.target.value;
-    }),
-      filter((res: any) => res.length >= 0),
-      debounceTime(500),
-      distinctUntilChanged()
-    ).subscribe((text: string) => {
-      if (text.length !== 0) {
-        if (!this.multiple) {
-          if (this.selectedElements && this.selectedElements.length > 0) {
-            const label = this.selectedElements[0]?.label ? this.selectedElements[0].label : '';
-            if (this.selectedElements && text?.trim().toLowerCase() === label?.trim().toLowerCase() && label?.trim().toLowerCase() !== '') {
-              return;
+    fromEvent(this.searchInputTreeControl.nativeElement, 'keyup')
+      .pipe(
+        map((event: any) => {
+          return event.target.value;
+        }),
+        filter((res: any) => res.length >= 0),
+        debounceTime(500),
+        distinctUntilChanged()
+      )
+      .subscribe((text: string) => {
+        if (text.length !== 0) {
+          if (!this.multiple) {
+            if (this.selectedElements && this.selectedElements.length > 0) {
+              const label = this.selectedElements[0]?.label
+                ? this.selectedElements[0].label
+                : '';
+              if (
+                this.selectedElements &&
+                text?.trim().toLowerCase() === label?.trim().toLowerCase() &&
+                label?.trim().toLowerCase() !== ''
+              ) {
+                return;
+              }
             }
           }
-        }
-        if (this.searchCriteria.trim().length > 0) {
-          this.inSearchMode = true;
-          this.resources.tree.search(ContainerDomainType.Folders, this.searchCriteria).subscribe((result: MdmTreeItemListResponse) => {
-            this.filteredRootNode = {
-              children: result.body,
-              isRoot: true
-            };
-          });
+          if (this.searchCriteria.trim().length > 0) {
+            this.inSearchMode = true;
+            this.resources.tree
+              .search(ContainerDomainType.Folders, this.searchCriteria)
+              .subscribe((result: MdmTreeItemListResponse) => {
+                this.filteredRootNode = {
+                  children: result.body,
+                  isRoot: true
+                };
+              });
+          } else {
+            this.inSearchMode = false;
+            this.reload();
+          }
         } else {
-          this.inSearchMode = false;
           this.reload();
         }
-      } else {
-        this.reload();
-      }
-    });
+      });
   }
 
   loadFolder(folder) {
-    const id = (folder && folder.id) ? folder.id : null;
+    const id = folder && folder.id ? folder.id : null;
     this.loading = true;
     if (folder?.id) {
-      this.resources.folder.get(id).subscribe((data: FolderIndexResponse) => {
-        const children = data.body.items;
-        this.loading = false;
-        this.rootNode = {
-          children,
-          isRoot: true
-        };
-        this.filteredRootNode = this.rootNode;
-      }, () => {
-        this.loading = false;
-      });
-    }
-    else {
-      this.resources.tree.list(
-        ContainerDomainType.Folders,
-        {
-          foldersOnly: true,
-          modelCreatableOnly: true
-        })
-        .subscribe((data: MdmTreeItemListResponse) => {
-          // TODO: this is not a very "Angular way" of filtering data for a component, really the data should be filterd
-          // outside the component and passed into this component as an @Input(), making this a "dumb" component.
-          // Issue currently is that this component is already heavily used and cannot be refactored yet, consider for
-          // the future.
-          const children = this.folderFilterFn ? this.filterFolderTreeItems(data.body) : data.body;
+      this.resources.folder.get(id).subscribe(
+        (data: FolderIndexResponse) => {
+          const children = data.body.items;
           this.loading = false;
           this.rootNode = {
             children,
             isRoot: true
           };
           this.filteredRootNode = this.rootNode;
-
-          if ((this.selectedElements?.length ?? 0) > 0 && !this.multiple) {
-            // If a node has already been initially selected, update the input field to
-            // display it
-            this.searchCriteria = this.selectedElements[0].label;
-          }
-
-        }, () => {
+        },
+        () => {
           this.loading = false;
-        });
+        }
+      );
+    } else {
+      this.resources.tree
+        .list(ContainerDomainType.Folders, {
+          foldersOnly: true,
+          modelCreatableOnly: true
+        })
+        .subscribe(
+          (data: MdmTreeItemListResponse) => {
+            // TODO: this is not a very "Angular way" of filtering data for a component, really the data should be filterd
+            // outside the component and passed into this component as an @Input(), making this a "dumb" component.
+            // Issue currently is that this component is already heavily used and cannot be refactored yet, consider for
+            // the future.
+            const children = this.folderFilterFn
+              ? this.filterFolderTreeItems(data.body)
+              : data.body;
+            this.loading = false;
+            this.rootNode = {
+              children,
+              isRoot: true
+            };
+            this.filteredRootNode = this.rootNode;
+
+            if ((this.selectedElements?.length ?? 0) > 0 && !this.multiple) {
+              // If a node has already been initially selected, update the input field to
+              // display it
+              this.searchCriteria = this.selectedElements[0].label;
+            }
+          },
+          () => {
+            this.loading = false;
+          }
+        );
     }
   }
 
   loadTree(model) {
-    const id = (model && model.id) ? model.id : null;
+    const id = model && model.id ? model.id : null;
     this.loading = true;
     let options: any = {};
     if (!this.doNotApplySettingsFilter && this.securityHandler.isLoggedIn()) {
       if (this.userSettingsHandler.get('includeSupersededDocModels') || false) {
         options = {
           queryStringParams: {
-            includeModelSuperseded: true,
+            includeModelSuperseded: true
           }
         };
       }
@@ -269,26 +312,31 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
       };
     }
 
-    let method = this.resources.tree.list(ContainerDomainType.Folders, options.queryStringParams);
-
+    let method = this.resources.tree.list(
+      ContainerDomainType.Folders,
+      options.queryStringParams
+    );
 
     if (id) {
       method = this.resources.tree.get('folders', 'dataModel', id, options);
     }
 
-    method.subscribe(data => {
-      this.loading = false;
-      this.rootNode = {
-        children: data.body,
-        isRoot: true
-      };
-      this.filteredRootNode = this.rootNode;
-      if (this.defaultCheckedMap && this.markChildren) {
-        this.markChildren(this.filteredRootNode);
+    method.subscribe(
+      (data) => {
+        this.loading = false;
+        this.rootNode = {
+          children: data.body,
+          isRoot: true
+        };
+        this.filteredRootNode = this.rootNode;
+        if (this.defaultCheckedMap && this.markChildren) {
+          this.markChildren(this.filteredRootNode);
+        }
+      },
+      () => {
+        this.loading = false;
       }
-    }, () => {
-      this.loading = false;
-    });
+    );
   }
 
   remove(event, element) {
@@ -305,7 +353,10 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   elementExists(element) {
     let i = 0;
     while (this.selectedElements && i < this.selectedElements.length) {
-      if (this.selectedElements[i] && this.selectedElements[i].id === element.id) {
+      if (
+        this.selectedElements[i] &&
+        this.selectedElements[i].id === element.id
+      ) {
         return { element: this.selectedElements[i], index: i };
       }
       i++;
@@ -332,13 +383,14 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   checkValidationError() {
     this.hasValidationError = false;
     if (this.isRequired && this.showValidationError) {
-
       if (this.multiple && this.selectedElements.length === 0) {
         this.hasValidationError = true;
       }
-      if (!this.multiple &&
+      if (
+        !this.multiple &&
         (!this.selectedElements ||
-          (this.selectedElements && this.selectedElements.length === 0))) {
+          (this.selectedElements && this.selectedElements.length === 0))
+      ) {
         this.hasValidationError = true;
       }
     }
@@ -351,7 +403,6 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
     }
     this.showTree = !this.showTree;
   }
-
 
   onNodeClick(node: MdmTreeItem) {
     this.selectNode(node);
@@ -383,7 +434,6 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
     }
 
     this.selectedElements.push(node);
-
 
     if (this.onSelect) {
       this.onSelect(this.selectedElements);
@@ -423,11 +473,11 @@ export class ModelSelectorTreeComponent implements OnInit, OnChanges {
   };
 
   // TODO
-  onAddFolder = () => { };
+  onAddFolder = () => {};
 
   private filterFolderTreeItems(folders?: MdmTreeItem[]): MdmTreeItem[] {
     // Recursively filter the folder items and their children
-    return folders.filter(folder => {
+    return folders.filter((folder) => {
       if (folder.children && folder.children.length > 0) {
         folder.children = this.filterFolderTreeItems(folder.children);
         folder.hasChildFolders = folder.children && folder.children.length > 0;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -68,7 +68,7 @@ export const environment = {
     useOpenIdConnect: true,
     useDigitalObjectIdentifiers: true,
     useIssueReporting: true,
-    useCatalogueSearch: false
+    useCatalogueSearch: true
   }
 };
 

--- a/src/style/components/_custom.scss
+++ b/src/style/components/_custom.scss
@@ -22,6 +22,7 @@ SPDX-License-Identifier: Apache-2.0
 @import '../../app//shared/footer/footer.component.scss';
 @import '../../app//shared/models/models.component.scss';
 @import '../../app/shared/alert/alert.component.scss';
+@import '../../app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.scss';
 
 /* Combine all custom component theme mixins into one */
 @mixin mdm-custom-components-theme($theme) {
@@ -29,4 +30,5 @@ SPDX-License-Identifier: Apache-2.0
   @include mdm-footer-theme($theme);
   @include mdm-models-tree-theme($theme);
   @include mdm-alert-theme($theme);
+  @include mdm-catalogue-item-search-result-theme($theme);
 }


### PR DESCRIPTION
Resolves #525 
Resolves #526

* Route added to render the new page - `/search/listing`
* Currently only displays the search term field, list of results and various messages (e.g. no results, error, loading, etc)
* Search service currently only does a full catalogue search, will require further domain type parents later
* Basic rendering of search results, with links to navigate to each item

**Note**: currently to test this new page you must directly go to the URL `/search/listing?search=<term>`. Eventually the work done in #524 will redirect to this page cohesively.

Also, the page has not implemented pagination (#527), sorting (#528) or filtering (#529) yet.

![image](https://user-images.githubusercontent.com/3219480/172357291-8506bc56-5800-48c2-a58e-bf85c4a229db.png)
