### PR TITLE
Feature/gh 529 ux - Improvements to catalogue item search filters

### DIFF
--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.html
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.html
@@ -47,7 +47,10 @@ SPDX-License-Identifier: Apache-2.0
   </div>
   <div *ngIf="status === 'ready'">
     <div class="row">
-      <div class="col">
+      <div class="col-md-3">
+
+      </div>
+      <div class="col-md-9">
         <div class="mdm-search-listing__sort-row">
           <div class="vertically-aligned">
             {{ resultSet?.totalResults }} results found
@@ -97,10 +100,10 @@ SPDX-License-Identifier: Apache-2.0
             </ul>
           </mdm-alert>
         </div>
+        <div class="mdm--mat-pagination" [ngClass]="{'is-hidden':resultSet?.totalResults < resultSet?.pageSize}">
+          <mdm-paginator [length]="resultSet?.totalResults" [pageIndex]="resultSet?.page" [pageSize]="resultSet?.pageSize" (page)="onPageChange($event)" showFirstLastButtons> </mdm-paginator>
+        </div>
       </div>
-    </div>
-    <div class="mdm--mat-pagination" [ngClass]="{'is-hidden':resultSet?.totalResults < resultSet?.pageSize}">
-      <mdm-paginator [length]="resultSet?.totalResults" [pageIndex]="resultSet?.page" [pageSize]="resultSet?.pageSize" (page)="onPageChange($event)" showFirstLastButtons> </mdm-paginator>
     </div>
   </div>
 </div>

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.html
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.html
@@ -74,7 +74,6 @@ SPDX-License-Identifier: Apache-2.0
           [createdAfter]="parameters.createdAfter"
           [createdBefore]="parameters.createdBefore"
           [classifiers]="parameters.classifiers" 
-          [fields]="filters"
           (filterChange)="onFilterChanged($event)"
           (filterReset)="onFilterReset()"
         ></mdm-search-filters>

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
@@ -118,7 +118,6 @@ export class CatalogueSearchListingComponent implements OnInit {
   }
 
   onFilterChanged(event: SearchFilterChange) {
-    console.log(event);
     this.parameters[event.name] = event.value;
     this.updateSearch();
   }

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
@@ -29,7 +29,7 @@ import {
 } from '../catalogue-search.types';
 import { PageEvent } from '@angular/material/paginator';
 import { SortByOption, SortOrder } from '@mdm/shared/sort-by/sort-by.component';
-import { SearchFilterChange, SearchFilterField } from '../search-filters/search-filters.component';
+import { SearchFilterChange } from '../search-filters/search-filters.component';
 
 export type SearchListingStatus = 'init' | 'loading' | 'ready' | 'error';
 
@@ -60,9 +60,6 @@ export class CatalogueSearchListingComponent implements OnInit {
     { value: 'label-desc', displayName: 'Label (z-a)' },
   ];
   sortByDefaultOption: SortByOption = this.searchListingSortByOptions[0];
-
-
-  filters: SearchFilterField[] = [];
 
   constructor(
     private routerGlobals: UIRouterGlobals,
@@ -123,7 +120,15 @@ export class CatalogueSearchListingComponent implements OnInit {
   }
 
   onFilterReset() {
-    // TODO do something
+    this.parameters.domainTypes = [];
+    this.parameters.labelOnly = undefined;
+    this.parameters.exactMatch = undefined;
+    this.parameters.lastUpdatedAfter = undefined;
+    this.parameters.lastUpdatedBefore = undefined;
+    this.parameters.createdAfter = undefined;
+    this.parameters.createdBefore = undefined;
+    this.parameters.classifiers = [];
+    this.updateSearch();
   }
 
   private setEmptyResultPage() {

--- a/src/app/catalogue-search/catalogue-search.types.ts
+++ b/src/app/catalogue-search/catalogue-search.types.ts
@@ -132,7 +132,7 @@ export const mapStateParamsToSearchParameters = (
     order: query?.order ?? undefined,
     pageSize: query?.pageSize ?? undefined,
     domainTypes,
-    labelOnly: query?.labelOnly === 'true' ? true : undefined,
+    labelOnly: query?.labelOnly === 'false' ? false : true,
     exactMatch: query?.exactMatch === 'true' ? true : undefined,
     lastUpdatedAfter: query?.lastUpdatedAfter ?? undefined,
     lastUpdatedBefore: query?.lastUpdatedBefore ?? undefined,

--- a/src/app/catalogue-search/search-filters/search-filters.component.html
+++ b/src/app/catalogue-search/search-filters/search-filters.component.html
@@ -20,13 +20,26 @@ SPDX-License-Identifier: Apache-2.0
   <div class="mdm-search-filters__header">
     <h3>Filters</h3>
   </div>
+  <button mat-stroked-button color="primary" type="button" class="w-100" (click)="resetAll()">
+    Reset All
+  </button>
   <div>
     <div class="mdm-search-filters__section">
-        <mat-label>Domain Type</mat-label>
-        <mat-select (selectionChange)="onDomainTypeChange($event)" multiple placeholder="Domain Types" class="form-control" [(ngModel)]="domainTypes">
-          <mat-option *ngFor="let domainType of domainTypesFilter" [value]="domainType.domainType">
-                {{domainType.name}}</mat-option>
-        </mat-select>
+      <mat-label>Domain Type</mat-label>
+      <mat-select
+        (selectionChange)="onDomainTypeChange($event)"
+        multiple
+        placeholder="Domain Types"
+        class="form-control"
+        [(ngModel)]="domainTypes"
+      >
+        <mat-option
+          *ngFor="let domainType of domainTypesFilter"
+          [value]="domainType.domainType"
+        >
+          {{ domainType.name }}</mat-option
+        >
+      </mat-select>
     </div>
     <div class="mdm-search-filters__section">
       <mat-label>Matching</mat-label>
@@ -35,7 +48,8 @@ SPDX-License-Identifier: Apache-2.0
           <mat-checkbox
             color="primary"
             [checked]="labelOnlyFilter.checked"
-            (change)="onLabelOnlyChange($event)">
+            (change)="onLabelOnlyChange($event)"
+          >
             Label Only
           </mat-checkbox>
         </li>
@@ -43,58 +57,102 @@ SPDX-License-Identifier: Apache-2.0
           <mat-checkbox
             color="primary"
             [checked]="exactMatchFilter.checked"
-            (change)="onExactMatchChange($event)">
+            (change)="onExactMatchChange($event)"
+          >
             Exact Match
           </mat-checkbox>
-        </li>        
+        </li>
       </ul>
-    </div>   
+    </div>
     <div class="mdm-search-filters__section">
       <mat-label>Dates</mat-label>
-      <mat-form-field appearance="fill">
-        <mat-label>Updated After</mat-label>
-        <input matInput [matDatepicker]="lastUpdatedAfter" (dateChange)="onDateChange('lastUpdatedAfter', $event)" [value]="lastUpdatedAfterFilter.value">
-        <mat-icon matDatepickerToggleIcon (click)="onDateClear('lastUpdatedAfter')">clear</mat-icon>
-        <mat-datepicker-toggle matSuffix [for]="lastUpdatedAfter">
-        </mat-datepicker-toggle>
-        <mat-datepicker #lastUpdatedAfter></mat-datepicker>
-      </mat-form-field> 
-      <mat-form-field appearance="fill">
-        <mat-label>Updated Before</mat-label>
-        <input matInput [matDatepicker]="lastUpdatedBefore" (dateChange)="onDateChange('lastUpdatedBefore', $event)" [value]="lastUpdatedBeforeFilter.value">
-        <mat-icon matDatepickerToggleIcon (click)="onDateClear('lastUpdatedBefore')">clear</mat-icon>
-        <mat-datepicker-toggle matSuffix [for]="lastUpdatedBefore">
-        </mat-datepicker-toggle>
-        <mat-datepicker #lastUpdatedBefore></mat-datepicker>
-      </mat-form-field>   
-      <mat-form-field appearance="fill">
-        <mat-label>Created After</mat-label>
-        <input matInput [matDatepicker]="createdAfter" (dateChange)="onDateChange('createdAfter', $event)" [value]="createdAfterFilter.value">
-        <mat-icon matDatepickerToggleIcon (click)="onDateClear('createdAfter')">clear</mat-icon>
-        <mat-datepicker-toggle matSuffix [for]="createdAfter">
-        </mat-datepicker-toggle>
-        <mat-datepicker #createdAfter></mat-datepicker>
-      </mat-form-field> 
-      <mat-form-field appearance="fill">
-        <mat-label>Created Before</mat-label>
-        <input matInput [matDatepicker]="createdBefore" (dateChange)="onDateChange('createdBefore', $event)" [value]="createdBeforeFilter.value">
-        <mat-icon matDatepickerToggleIcon (click)="onDateClear('createdBefore')">clear</mat-icon>
-        <mat-datepicker-toggle matSuffix [for]="createdBefore">
-        </mat-datepicker-toggle>
-        <mat-datepicker #createdBefore></mat-datepicker>
-      </mat-form-field>            
+      <div>
+        <mat-form-field appearance="fill">
+          <mat-label>Updated After</mat-label>
+          <input
+            matInput
+            [matDatepicker]="lastUpdatedAfter"
+            (dateChange)="onDateChange('lastUpdatedAfter', $event)"
+            [value]="lastUpdatedAfterFilter.value"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('lastUpdatedAfter')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle matSuffix [for]="lastUpdatedAfter">
+          </mat-datepicker-toggle>
+          <mat-datepicker #lastUpdatedAfter></mat-datepicker>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Updated Before</mat-label>
+          <input
+            matInput
+            [matDatepicker]="lastUpdatedBefore"
+            (dateChange)="onDateChange('lastUpdatedBefore', $event)"
+            [value]="lastUpdatedBeforeFilter.value"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('lastUpdatedBefore')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle matSuffix [for]="lastUpdatedBefore">
+          </mat-datepicker-toggle>
+          <mat-datepicker #lastUpdatedBefore></mat-datepicker>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Created After</mat-label>
+          <input
+            matInput
+            [matDatepicker]="createdAfter"
+            (dateChange)="onDateChange('createdAfter', $event)"
+            [value]="createdAfterFilter.value"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('createdAfter')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle matSuffix [for]="createdAfter">
+          </mat-datepicker-toggle>
+          <mat-datepicker #createdAfter></mat-datepicker>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Created Before</mat-label>
+          <input
+            matInput
+            [matDatepicker]="createdBefore"
+            (dateChange)="onDateChange('createdBefore', $event)"
+            [value]="createdBeforeFilter.value"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('createdBefore')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle matSuffix [for]="createdBefore">
+          </mat-datepicker-toggle>
+          <mat-datepicker #createdBefore></mat-datepicker>
+        </mat-form-field>
+      </div>
     </div>
     <div class="mdm-search-filters__section" *ngIf="isReady">
-    <mat-label>Classifiers</mat-label>
-        <mat-select (selectionChange)="onClassifiersChange($event)" multiple placeholder="Classifiers" class="form-control" [(ngModel)]="classifiers">
-          <mat-option *ngFor="let classifier of classifiersFilter" [value]="classifier.label">
-                {{classifier.label}}</mat-option>
-        </mat-select>
-  </div>
-    <div class="mdm-search-filters__footer">
-      <button *ngIf="hasValues" mat-flat-button color="primary" (click)="clearAll()">
-        Clear all
-      </button>
+      <mat-label>Classifiers</mat-label>
+      <mat-select
+        (selectionChange)="onClassifiersChange($event)"
+        multiple
+        placeholder="Classifiers"
+        class="form-control"
+        [(ngModel)]="classifiers"
+      >
+        <mat-option
+          *ngFor="let classifier of classifiersFilter"
+          [value]="classifier.label"
+        >
+          {{ classifier.label }}</mat-option
+        >
+      </mat-select>
     </div>
   </div>
 </div>

--- a/src/app/catalogue-search/search-filters/search-filters.component.html
+++ b/src/app/catalogue-search/search-filters/search-filters.component.html
@@ -16,22 +16,20 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="highlight-box mdm-search-filters">
+<div class="mdm-search-filters">
   <div class="mdm-search-filters__header">
     <h3>Filters</h3>
   </div>
   <div>
     <div class="mdm-search-filters__section">
-      <h4>Domain Type</h4>
-      <div>
+        <mat-label>Domain Type</mat-label>
         <mat-select (selectionChange)="onDomainTypeChange($event)" multiple placeholder="Domain Types" class="form-control" [(ngModel)]="domainTypes">
           <mat-option *ngFor="let domainType of domainTypesFilter" [value]="domainType.domainType">
                 {{domainType.name}}</mat-option>
         </mat-select>
     </div>
-    </div>
     <div class="mdm-search-filters__section">
-      <h4>Matching</h4>
+      <mat-label>Matching</mat-label>
       <ul>
         <li>
           <mat-checkbox
@@ -52,7 +50,7 @@ SPDX-License-Identifier: Apache-2.0
       </ul>
     </div>   
     <div class="mdm-search-filters__section">
-      <h4>Dates</h4>
+      <mat-label>Dates</mat-label>
       <mat-form-field appearance="fill">
         <mat-label>Updated After</mat-label>
         <input matInput [matDatepicker]="lastUpdatedAfter" (dateChange)="onDateChange('lastUpdatedAfter', $event)" [value]="lastUpdatedAfterFilter.value">
@@ -87,13 +85,11 @@ SPDX-License-Identifier: Apache-2.0
       </mat-form-field>            
     </div>
     <div class="mdm-search-filters__section" *ngIf="isReady">
-    <h4>Classifiers</h4>
-    <div>
+    <mat-label>Classifiers</mat-label>
         <mat-select (selectionChange)="onClassifiersChange($event)" multiple placeholder="Classifiers" class="form-control" [(ngModel)]="classifiers">
           <mat-option *ngFor="let classifier of classifiersFilter" [value]="classifier.label">
                 {{classifier.label}}</mat-option>
         </mat-select>
-    </div>
   </div>
     <div class="mdm-search-filters__footer">
       <button *ngIf="hasValues" mat-flat-button color="primary" (click)="clearAll()">

--- a/src/app/catalogue-search/search-filters/search-filters.component.html
+++ b/src/app/catalogue-search/search-filters/search-filters.component.html
@@ -54,15 +54,17 @@ SPDX-License-Identifier: Apache-2.0
     <div class="mdm-search-filters__section">
       <h4>Dates</h4>
       <mat-form-field appearance="fill">
-        <mat-label>Last Updated After</mat-label>
+        <mat-label>Updated After</mat-label>
         <input matInput [matDatepicker]="lastUpdatedAfter" (dateChange)="onDateChange('lastUpdatedAfter', $event)" [value]="lastUpdatedAfterFilter.value">
+        <mat-icon matDatepickerToggleIcon (click)="onDateClear('lastUpdatedAfter')">clear</mat-icon>
         <mat-datepicker-toggle matSuffix [for]="lastUpdatedAfter">
         </mat-datepicker-toggle>
         <mat-datepicker #lastUpdatedAfter></mat-datepicker>
       </mat-form-field> 
       <mat-form-field appearance="fill">
-        <mat-label>Last Updated Before</mat-label>
+        <mat-label>Updated Before</mat-label>
         <input matInput [matDatepicker]="lastUpdatedBefore" (dateChange)="onDateChange('lastUpdatedBefore', $event)" [value]="lastUpdatedBeforeFilter.value">
+        <mat-icon matDatepickerToggleIcon (click)="onDateClear('lastUpdatedBefore')">clear</mat-icon>
         <mat-datepicker-toggle matSuffix [for]="lastUpdatedBefore">
         </mat-datepicker-toggle>
         <mat-datepicker #lastUpdatedBefore></mat-datepicker>
@@ -70,6 +72,7 @@ SPDX-License-Identifier: Apache-2.0
       <mat-form-field appearance="fill">
         <mat-label>Created After</mat-label>
         <input matInput [matDatepicker]="createdAfter" (dateChange)="onDateChange('createdAfter', $event)" [value]="createdAfterFilter.value">
+        <mat-icon matDatepickerToggleIcon (click)="onDateClear('createdAfter')">clear</mat-icon>
         <mat-datepicker-toggle matSuffix [for]="createdAfter">
         </mat-datepicker-toggle>
         <mat-datepicker #createdAfter></mat-datepicker>
@@ -77,6 +80,7 @@ SPDX-License-Identifier: Apache-2.0
       <mat-form-field appearance="fill">
         <mat-label>Created Before</mat-label>
         <input matInput [matDatepicker]="createdBefore" (dateChange)="onDateChange('createdBefore', $event)" [value]="createdBeforeFilter.value">
+        <mat-icon matDatepickerToggleIcon (click)="onDateClear('createdBefore')">clear</mat-icon>
         <mat-datepicker-toggle matSuffix [for]="createdBefore">
         </mat-datepicker-toggle>
         <mat-datepicker #createdBefore></mat-datepicker>

--- a/src/app/catalogue-search/search-filters/search-filters.component.html
+++ b/src/app/catalogue-search/search-filters/search-filters.component.html
@@ -23,17 +23,12 @@ SPDX-License-Identifier: Apache-2.0
   <div>
     <div class="mdm-search-filters__section">
       <h4>Domain Type</h4>
-      <ul>
-        <li *ngFor="let domainType of allDomainTypes">
-          <mat-checkbox
-            color="primary"
-            [checked]="domainType.checked"
-            [value]="domainType.domainType"
-            (change)="onDomainTypeChange($event, domainType)"
-            >{{ domainType.name }}
-          </mat-checkbox>
-        </li>
-      </ul>
+      <div>
+        <mat-select (selectionChange)="onDomainTypeChange($event)" multiple placeholder="Domain Types" class="form-control" [(ngModel)]="domainTypes">
+          <mat-option *ngFor="let domainType of domainTypesFilter" [value]="domainType.domainType">
+                {{domainType.name}}</mat-option>
+        </mat-select>
+    </div>
     </div>
     <div class="mdm-search-filters__section">
       <h4>Matching</h4>

--- a/src/app/catalogue-search/search-filters/search-filters.component.scss
+++ b/src/app/catalogue-search/search-filters/search-filters.component.scss
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 
 @mixin mdm-search-filters-theme($theme) {
   $primary: map-get($theme, primary);
+  $accent: map-get($theme, accent);
 
   $search-filters-heading-background-color: mat.get-color-from-palette($primary);
   $search-filters-heading-color: mat.get-color-from-palette(
@@ -35,7 +36,9 @@ SPDX-License-Identifier: Apache-2.0
   
       h3 {
         font-weight: 500;
-        margin: 0.2em 0.635em;
+        padding-left: 4px;
+        padding-top: 4px;
+        padding-bottom: 4px;
         vertical-align: middle;
       }
     }
@@ -50,69 +53,17 @@ SPDX-License-Identifier: Apache-2.0
       padding-left: 0;
       padding-right: 0;
     }
-  }
 
-}
-
-
-$search-result-header-padding: 0.5em 0.5em;
-$search-result-content-padding: 0.8em 1.2em;
-$search-result-border-radius: 4px;
-
-
-
-.mat-datepicker-input {
-  width: 85%;
-}
-
-mat-icon {
-  position: relative;
-  float: right;
-  top: -8px;
-  cursor: pointer;
-  color: rgba(0, 0, 0, 0.54);
-}
-
-
-
-
-/*$search-filters-heading-background-color: $color-mauro-dark-green;
-$search-filters-heading-color: $color-white;
-$search-filters-header-padding: 0.2em 1.2em;
-
-$search-filters-content-color: $color-mauro-light-gold;
-$search-filters-content-padding: 1.2em 1.2em;
-
-$search-filters-border-radius: 4px;
-
-$search-filters-clear-button-width: 40px;
-
-.mdm-search-filters {
-  &__header {
-    border-radius: $search-filters-border-radius;
-    padding: $search-filters-header-padding;
-    background-color: $search-filters-heading-background-color;
-    color: $search-filters-heading-color;
-
-    h3 {
-      font-weight: 500;
-      margin: 0.2em 0.635em;
-      vertical-align: middle;
+    .mat-datepicker-input {
+      width: 85%;
+    }
+    
+    mat-icon {
+      position: relative;
+      float: right;
+      top: -8px;
+      cursor: pointer;
+      color: rgba(0, 0, 0, 0.54);
     }
   }
-
-  &__controls {
-    border-radius: $search-filters-border-radius;
-    padding: $search-filters-content-padding;
-    background-color: $search-filters-content-color;
-
-    .mat-form-field {
-      // Input field should take up remaining width of container. Assumes we know the exact width of the clear button though
-      width: calc(100% - $search-filters-clear-button-width);
-    }
-  }
-
-  &__footer {
-    text-align: right;
-  }
-}*/
+}

--- a/src/app/catalogue-search/search-filters/search-filters.component.scss
+++ b/src/app/catalogue-search/search-filters/search-filters.component.scss
@@ -16,12 +16,50 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-ul {
-  list-style-type: none;
-  margin-top: 4px;
-  padding-left: 0;
-  padding-right: 0;
+@use '~@angular/material' as mat;
+
+@mixin mdm-search-filters-theme($theme) {
+  $primary: map-get($theme, primary);
+
+  $search-filters-heading-background-color: mat.get-color-from-palette($primary);
+  $search-filters-heading-color: mat.get-color-from-palette(
+    $primary,
+    '500-contrast'
+  );
+
+  .mdm-search-filters {
+    &__header {
+      border-radius: 2px;
+      background-color: $search-filters-heading-background-color;
+      color: $search-filters-heading-color;
+  
+      h3 {
+        font-weight: 500;
+        margin: 0.2em 0.635em;
+        vertical-align: middle;
+      }
+    }
+  
+    &__section {
+      margin-top: 1em;
+    }
+
+    ul {
+      list-style-type: none;
+      margin-top: 4px;
+      padding-left: 0;
+      padding-right: 0;
+    }
+  }
+
 }
+
+
+$search-result-header-padding: 0.5em 0.5em;
+$search-result-content-padding: 0.8em 1.2em;
+$search-result-border-radius: 4px;
+
+
 
 .mat-datepicker-input {
   width: 85%;
@@ -34,6 +72,9 @@ mat-icon {
   cursor: pointer;
   color: rgba(0, 0, 0, 0.54);
 }
+
+
+
 
 /*$search-filters-heading-background-color: $color-mauro-dark-green;
 $search-filters-heading-color: $color-white;

--- a/src/app/catalogue-search/search-filters/search-filters.component.scss
+++ b/src/app/catalogue-search/search-filters/search-filters.component.scss
@@ -23,6 +23,18 @@ ul {
   padding-right: 0;
 }
 
+.mat-datepicker-input {
+  width: 85%;
+}
+
+mat-icon {
+  position: relative;
+  float: right;
+  top: -8px;
+  cursor: pointer;
+  color: rgba(0, 0, 0, 0.54);
+}
+
 /*$search-filters-heading-background-color: $color-mauro-dark-green;
 $search-filters-heading-color: $color-white;
 $search-filters-header-padding: 0.2em 1.2em;

--- a/src/app/catalogue-search/search-filters/search-filters.component.spec.ts
+++ b/src/app/catalogue-search/search-filters/search-filters.component.spec.ts
@@ -96,7 +96,7 @@ describe('SearchFiltersComponent', () => {
 
     it('should raise a filter reset event to clear all filters', () => {
       const spy = jest.spyOn(harness.component.filterReset, 'emit');
-      harness.component.clearAll();
+      harness.component.resetAll();
       expect(spy).toHaveBeenCalled();
     });
   });

--- a/src/app/catalogue-search/search-filters/search-filters.component.ts
+++ b/src/app/catalogue-search/search-filters/search-filters.component.ts
@@ -161,7 +161,7 @@ export class SearchFiltersComponent implements OnInit {
     this.filterChange.emit({ name });
   }
 
-  clearAll() {
+  resetAll() {
     this.filterReset.emit();
   }
 

--- a/src/app/catalogue-search/search-filters/search-filters.component.ts
+++ b/src/app/catalogue-search/search-filters/search-filters.component.ts
@@ -39,7 +39,6 @@ export interface SearchFilterChange {
 export interface SearchFilterDomainType {
   name: string;
   domainType: string;
-  checked: boolean;
 }
 
 export interface SearchFilterCheckbox {
@@ -82,12 +81,12 @@ export class SearchFiltersComponent implements OnInit {
 
   @Output() filterReset = new EventEmitter<void>();
 
-  allDomainTypes: SearchFilterDomainType[] = [
-    {name: 'Data Model', domainType: 'DataModel', checked: false},
-    {name: 'Data Class', domainType: 'DataClass', checked: false},
-    {name: 'Data Element', domainType: 'DataElement', checked: false},
-    {name: 'Data Type', domainType: 'DataType', checked: false},
-    {name: 'Enumeration Value', domainType: 'EnumerationValue', checked: false},
+  domainTypesFilter: SearchFilterDomainType[] = [
+    {name: 'Data Model', domainType: 'DataModel'},
+    {name: 'Data Class', domainType: 'DataClass'},
+    {name: 'Data Element', domainType: 'DataElement'},
+    {name: 'Data Type', domainType: 'DataType'},
+    {name: 'Enumeration Value', domainType: 'EnumerationValue'},
   ];
 
   labelOnlyFilter: SearchFilterCheckbox = {
@@ -137,9 +136,6 @@ export class SearchFiltersComponent implements OnInit {
       this.isReady = true;
     });
 
-    // For each domain type option, set checked to true if that domain type appeared in the search parameters
-    this.allDomainTypes.forEach((domainType) => domainType.checked = this.domainTypes.indexOf(domainType.domainType) > -1);
-
     this.labelOnlyFilter.checked = this.labelOnly;
 
     this.exactMatchFilter.checked = this.exactMatch;
@@ -169,19 +165,8 @@ export class SearchFiltersComponent implements OnInit {
     this.filterReset.emit();
   }
 
-  onDomainTypeChange(event: MatCheckboxChange, changedDomainType: SearchFilterDomainType) {
-    // Determine the checked state of each of the options
-    this.allDomainTypes.forEach((domainType) => {
-      if (domainType.domainType === changedDomainType.domainType) {
-        domainType.checked = event.checked;
-      }
-    });
-
-    // Make a string array containing only the 'domainType' properties of those selected
-    const checked = this.allDomainTypes.filter( p => p.checked).map(p => p.domainType);
-
-    // And emit that list
-    this.filterChange.emit({ name: 'domainTypes', value: checked });
+  onDomainTypeChange(event: MatSelectChange) {
+    this.filterChange.emit({ name: 'domainTypes', value: event.value });
   }
 
   onLabelOnlyChange(event: MatCheckboxChange,) {

--- a/src/app/catalogue-search/search-filters/search-filters.component.ts
+++ b/src/app/catalogue-search/search-filters/search-filters.component.ts
@@ -195,6 +195,10 @@ export class SearchFiltersComponent implements OnInit {
     this.filterChange.emit({ name, value: formatted});
   }
 
+  onDateClear(name: string) {
+    this.filterChange.emit({ name: name, value: null });
+  }  
+
   onClassifiersChange(event: MatSelectChange) {
     this.filterChange.emit({ name: 'classifiers', value: event.value });
   }

--- a/src/app/catalogue-search/search-filters/search-filters.component.ts
+++ b/src/app/catalogue-search/search-filters/search-filters.component.ts
@@ -196,8 +196,8 @@ export class SearchFiltersComponent implements OnInit {
   }
 
   onDateClear(name: string) {
-    this.filterChange.emit({ name: name, value: null });
-  }  
+    this.filterChange.emit({ name, value: null });
+  }
 
   onClassifiersChange(event: MatSelectChange) {
     this.filterChange.emit({ name: 'classifiers', value: event.value });

--- a/src/style/components/_custom.scss
+++ b/src/style/components/_custom.scss
@@ -23,6 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 @import '../../app//shared/models/models.component.scss';
 @import '../../app/shared/alert/alert.component.scss';
 @import '../../app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.scss';
+@import '../../app/catalogue-search/search-filters/search-filters.component.scss';
 
 /* Combine all custom component theme mixins into one */
 @mixin mdm-custom-components-theme($theme) {
@@ -31,4 +32,5 @@ SPDX-License-Identifier: Apache-2.0
   @include mdm-models-tree-theme($theme);
   @include mdm-alert-theme($theme);
   @include mdm-catalogue-item-search-result-theme($theme);
+  @include mdm-search-filters-theme($theme);
 }


### PR DESCRIPTION
Improve catalogue item search filters as follows:
- Tidy up styles and alignments
- Add a 'Reset All' button
- Default labelOnly to true
- Change domainTypes filter to a mat-select
- Add a 'clear' button to the date fields

Known bug: if you click the 'Reset All' button twice in succession, on the second click the router seems to hang

Still to do: Add tree control to filter by a specific catalogue item