### PR TITLE
gh-570 Fix search reset bug which sticks on loading screen

### DIFF
--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.spec.ts
@@ -22,6 +22,7 @@ import {
   CatalogueItemSearchResult
 } from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
+import { StateHandlerService } from '@mdm/services';
 import {
   ComponentHarness,
   setupTestModuleForComponent
@@ -50,6 +51,10 @@ const resourcesStub: MdmResourcesServiceStub = {
 describe('CatalogueSearchListingComponent', () => {
   let harness: ComponentHarness<CatalogueSearchListingComponent>;
 
+  const stateRouterStub = {
+    Go: jest.fn()
+  };
+
   const setupComponentTest = async (parameters: CatalogueSearchParameters) => {
     const params = mapSearchParametersToRawParams(parameters);
 
@@ -66,6 +71,10 @@ describe('CatalogueSearchListingComponent', () => {
         {
           provide: MdmResourcesService,
           useValue: resourcesStub
+        },
+        {
+          provide: StateHandlerService,
+          useValue: stateRouterStub
         }
       ]
     });
@@ -132,6 +141,7 @@ describe('CatalogueSearchListingComponent', () => {
 
     beforeEach(async () => {
       harness = await setupComponentTest(parameters);
+      stateRouterStub.Go.mockReset();
     });
 
     it('should display the expected search results', () => {
@@ -175,11 +185,14 @@ describe('CatalogueSearchListingComponent', () => {
         pageIndex: 6,
         previousPageIndex: 5,
         pageSize: 3,
-        length: 100,
+        length: 100
       };
 
       harness.component.onPageChange(pageEvent);
-      expect(harness.component.status).toBe('loading');
+      expect(stateRouterStub.Go).toHaveBeenCalledWith(
+        'appContainer.mainApp.catalogueSearchListing',
+        expect.any(Object)
+      );
     });
 
     it('should display an error when search fails', () => {

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
@@ -38,7 +38,7 @@ export type SearchListingStatus = 'init' | 'loading' | 'ready' | 'error';
  * can be any property on the objects you are sorting and order must be of type
  * {@link SortOrder }
  */
- export type SearchListingSortByOption = 'label-asc' | 'label-desc';
+export type SearchListingSortByOption = 'label-asc' | 'label-desc';
 
 @Component({
   selector: 'mdm-catalogue-search-listing',
@@ -55,9 +55,9 @@ export class CatalogueSearchListingComponent implements OnInit {
    * Each new option must have a {@link SearchListingSortByOption} as a value to ensure
    * the catalogue-search-listing page can interpret the result emitted by the SortByComponent
    */
-   searchListingSortByOptions: SortByOption[] = [
+  searchListingSortByOptions: SortByOption[] = [
     { value: 'label-asc', displayName: 'Label (a-z)' },
-    { value: 'label-desc', displayName: 'Label (z-a)' },
+    { value: 'label-desc', displayName: 'Label (z-a)' }
   ];
   sortByDefaultOption: SortByOption = this.searchListingSortByOptions[0];
 
@@ -87,13 +87,14 @@ export class CatalogueSearchListingComponent implements OnInit {
     this.performSearch();
   }
 
-
   /**
    * Update the search by using the state router.
    */
   updateSearch() {
-    this.status = 'loading';
-    this.stateRouter.Go('appContainer.mainApp.catalogueSearchListing', this.parameters);
+    this.stateRouter.Go(
+      'appContainer.mainApp.catalogueSearchListing',
+      this.parameters
+    );
   }
 
   onSearchTerm() {
@@ -168,7 +169,7 @@ export class CatalogueSearchListingComponent implements OnInit {
    * @param order the order in which to sort that propery
    * @returns a SortByOption object with value matching the route string sortBy value or the default sortBy option.
    */
-   private setSortByFromRouteOrAsDefault(
+  private setSortByFromRouteOrAsDefault(
     sort: string | undefined,
     order: string | undefined
   ): SortByOption {

--- a/src/app/catalogue-search/search-filters/search-filters.component.ts
+++ b/src/app/catalogue-search/search-filters/search-filters.component.ts
@@ -20,7 +20,10 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
 import { MatSelectChange } from '@angular/material/select';
-import { Classifier, ClassifierIndexResponse } from '@maurodatamapper/mdm-resources';
+import {
+  Classifier,
+  ClassifierIndexResponse
+} from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
 
 export interface SearchFilterField {
@@ -54,7 +57,7 @@ export interface SearchFilterDate {
 @Component({
   selector: 'mdm-search-filters',
   templateUrl: './search-filters.component.html',
-  styleUrls: ['./search-filters.component.scss'],
+  styleUrls: ['./search-filters.component.scss']
 })
 export class SearchFiltersComponent implements OnInit {
   @Input() fields: SearchFilterField[] = [];
@@ -82,59 +85,57 @@ export class SearchFiltersComponent implements OnInit {
   @Output() filterReset = new EventEmitter<void>();
 
   domainTypesFilter: SearchFilterDomainType[] = [
-    {name: 'Data Model', domainType: 'DataModel'},
-    {name: 'Data Class', domainType: 'DataClass'},
-    {name: 'Data Element', domainType: 'DataElement'},
-    {name: 'Data Type', domainType: 'DataType'},
-    {name: 'Enumeration Value', domainType: 'EnumerationValue'},
+    { name: 'Data Model', domainType: 'DataModel' },
+    { name: 'Data Class', domainType: 'DataClass' },
+    { name: 'Data Element', domainType: 'DataElement' },
+    { name: 'Data Type', domainType: 'DataType' },
+    { name: 'Enumeration Value', domainType: 'EnumerationValue' }
   ];
 
   labelOnlyFilter: SearchFilterCheckbox = {
     name: 'labelOnly',
-    checked: false,
+    checked: false
   };
 
   exactMatchFilter: SearchFilterCheckbox = {
     name: 'labelOnly',
-    checked: false,
+    checked: false
   };
 
   lastUpdatedAfterFilter: SearchFilterDate = {
     name: 'lastUpdatedAfter',
-    value: null,
+    value: null
   };
 
   lastUpdatedBeforeFilter: SearchFilterDate = {
     name: 'lastUpdatedBefore',
-    value: null,
+    value: null
   };
 
   createdAfterFilter: SearchFilterDate = {
     name: 'createdAfter',
-    value: null,
+    value: null
   };
 
   createdBeforeFilter: SearchFilterDate = {
     name: 'createdBefore',
-    value: null,
+    value: null
   };
 
   classifiersFilter: Classifier[] = [];
 
   isReady = false;
 
-  constructor(
-    private resources: MdmResourcesService
-  ) {}
+  constructor(private resources: MdmResourcesService) {}
 
   ngOnInit(): void {
     this.resources.classifier
-    .list({ all: true })
-    .subscribe((result: ClassifierIndexResponse) => {
-      this.classifiersFilter = result.body.items;
+      .list({ all: true })
+      .subscribe((result: ClassifierIndexResponse) => {
+        this.classifiersFilter = result.body.items;
 
-      this.isReady = true;
-    });
+        this.isReady = true;
+      });
 
     this.labelOnlyFilter.checked = this.labelOnly;
 
@@ -169,13 +170,13 @@ export class SearchFiltersComponent implements OnInit {
     this.filterChange.emit({ name: 'domainTypes', value: event.value });
   }
 
-  onLabelOnlyChange(event: MatCheckboxChange,) {
+  onLabelOnlyChange(event: MatCheckboxChange) {
     this.labelOnlyFilter.checked = event.checked;
 
     this.filterChange.emit({ name: 'labelOnly', value: event.checked });
   }
 
-  onExactMatchChange(event: MatCheckboxChange,) {
+  onExactMatchChange(event: MatCheckboxChange) {
     this.exactMatchFilter.checked = event.checked;
 
     this.filterChange.emit({ name: 'exactMatch', value: event.checked });
@@ -187,16 +188,18 @@ export class SearchFiltersComponent implements OnInit {
 
     if (event.value) {
       const yyyy: String = event.value.getFullYear().toString();
-      const mm: String = (parseInt(event.value.getMonth(), 10) + 1).toString().padStart(2, '0');
-      const dd: String = (event.value.getDate()).toString().padStart(2, '0');
+      const mm: String = (parseInt(event.value.getMonth(), 10) + 1)
+        .toString()
+        .padStart(2, '0');
+      const dd: String = event.value.getDate().toString().padStart(2, '0');
 
       formatted = `${yyyy}-${mm}-${dd}`;
     }
-    this.filterChange.emit({ name, value: formatted});
+    this.filterChange.emit({ name, value: formatted });
   }
 
   onDateClear(name: string) {
-    this.filterChange.emit({ name, value: null });
+    this.filterChange.emit({ name, value: undefined });
   }
 
   onClassifiersChange(event: MatSelectChange) {


### PR DESCRIPTION
Fixes #570 

Due to the way the UI Router works when it decides no transition between routes is required, the loading screen was accidentally kept on preventing the user from doing anything else. This PR resolves that issue.