### PR TITLE
gh-951 Create DefaultProfileProviderService

### DIFF
--- a/src/app/mauro/mauro-item-provider.service.spec.ts
+++ b/src/app/mauro/mauro-item-provider.service.spec.ts
@@ -1,0 +1,493 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { CatalogueItemDomainType, Uuid } from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+import { cold } from 'jest-marbles';
+import { Observable } from 'rxjs';
+import { MauroItemProviderService } from './mauro-item-provider.service';
+import {
+  MauroIdentifier,
+  MauroItem,
+  MauroItemResponse
+} from './mauro-item.types';
+
+describe('MauroItemProviderService', () => {
+  let service: MauroItemProviderService;
+
+  const resourcesStub = {
+    dataModel: {
+      get: jest.fn() as jest.MockedFunction<
+        (id: Uuid) => Observable<MauroItemResponse>
+      >
+    },
+    dataClass: {
+      get: jest.fn() as jest.MockedFunction<
+        (modelId: Uuid, id: Uuid) => Observable<MauroItemResponse>
+      >,
+      getChildDataClass: jest.fn() as jest.MockedFunction<
+        (
+          modelId: Uuid,
+          dataClassId: Uuid,
+          id: Uuid
+        ) => Observable<MauroItemResponse>
+      >
+    },
+    dataElement: {
+      get: jest.fn() as jest.MockedFunction<
+        (
+          modelId: Uuid,
+          dataClassId: Uuid,
+          id: Uuid
+        ) => Observable<MauroItemResponse>
+      >
+    },
+    dataType: {
+      get: jest.fn() as jest.MockedFunction<
+        (modelId: Uuid, id: Uuid) => Observable<MauroItemResponse>
+      >
+    },
+    terminology: {
+      get: jest.fn() as jest.MockedFunction<
+        (id: Uuid) => Observable<MauroItemResponse>
+      >
+    },
+    term: {
+      get: jest.fn() as jest.MockedFunction<
+        (modelId: Uuid, id: Uuid) => Observable<MauroItemResponse>
+      >
+    },
+    codeSet: {
+      get: jest.fn() as jest.MockedFunction<
+        (id: Uuid) => Observable<MauroItemResponse>
+      >
+    },
+    folder: {
+      get: jest.fn() as jest.MockedFunction<
+        (id: Uuid) => Observable<MauroItemResponse>
+      >
+    },
+    versionedFolder: {
+      get: jest.fn() as jest.MockedFunction<
+        (id: Uuid) => Observable<MauroItemResponse>
+      >
+    },
+    classifier: {
+      get: jest.fn() as jest.MockedFunction<
+        (id: Uuid) => Observable<MauroItemResponse>
+      >
+    }
+  };
+
+  const constructMauroItemFromIdentifier = (
+    identifier: MauroIdentifier
+  ): MauroItem => {
+    return {
+      ...identifier,
+      label: identifier.domainType,
+      description: 'This is a description'
+    };
+  };
+
+  const mockModelRequest = (
+    identifier: MauroIdentifier,
+    returnItem: MauroItem,
+    resource:
+      | 'dataModel'
+      | 'terminology'
+      | 'codeSet'
+      | 'folder'
+      | 'versionedFolder'
+      | 'classifier'
+  ) => {
+    resourcesStub[resource].get.mockImplementationOnce((id) => {
+      expect(id).toBe(identifier.id);
+      return cold('--a|', { a: { body: returnItem } });
+    });
+  };
+
+  const mockModelItemRequest = (
+    identifier: MauroIdentifier,
+    returnItem: MauroItem,
+    resource: 'dataClass' | 'dataType' | 'term'
+  ) => {
+    resourcesStub[resource].get.mockImplementationOnce((modelId, id) => {
+      expect(modelId).toBe(identifier.model);
+      expect(id).toBe(identifier.id);
+      return cold('--a|', { a: { body: returnItem } });
+    });
+  };
+
+  beforeEach(() => {
+    service = setupTestModuleForService(MauroItemProviderService, {
+      providers: [
+        {
+          provide: MdmResourcesService,
+          useValue: resourcesStub
+        }
+      ]
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  const testSingleItemIsReturned = (
+    identifier: MauroIdentifier,
+    setupMockRequest: (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => void
+  ) => {
+    const item = constructMauroItemFromIdentifier(identifier);
+    setupMockRequest(identifier, item);
+
+    const expected$ = cold('--a|', {
+      a: item
+    });
+    const actual$ = service.get(identifier);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  const testMultipleItemsAreReturned = (
+    domainType: CatalogueItemDomainType,
+    setupMockRequest: (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => void
+  ) => {
+    const identifiers: MauroIdentifier[] = [...Array(10).keys()].map((id) => {
+      return {
+        id: id.toString(),
+        domainType,
+        model: '123', // Only required for model items
+        dataClass: '456', // Only required for Data Elements
+        parentDataClass: '789' // Only required for child Data Classes
+      };
+    });
+
+    const items = identifiers.map((id) => {
+      const item = constructMauroItemFromIdentifier(id);
+      setupMockRequest(id, item);
+      return item;
+    });
+
+    const expected$ = cold('---(a|)', { a: items });
+    const actual$ = service.getMany(identifiers);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  const testMissingModelIdThrowsError = (identifier: MauroIdentifier) => {
+    const expected$ = cold('#', null, new Error());
+    const actual$ = service.get(identifier);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  const testMissingDataClassIdThrowsError = (identifier: MauroIdentifier) => {
+    const expected$ = cold('#', null, new Error());
+    const actual$ = service.get(identifier);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  describe('unsupported domain types', () => {
+    const unsupported = [
+      CatalogueItemDomainType.ReferenceDataModel,
+      CatalogueItemDomainType.ReferenceDataModelType
+    ];
+
+    it.each(unsupported)(
+      'should throw an error for the domain type %p',
+      (domainType) => {
+        const expected$ = cold('#', null, new Error());
+        const actual$ = service.get({ id: '123', domainType });
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+  });
+
+  describe('get data models', () => {
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataModel
+        },
+        (id, item) => mockModelRequest(id, item, 'dataModel')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.DataModel,
+        (id, item) => mockModelRequest(id, item, 'dataModel')
+      );
+    });
+  });
+
+  describe('get data classes', () => {
+    const mockDataClassChildRequest = (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => {
+      resourcesStub.dataClass.getChildDataClass.mockImplementationOnce(
+        (modelId, dataClassId, id) => {
+          expect(modelId).toBe(identifier.model);
+          expect(dataClassId).toBe(identifier.parentDataClass);
+          expect(id).toBe(identifier.id);
+          return cold('--a|', { a: { body: returnItem } });
+        }
+      );
+    };
+
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.DataClass
+      });
+    });
+
+    it('should return a single parent data class', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataClass,
+          model: '456'
+        },
+        (id, item) => mockModelItemRequest(id, item, 'dataClass')
+      );
+    });
+
+    it('should return a single child data class', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataClass,
+          model: '456',
+          parentDataClass: '789'
+        },
+        mockDataClassChildRequest
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.DataClass,
+        mockDataClassChildRequest
+      );
+    });
+  });
+
+  describe('get data elements', () => {
+    const mockDataElementRequest = (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => {
+      resourcesStub.dataElement.get.mockImplementationOnce(
+        (modelId, dataClassId, id) => {
+          expect(modelId).toBe(identifier.model);
+          expect(dataClassId).toBe(identifier.dataClass);
+          expect(id).toBe(identifier.id);
+          return cold('--a|', { a: { body: returnItem } });
+        }
+      );
+    };
+
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.DataElement
+      });
+    });
+
+    it('should fail if not given a data class', () => {
+      testMissingDataClassIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.DataElement,
+        model: '456'
+      });
+    });
+
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataElement,
+          model: '456',
+          dataClass: '789'
+        },
+        mockDataElementRequest
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.DataElement,
+        mockDataElementRequest
+      );
+    });
+  });
+
+  describe('get data types', () => {
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.ModelDataType
+      });
+    });
+
+    it('should return a single data type', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.ModelDataType,
+          model: '456'
+        },
+        (id, item) => mockModelItemRequest(id, item, 'dataType')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.ModelDataType,
+        (id, item) => mockModelItemRequest(id, item, 'dataType')
+      );
+    });
+  });
+
+  describe('get terminologies', () => {
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Terminology
+        },
+        (id, item) => mockModelRequest(id, item, 'terminology')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.Terminology,
+        (id, item) => mockModelRequest(id, item, 'terminology')
+      );
+    });
+  });
+
+  describe('get terms', () => {
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.Term
+      });
+    });
+
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Term,
+          model: '456'
+        },
+        (id, item) => mockModelItemRequest(id, item, 'term')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(CatalogueItemDomainType.Term, (id, item) =>
+        mockModelItemRequest(id, item, 'term')
+      );
+    });
+  });
+
+  describe('get code sets', () => {
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.CodeSet
+        },
+        (id, item) => mockModelRequest(id, item, 'codeSet')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.CodeSet,
+        (id, item) => mockModelRequest(id, item, 'codeSet')
+      );
+    });
+  });
+
+  describe('get folders', () => {
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Folder
+        },
+        (id, item) => mockModelRequest(id, item, 'folder')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(CatalogueItemDomainType.Folder, (id, item) =>
+        mockModelRequest(id, item, 'folder')
+      );
+    });
+  });
+
+  describe('get versioned folders', () => {
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.VersionedFolder
+        },
+        (id, item) => mockModelRequest(id, item, 'versionedFolder')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.VersionedFolder,
+        (id, item) => mockModelRequest(id, item, 'versionedFolder')
+      );
+    });
+  });
+
+  describe('get classifiers', () => {
+    it('should return a single item', () => {
+      testSingleItemIsReturned(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Classifier
+        },
+        (id, item) => mockModelRequest(id, item, 'classifier')
+      );
+    });
+
+    it('should return many items', () => {
+      testMultipleItemsAreReturned(
+        CatalogueItemDomainType.Classifier,
+        (id, item) => mockModelRequest(id, item, 'classifier')
+      );
+    });
+  });
+});

--- a/src/app/mauro/mauro-item-provider.service.ts
+++ b/src/app/mauro/mauro-item-provider.service.ts
@@ -1,0 +1,211 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import {
+  CatalogueItemDomainType,
+  isDataType
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { forkJoin, Observable, throwError } from 'rxjs';
+import { map } from 'rxjs/operators';
+import {
+  MauroIdentifier,
+  MauroItem,
+  MauroItemResponse
+} from './mauro-item.types';
+
+/**
+ * Service to provide Mauro catalogue items based on any identifier information.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class MauroItemProviderService {
+  constructor(private resources: MdmResourcesService) {}
+
+  /**
+   * Get any Mauro catalogue item based on the identifier information provided.
+   *
+   * @param identifier A {@link MauroIdentifier} containing identification information. At least an ID and
+   * domain type is required, but some domain types based on hierarchy require further details.
+   * @returns The requested catalogue item passed through an observable stream.
+   */
+  get(identifier: MauroIdentifier): Observable<MauroItem> {
+    let response: Observable<MauroItemResponse>;
+
+    if (identifier.domainType === CatalogueItemDomainType.DataModel) {
+      response = this.getDataModel(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.DataClass) {
+      response = this.getDataClass(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.DataElement) {
+      response = this.getDataElement(identifier);
+    }
+
+    if (isDataType(identifier.domainType)) {
+      response = this.getDataType(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Terminology) {
+      response = this.getTerminology(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Term) {
+      response = this.getTerm(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.CodeSet) {
+      response = this.getCodeSet(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Folder) {
+      response = this.getFolder(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.VersionedFolder) {
+      response = this.getVersionedFolder(identifier);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Classifier) {
+      response = this.getClassifier(identifier);
+    }
+
+    if (!response) {
+      return throwError(`${identifier.domainType} is not supported`);
+    }
+
+    return response.pipe(map((res) => res.body));
+  }
+
+  /**
+   * Get multiple Mauro catalogue items based on the provided identification information.
+   *
+   * @param identifiers An array of {@link MauroIdentifier} objects containing identification information.
+   * At least an ID and domain type is required per object, but some domain types based on hierarchy require further details.
+   * @returns An array of the requested catalogue items passed through an observable stream.
+   */
+  getMany(identifiers: MauroIdentifier[]): Observable<MauroItem[]> {
+    const requests$ = identifiers.map((identifier) => this.get(identifier));
+    return forkJoin(requests$);
+  }
+
+  private getDataModel(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    return this.resources.dataModel.get(identifier.id);
+  }
+
+  private getDataClass(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    const dataClassId = identifier.parentDataClass ?? identifier.dataClass;
+    if (dataClassId) {
+      return this.resources.dataClass.getChildDataClass(
+        identifier.model,
+        dataClassId,
+        identifier.id
+      );
+    }
+
+    return this.resources.dataClass.get(identifier.model, identifier.id);
+  }
+
+  private getDataElement(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    if (!identifier.dataClass) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a data class`
+      );
+    }
+
+    return this.resources.dataElement.get(
+      identifier.model,
+      identifier.dataClass,
+      identifier.id
+    );
+  }
+
+  private getDataType(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    return this.resources.dataType.get(identifier.model, identifier.id);
+  }
+
+  private getTerminology(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    return this.resources.terminology.get(identifier.id);
+  }
+
+  private getTerm(identifier: MauroIdentifier): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    return this.resources.term.get(identifier.model, identifier.id);
+  }
+
+  private getCodeSet(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    return this.resources.codeSet.get(identifier.id);
+  }
+
+  private getFolder(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    return this.resources.folder.get(identifier.id);
+  }
+
+  private getVersionedFolder(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    return this.resources.versionedFolder.get(identifier.id);
+  }
+
+  private getClassifier(
+    identifier: MauroIdentifier
+  ): Observable<MauroItemResponse> {
+    return this.resources.classifier.get(identifier.id);
+  }
+}

--- a/src/app/mauro/mauro-item-update.service.spec.ts
+++ b/src/app/mauro/mauro-item-update.service.spec.ts
@@ -1,0 +1,514 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { CatalogueItemDomainType, Uuid } from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+import { cold } from 'jest-marbles';
+import { Observable } from 'rxjs';
+import { MauroItemUpdateService } from './mauro-item-update.service';
+import {
+  MauroIdentifier,
+  MauroItem,
+  MauroItemResponse
+} from './mauro-item.types';
+
+describe('MauroItemUpdateService', () => {
+  let service: MauroItemUpdateService;
+
+  const resourcesStub = {
+    dataModel: {
+      update: jest.fn() as jest.MockedFunction<
+        (id: Uuid, data: MauroItem) => Observable<MauroItemResponse>
+      >
+    },
+    dataClass: {
+      update: jest.fn() as jest.MockedFunction<
+        (
+          modelId: Uuid,
+          id: Uuid,
+          data: MauroItem
+        ) => Observable<MauroItemResponse>
+      >,
+      updateChildDataClass: jest.fn() as jest.MockedFunction<
+        (
+          modelId: Uuid,
+          dataClassId: Uuid,
+          id: Uuid,
+          data: MauroItem
+        ) => Observable<MauroItemResponse>
+      >
+    },
+    dataElement: {
+      update: jest.fn() as jest.MockedFunction<
+        (
+          modelId: Uuid,
+          dataClassId: Uuid,
+          id: Uuid,
+          data: MauroItem
+        ) => Observable<MauroItemResponse>
+      >
+    },
+    dataType: {
+      update: jest.fn() as jest.MockedFunction<
+        (
+          modelId: Uuid,
+          id: Uuid,
+          data: MauroItem
+        ) => Observable<MauroItemResponse>
+      >
+    },
+    terminology: {
+      update: jest.fn() as jest.MockedFunction<
+        (id: Uuid, data: MauroItem) => Observable<MauroItemResponse>
+      >
+    },
+    term: {
+      update: jest.fn() as jest.MockedFunction<
+        (
+          modelId: Uuid,
+          id: Uuid,
+          data: MauroItem
+        ) => Observable<MauroItemResponse>
+      >
+    },
+    codeSet: {
+      update: jest.fn() as jest.MockedFunction<
+        (id: Uuid, data: MauroItem) => Observable<MauroItemResponse>
+      >
+    },
+    folder: {
+      update: jest.fn() as jest.MockedFunction<
+        (id: Uuid, data: MauroItem) => Observable<MauroItemResponse>
+      >
+    },
+    versionedFolder: {
+      update: jest.fn() as jest.MockedFunction<
+        (id: Uuid, data: MauroItem) => Observable<MauroItemResponse>
+      >
+    },
+    classifier: {
+      update: jest.fn() as jest.MockedFunction<
+        (id: Uuid, data: MauroItem) => Observable<MauroItemResponse>
+      >
+    }
+  };
+
+  const constructMauroItemFromIdentifier = (
+    identifier: MauroIdentifier
+  ): MauroItem => {
+    return {
+      ...identifier,
+      label: identifier.domainType,
+      description: 'This is a description'
+    };
+  };
+
+  const mockModelRequest = (
+    identifier: MauroIdentifier,
+    returnItem: MauroItem,
+    resource:
+      | 'dataModel'
+      | 'terminology'
+      | 'codeSet'
+      | 'folder'
+      | 'versionedFolder'
+      | 'classifier'
+  ) => {
+    resourcesStub[resource].update.mockImplementationOnce((id, data) => {
+      expect(id).toBe(identifier.id);
+      expect(data).toStrictEqual(returnItem);
+      return cold('--a|', { a: { body: returnItem } });
+    });
+  };
+
+  const mockModelItemRequest = (
+    identifier: MauroIdentifier,
+    returnItem: MauroItem,
+    resource: 'dataClass' | 'dataType' | 'term'
+  ) => {
+    resourcesStub[resource].update.mockImplementationOnce(
+      (modelId, id, data) => {
+        expect(modelId).toBe(identifier.model);
+        expect(id).toBe(identifier.id);
+        expect(data).toStrictEqual(returnItem);
+        return cold('--a|', { a: { body: returnItem } });
+      }
+    );
+  };
+
+  beforeEach(() => {
+    service = setupTestModuleForService(MauroItemUpdateService, {
+      providers: [
+        {
+          provide: MdmResourcesService,
+          useValue: resourcesStub
+        }
+      ]
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  const testSingleItemIsSaved = (
+    identifier: MauroIdentifier,
+    setupMockRequest: (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => void
+  ) => {
+    const item = constructMauroItemFromIdentifier(identifier);
+    setupMockRequest(identifier, item);
+
+    const expected$ = cold('--a|', {
+      a: item
+    });
+    const actual$ = service.save(identifier, item);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  const testMultipleItemsAreSaved = (
+    domainType: CatalogueItemDomainType,
+    setupMockRequest: (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => void
+  ) => {
+    const identifiers: MauroIdentifier[] = [...Array(10).keys()].map((id) => {
+      return {
+        id: id.toString(),
+        domainType,
+        model: '123', // Only required for model items
+        dataClass: '456', // Only required for Data Elements
+        parentDataClass: '789' // Only required for child Data Classes
+      };
+    });
+
+    const payloads = identifiers.map((identifier) => {
+      const item = constructMauroItemFromIdentifier(identifier);
+      setupMockRequest(identifier, item);
+      return { identifier, item };
+    });
+
+    const expected$ = cold('---(a|)', { a: payloads.map((p) => p.item) });
+    const actual$ = service.saveMany(payloads);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  const testMissingModelIdThrowsError = (identifier: MauroIdentifier) => {
+    const expected$ = cold('#', null, new Error());
+    const actual$ = service.save(identifier, {} as MauroItem);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  const testMissingDataClassIdThrowsError = (identifier: MauroIdentifier) => {
+    const expected$ = cold('#', null, new Error());
+    const actual$ = service.save(identifier, {} as MauroItem);
+    expect(actual$).toBeObservable(expected$);
+  };
+
+  describe('unsupported domain types', () => {
+    const unsupported = [
+      CatalogueItemDomainType.ReferenceDataModel,
+      CatalogueItemDomainType.ReferenceDataModelType
+    ];
+
+    it.each(unsupported)(
+      'should throw an error for the domain type %p',
+      (domainType) => {
+        const expected$ = cold('#', null, new Error());
+        const actual$ = service.save(
+          { id: '123', domainType },
+          {} as MauroItem
+        );
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+  });
+
+  describe('save data models', () => {
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataModel
+        },
+        (id, item) => mockModelRequest(id, item, 'dataModel')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(CatalogueItemDomainType.DataModel, (id, item) =>
+        mockModelRequest(id, item, 'dataModel')
+      );
+    });
+  });
+
+  describe('save data classes', () => {
+    const mockDataClassChildRequest = (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => {
+      resourcesStub.dataClass.updateChildDataClass.mockImplementationOnce(
+        (modelId, dataClassId, id, data) => {
+          expect(modelId).toBe(identifier.model);
+          expect(dataClassId).toBe(identifier.parentDataClass);
+          expect(id).toBe(identifier.id);
+          expect(data).toStrictEqual(returnItem);
+          return cold('--a|', { a: { body: returnItem } });
+        }
+      );
+    };
+
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.DataClass
+      });
+    });
+
+    it('should save a single parent data class', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataClass,
+          model: '456'
+        },
+        (id, item) => mockModelItemRequest(id, item, 'dataClass')
+      );
+    });
+
+    it('should save a single child data class', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataClass,
+          model: '456',
+          parentDataClass: '789'
+        },
+        mockDataClassChildRequest
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(
+        CatalogueItemDomainType.DataClass,
+        mockDataClassChildRequest
+      );
+    });
+  });
+
+  describe('save data elements', () => {
+    const mockDataElementRequest = (
+      identifier: MauroIdentifier,
+      returnItem: MauroItem
+    ) => {
+      resourcesStub.dataElement.update.mockImplementationOnce(
+        (modelId, dataClassId, id, data) => {
+          expect(modelId).toBe(identifier.model);
+          expect(dataClassId).toBe(identifier.dataClass);
+          expect(id).toBe(identifier.id);
+          expect(data).toStrictEqual(returnItem);
+          return cold('--a|', { a: { body: returnItem } });
+        }
+      );
+    };
+
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.DataElement
+      });
+    });
+
+    it('should fail if not given a data class', () => {
+      testMissingDataClassIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.DataElement,
+        model: '456'
+      });
+    });
+
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.DataElement,
+          model: '456',
+          dataClass: '789'
+        },
+        mockDataElementRequest
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(
+        CatalogueItemDomainType.DataElement,
+        mockDataElementRequest
+      );
+    });
+  });
+
+  describe('save data types', () => {
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.ModelDataType
+      });
+    });
+
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.ModelDataType,
+          model: '456'
+        },
+        (id, item) => mockModelItemRequest(id, item, 'dataType')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(
+        CatalogueItemDomainType.ModelDataType,
+        (id, item) => mockModelItemRequest(id, item, 'dataType')
+      );
+    });
+  });
+
+  describe('save terminologies', () => {
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Terminology
+        },
+        (id, item) => mockModelRequest(id, item, 'terminology')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(
+        CatalogueItemDomainType.Terminology,
+        (id, item) => mockModelRequest(id, item, 'terminology')
+      );
+    });
+  });
+
+  describe('save terms', () => {
+    it('should fail if not given a model', () => {
+      testMissingModelIdThrowsError({
+        id: '123',
+        domainType: CatalogueItemDomainType.Term
+      });
+    });
+
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Term,
+          model: '456'
+        },
+        (id, item) => mockModelItemRequest(id, item, 'term')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(CatalogueItemDomainType.Term, (id, item) =>
+        mockModelItemRequest(id, item, 'term')
+      );
+    });
+  });
+
+  describe('save code sets', () => {
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.CodeSet
+        },
+        (id, item) => mockModelRequest(id, item, 'codeSet')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(CatalogueItemDomainType.CodeSet, (id, item) =>
+        mockModelRequest(id, item, 'codeSet')
+      );
+    });
+  });
+
+  describe('save folders', () => {
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Folder
+        },
+        (id, item) => mockModelRequest(id, item, 'folder')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(CatalogueItemDomainType.Folder, (id, item) =>
+        mockModelRequest(id, item, 'folder')
+      );
+    });
+  });
+
+  describe('save versioned folders', () => {
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.VersionedFolder
+        },
+        (id, item) => mockModelRequest(id, item, 'versionedFolder')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(
+        CatalogueItemDomainType.VersionedFolder,
+        (id, item) => mockModelRequest(id, item, 'versionedFolder')
+      );
+    });
+  });
+
+  describe('save classifiers', () => {
+    it('should save a single item', () => {
+      testSingleItemIsSaved(
+        {
+          id: '123',
+          domainType: CatalogueItemDomainType.Classifier
+        },
+        (id, item) => mockModelRequest(id, item, 'classifier')
+      );
+    });
+
+    it('should save many items', () => {
+      testMultipleItemsAreSaved(
+        CatalogueItemDomainType.Classifier,
+        (id, item) => mockModelRequest(id, item, 'classifier')
+      );
+    });
+  });
+});

--- a/src/app/mauro/mauro-item-update.service.ts
+++ b/src/app/mauro/mauro-item-update.service.ts
@@ -1,0 +1,242 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import {
+  CatalogueItemDomainType,
+  isDataType,
+  Term
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { forkJoin, Observable, throwError } from 'rxjs';
+import { map } from 'rxjs/operators';
+import {
+  MauroIdentifier,
+  MauroItem,
+  MauroItemResponse,
+  MauroUpdatePayload
+} from './mauro-item.types';
+
+/**
+ * Service to update any Mauro catalogue item based on identifying information and data to update.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class MauroItemUpdateService {
+  constructor(private resources: MdmResourcesService) {}
+
+  /**
+   * Saves any Mauro catalogue item back to Mauro.
+   *
+   * @param identifier A {@link MauroIdentifier} containing identification information. At least an ID and
+   * domain type is required, but some domain types based on hierarchy require further details.
+   * @param item The item and data to save. This should contain the necessary fields to update.
+   * @returns The updated catalogue item passed through an observable stream, if successful.
+   */
+  save(identifier: MauroIdentifier, item: MauroItem): Observable<MauroItem> {
+    let response: Observable<MauroItemResponse>;
+
+    if (identifier.domainType === CatalogueItemDomainType.DataModel) {
+      response = this.saveDataModel(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.DataClass) {
+      response = this.saveDataClass(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.DataElement) {
+      response = this.saveDataElement(identifier, item);
+    }
+
+    if (isDataType(identifier.domainType)) {
+      response = this.saveDataType(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Terminology) {
+      response = this.saveTerminology(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Term) {
+      response = this.saveTerm(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.CodeSet) {
+      response = this.saveCodeSet(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Folder) {
+      response = this.saveFolder(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.VersionedFolder) {
+      response = this.saveVersionedFolder(identifier, item);
+    }
+
+    if (identifier.domainType === CatalogueItemDomainType.Classifier) {
+      response = this.saveClassifier(identifier, item);
+    }
+
+    if (!response) {
+      return throwError(`${identifier.domainType} is not supported`);
+    }
+
+    return response.pipe(map((res) => res.body));
+  }
+
+  /**
+   * Save multiple Mauro catalogue items back to Mauro.
+   *
+   * @param payloads An array of Mauro items and identifiers required to update in bulk.
+   * @returns An array of the updated catalogue items passed through an observable stream, if successful.
+   */
+  saveMany(payloads: MauroUpdatePayload[]): Observable<MauroItem[]> {
+    const requests$ = payloads.map((payload) =>
+      this.save(payload.identifier, payload.item)
+    );
+
+    return forkJoin(requests$);
+  }
+
+  private saveDataModel(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    return this.resources.dataModel.update(identifier.id, item);
+  }
+
+  private saveDataClass(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    const dataClassId = identifier.parentDataClass ?? identifier.dataClass;
+    if (dataClassId) {
+      return this.resources.dataClass.updateChildDataClass(
+        identifier.model,
+        dataClassId,
+        identifier.id,
+        item
+      );
+    }
+
+    return this.resources.dataClass.update(
+      identifier.model,
+      identifier.id,
+      item
+    );
+  }
+
+  private saveDataElement(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    if (!identifier.dataClass) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a data class`
+      );
+    }
+
+    return this.resources.dataElement.update(
+      identifier.model,
+      identifier.dataClass,
+      identifier.id,
+      item
+    );
+  }
+
+  private saveDataType(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    return this.resources.dataType.update(
+      identifier.model,
+      identifier.id,
+      item
+    );
+  }
+
+  private saveTerminology(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    return this.resources.terminology.update(identifier.id, item);
+  }
+
+  private saveTerm(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    if (!identifier.model) {
+      return throwError(
+        `${identifier.domainType} ${identifier.id} has not provided a model`
+      );
+    }
+
+    return this.resources.term.update(
+      identifier.model,
+      identifier.id,
+      item as Term
+    );
+  }
+
+  private saveCodeSet(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    return this.resources.codeSet.update(identifier.id, item);
+  }
+
+  private saveFolder(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    return this.resources.folder.update(identifier.id, item);
+  }
+
+  private saveVersionedFolder(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    return this.resources.versionedFolder.update(identifier.id, item);
+  }
+
+  private saveClassifier(
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ): Observable<MauroItemResponse> {
+    return this.resources.classifier.update(identifier.id, item);
+  }
+}

--- a/src/app/mauro/mauro-item.types.ts
+++ b/src/app/mauro/mauro-item.types.ts
@@ -1,0 +1,85 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CatalogueItem,
+  MdmResponse,
+  Profile,
+  ProfileValidationError,
+  Uuid
+} from '@maurodatamapper/mdm-resources';
+
+/**
+ * Represents a generic identifier to locate any Mauro catalogue item.
+ */
+export interface MauroIdentifier extends Required<CatalogueItem> {
+  /**
+   * If locating a child catalogue item, provide the unique identifier of the parent model.
+   */
+  model?: Uuid;
+
+  /**
+   * If locating a Data Class, provide an optional parent Data Class if locating a child item.
+   */
+  parentDataClass?: Uuid;
+
+  /**
+   * If locating a Data Element, provide the unique identifier of the parent Data Class.
+   */
+  dataClass?: Uuid;
+}
+
+/**
+ * Represents a Mauro catalogue item in its most generic structure.
+ *
+ * The returned item may have many additional properties, which is why this type supports an index signature.
+ * To provide more structure, cast this object to a more specific type e.g. {@link DataModel}.
+ */
+export interface MauroItem extends Required<CatalogueItem> {
+  [key: string]: any;
+
+  /**
+   * The label assigned to this catalogue item.
+   */
+  label: string;
+
+  /**
+   * An optional description for this catalogue item.
+   */
+  description?: string;
+}
+
+export type MauroItemResponse = MdmResponse<MauroItem>;
+
+/**
+ * Represents the grouping of data required to update a collection of Mauro catalogue items in bulk.
+ */
+export interface MauroUpdatePayload {
+  identifier: MauroIdentifier;
+  item: MauroItem;
+}
+
+export interface MauroProfileUpdatePayload {
+  identifier: MauroIdentifier;
+  profile: Profile;
+}
+
+export interface MauroProfileValidationResult {
+  profile: Profile;
+  errors?: ProfileValidationError[];
+}

--- a/src/app/mauro/profiles/default-profile-provider.service.spec.ts
+++ b/src/app/mauro/profiles/default-profile-provider.service.spec.ts
@@ -1,0 +1,738 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CatalogueItemDomainType,
+  Profile,
+  ProfileField,
+  ProfileProvider,
+  ProfileSummary
+} from '@maurodatamapper/mdm-resources';
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+import { cold } from 'jest-marbles';
+import { Observable } from 'rxjs';
+import { MauroItemProviderService } from '../mauro-item-provider.service';
+import { MauroItemUpdateService } from '../mauro-item-update.service';
+import {
+  MauroIdentifier,
+  MauroItem,
+  MauroProfileUpdatePayload,
+  MauroProfileValidationResult,
+  MauroUpdatePayload
+} from '../mauro-item.types';
+import {
+  defaultProfileProvider,
+  DefaultProfileProviderService
+} from './default-profile-provider.service';
+
+describe('DefaultProfileProviderService', () => {
+  let service: DefaultProfileProviderService;
+
+  /**
+   * Stub object representing the MauroItemProviderService
+   */
+  const itemProviderStub = {
+    get: jest.fn() as jest.MockedFunction<
+      (id: MauroIdentifier) => Observable<MauroItem>
+    >,
+    getMany: jest.fn() as jest.MockedFunction<
+      (ids: MauroIdentifier[]) => Observable<MauroItem[]>
+    >
+  };
+
+  /**
+   * Stub object representing the MauroItemUpdaterService
+   */
+  const itemUpdaterStub = {
+    save: jest.fn() as jest.MockedFunction<
+      (id: MauroIdentifier, item: MauroItem) => Observable<MauroItem>
+    >,
+    saveMany: jest.fn() as jest.MockedFunction<
+      (payloads: MauroUpdatePayload[]) => Observable<MauroItem[]>
+    >
+  };
+
+  beforeEach(() => {
+    service = setupTestModuleForService(DefaultProfileProviderService, {
+      providers: [
+        {
+          provide: MauroItemProviderService,
+          useValue: itemProviderStub
+        },
+        {
+          provide: MauroItemUpdateService,
+          useValue: itemUpdaterStub
+        }
+      ]
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  /**
+   * Sample items to apply to it.each() tests. Maps a domain type and additional expected properties for
+   * catalogue items of that domain type.
+   *
+   * Note: the `description` property is assumed to apply to all domain types.
+   */
+  const sampleItems: [CatalogueItemDomainType, any][] = [
+    [
+      CatalogueItemDomainType.DataModel,
+      {
+        author: 'tester',
+        organisation: 'test org',
+        aliases: 'alias1,alias2',
+        classifications: 'test label'
+      }
+    ],
+    [
+      CatalogueItemDomainType.DataClass,
+      {
+        aliases: 'alias1,alias2',
+        classifications: 'test label',
+        minMultiplicity: 1,
+        maxMultiplicity: 1
+      }
+    ],
+    [
+      CatalogueItemDomainType.DataElement,
+      {
+        aliases: 'alias1,alias2',
+        classifications: 'test label',
+        minMultiplicity: 1,
+        maxMultiplicity: 1,
+        dataType: {
+          label: 'int'
+        }
+      }
+    ],
+    [
+      CatalogueItemDomainType.ModelDataType,
+      {
+        aliases: 'alias1,alias2',
+        classifications: 'test label'
+      }
+    ],
+    [
+      CatalogueItemDomainType.Terminology,
+      {
+        author: 'tester',
+        organisation: 'test org',
+        aliases: 'alias1,alias2',
+        classifications: 'test label'
+      }
+    ],
+    [
+      CatalogueItemDomainType.Term,
+      {
+        aliases: 'alias1,alias2',
+        classifications: 'test label',
+        code: 'test code',
+        definition: 'test definition',
+        terminology: {
+          label: 'test terminology'
+        },
+        url: 'http://test.org'
+      }
+    ],
+    [
+      CatalogueItemDomainType.CodeSet,
+      {
+        author: 'tester',
+        organisation: 'test org',
+        aliases: 'alias1,alias2',
+        classifications: 'test label'
+      }
+    ],
+    [CatalogueItemDomainType.Folder, {}],
+    [CatalogueItemDomainType.VersionedFolder, {}],
+    [CatalogueItemDomainType.Classifier, {}]
+  ];
+
+  /**
+   * Create a profile that should look like what is expected from the test scenarios.
+   *
+   * @param item A Mauro item containing the expected properties
+   *
+   * The fields mapped to the expected profile will depend on the domain types and what the mocked
+   * Mauro item properties should be.
+   */
+  const constructProfile = (item: MauroItem): Profile => {
+    const fields: ProfileField[] = [];
+
+    fields.push({
+      fieldName: 'Description',
+      metadataPropertyName: 'description',
+      dataType: 'text',
+      currentValue: item.description,
+      minMultiplicity: 0,
+      maxMultiplicity: 1
+    });
+
+    if (item.aliases) {
+      fields.push({
+        fieldName: 'Aliases',
+        metadataPropertyName: 'aliases',
+        dataType: 'string',
+        currentValue: item.aliases,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.classifications) {
+      fields.push({
+        fieldName: 'Classifications',
+        metadataPropertyName: 'classifications',
+        dataType: 'string',
+        currentValue: item.classifications,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.author) {
+      fields.push({
+        fieldName: 'Author',
+        metadataPropertyName: 'author',
+        dataType: 'string',
+        currentValue: item.author,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.organisation) {
+      fields.push({
+        fieldName: 'Organisation',
+        metadataPropertyName: 'organisation',
+        dataType: 'string',
+        currentValue: item.organisation,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.minMultiplicity && item.maxMultiplicity) {
+      fields.push({
+        fieldName: 'Multiplicity',
+        metadataPropertyName: 'multiplicity',
+        dataType: 'string',
+        currentValue: `${item.minMultiplicity}..${item.maxMultiplicity}`,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.dataType) {
+      fields.push({
+        fieldName: 'Data Type',
+        metadataPropertyName: 'dataType',
+        dataType: 'model',
+        currentValue: item.dataType,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.code) {
+      fields.push({
+        fieldName: 'Code',
+        metadataPropertyName: 'code',
+        dataType: 'string',
+        currentValue: item.code,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.definition) {
+      fields.push({
+        fieldName: 'Definition',
+        metadataPropertyName: 'definition',
+        dataType: 'string',
+        currentValue: item.definition,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.terminology) {
+      fields.push({
+        fieldName: 'Terminology',
+        metadataPropertyName: 'terminology',
+        dataType: 'model',
+        currentValue: item.terminology,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    if (item.url) {
+      fields.push({
+        fieldName: 'URL',
+        metadataPropertyName: 'url',
+        dataType: 'string',
+        currentValue: item.url,
+        minMultiplicity: 0,
+        maxMultiplicity: 1
+      });
+    }
+
+    return {
+      id: item.id,
+      domainType: item.domainType,
+      label: item.label,
+      sections: [
+        {
+          name: 'Default',
+          fields
+        }
+      ]
+    };
+  };
+
+  const mockItemProviderGet = (
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ) => {
+    itemProviderStub.get.mockImplementationOnce((id) => {
+      expect(id).toStrictEqual(identifier);
+      return cold('a|', { a: item });
+    });
+  };
+
+  const mockItemProviderGetMany = (
+    identifiers: MauroIdentifier[],
+    items: MauroItem[]
+  ) => {
+    itemProviderStub.getMany.mockImplementationOnce((ids) => {
+      expect(ids).toBe(identifiers);
+      return cold('a|', { a: items });
+    });
+  };
+
+  const mockItemUpdaterSave = (
+    identifier: MauroIdentifier,
+    item: MauroItem
+  ) => {
+    itemUpdaterStub.save.mockImplementationOnce((id, pl) => {
+      expect(id).toStrictEqual(identifier);
+      expect(pl).toStrictEqual(item);
+      return cold('a|', { a: item });
+    });
+  };
+
+  const mockItemUpdaterSaveMany = (
+    payloads: MauroUpdatePayload[],
+    items: MauroItem[]
+  ) => {
+    itemUpdaterStub.saveMany.mockImplementationOnce((pls) => {
+      expect(pls).toStrictEqual(payloads);
+      return cold('a|', { a: items });
+    });
+  };
+
+  describe('only accept default profile requests', () => {
+    const identifier: MauroIdentifier = {
+      id: '123',
+      domainType: CatalogueItemDomainType.DataModel
+    };
+
+    const badProvider: ProfileProvider = {
+      name: 'SomethingElse',
+      namespace: 'wrong.default.namespace'
+    };
+
+    const testExpectation = <R>(act: () => Observable<R>) => {
+      const expected$ = cold('|');
+      const actual$ = act();
+      expect(actual$).toBeObservable(expected$);
+    };
+
+    it('should return nothing for get()', () =>
+      testExpectation(() => service.get(identifier, badProvider)));
+
+    it('should return nothing for getMany()', () => {
+      testExpectation(() =>
+        service.getMany(
+          {
+            id: '123',
+            domainType: CatalogueItemDomainType.DataModel,
+            label: 'test'
+          },
+          [identifier],
+          badProvider
+        )
+      );
+    });
+
+    it('should return nothing for save()', () =>
+      testExpectation(() =>
+        service.save(identifier, badProvider, {} as Profile)
+      ));
+
+    it('should return nothing for saveMany()', () => {
+      testExpectation(() =>
+        service.saveMany(
+          {
+            id: '123',
+            domainType: CatalogueItemDomainType.DataModel,
+            label: 'test'
+          },
+          badProvider,
+          []
+        )
+      );
+    });
+
+    it('should return nothing for validate()', () => {
+      testExpectation(() => service.validate(badProvider, {} as Profile));
+    });
+  });
+
+  describe('get profiles', () => {
+    it.each(sampleItems)(
+      'should return a profile mapped to a %p',
+      (domainType, props) => {
+        const item: MauroItem = {
+          id: '123',
+          domainType,
+          label: domainType,
+          description: 'this is a description',
+          ...props
+        };
+
+        const identifier: MauroIdentifier = {
+          id: item.id,
+          domainType: item.domainType
+          // Note: this is missing "real" info for some domains but is good enough for mocks
+        };
+
+        mockItemProviderGet(identifier, item);
+
+        const profile = constructProfile(item);
+
+        const expected$ = cold('a|', { a: profile });
+        const actual$ = service.get(identifier, defaultProfileProvider);
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+
+    it.each(sampleItems)(
+      'should return every profile mapped to each %p',
+      (domainType, props) => {
+        // Root item isn't required for default profile provider but is a required parameter
+        const rootItem = {} as MauroItem;
+
+        const item: MauroItem = {
+          id: '123',
+          domainType,
+          label: domainType,
+          description: 'this is a description',
+          ...props
+        };
+
+        const identifier: MauroIdentifier = {
+          id: item.id,
+          domainType: item.domainType
+          // Note: this is missing "real" info for some domains but is good enough for mocks
+        };
+
+        // Mock collections of items and identifiers to simulate multiple objects
+        const identifiers = [identifier, identifier];
+        const items = [item, item];
+
+        mockItemProviderGetMany(identifiers, items);
+
+        const profiles = items.map((it) => constructProfile(it));
+
+        const expected$ = cold('a|', { a: profiles });
+        const actual$ = service.getMany(
+          rootItem,
+          identifiers,
+          defaultProfileProvider
+        );
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+  });
+
+  describe('save profiles', () => {
+    it.each(sampleItems)(
+      'should save a profile mapped to a %p',
+      (domainType, props) => {
+        const item: MauroItem = {
+          id: '123',
+          domainType,
+          label: domainType,
+          description: 'this is a description',
+          ...props
+        };
+
+        const identifier: MauroIdentifier = {
+          id: item.id,
+          domainType: item.domainType
+          // Note: this is missing "real" info for some domains but is good enough for mocks
+        };
+
+        const profile = constructProfile(item);
+
+        mockItemUpdaterSave(identifier, item);
+
+        const expected$ = cold('a|', { a: profile });
+        const actual$ = service.save(
+          identifier,
+          defaultProfileProvider,
+          profile
+        );
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+
+    it.each(sampleItems)(
+      'should save every profile mapped to each %p',
+      (domainType, props) => {
+        // Root item isn't required for default profile provider but is a required parameter
+        const rootItem = {} as MauroItem;
+
+        const item: MauroItem = {
+          id: '123',
+          domainType,
+          label: domainType,
+          description: 'this is a description',
+          ...props
+        };
+
+        const identifier: MauroIdentifier = {
+          id: item.id,
+          domainType: item.domainType
+          // Note: this is missing "real" info for some domains but is good enough for mocks
+        };
+
+        // Mock collections of items and identifiers to simulate multiple objects
+        const items = [item, item];
+        const payloads: MauroUpdatePayload[] = items.map((it) => ({
+          identifier,
+          item: it
+        }));
+
+        const profiles = items.map((it) => constructProfile(it));
+        const profilePayloads: MauroProfileUpdatePayload[] = profiles.map(
+          (profile) => ({ identifier, profile })
+        );
+
+        mockItemUpdaterSaveMany(payloads, items);
+
+        const expected$ = cold('a|', { a: profiles });
+        const actual$ = service.saveMany(
+          rootItem,
+          defaultProfileProvider,
+          profilePayloads
+        );
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+  });
+
+  describe('validate profiles', () => {
+    it.each(sampleItems)(
+      'should pass a valid a profile mapped to a %p',
+      (domainType, props) => {
+        const item: MauroItem = {
+          id: '123',
+          domainType,
+          label: domainType,
+          description: 'this is a description',
+          ...props
+        };
+
+        const profile = constructProfile(item);
+        const validation: MauroProfileValidationResult = {
+          profile,
+          errors: []
+        };
+
+        const expected$ = cold('(a|)', { a: validation });
+        const actual$ = service.validate(defaultProfileProvider, profile);
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+
+    it('should return errors with invalid multiplicity format', () => {
+      const item: MauroItem = {
+        id: '123',
+        domainType: CatalogueItemDomainType.DataElement,
+        label: CatalogueItemDomainType.DataElement,
+        description: 'this is a description',
+        minMultiplicity: 1,
+        maxMultiplicity: 1
+      };
+
+      const profile = constructProfile(item);
+
+      // Manually create bad string format
+      profile.sections
+        .find((s) => s.name === 'Default')
+        .fields.find(
+          (f) => f.metadataPropertyName === 'multiplicity'
+        ).currentValue = 'bad format';
+
+      const validation: MauroProfileValidationResult = {
+        profile,
+        errors: [
+          {
+            fieldName: 'Multiplicity',
+            metadataPropertyName: 'multiplicity',
+            message: 'Multiplicity is not in the format "x..y"'
+          }
+        ]
+      };
+
+      const expected$ = cold('(a|)', { a: validation });
+      const actual$ = service.validate(defaultProfileProvider, profile);
+      expect(actual$).toBeObservable(expected$);
+    });
+
+    it.each(sampleItems)(
+      'should pass every valid profile mapped to each %p',
+      (domainType, props) => {
+        const item: MauroItem = {
+          id: '123',
+          domainType,
+          label: domainType,
+          description: 'this is a description',
+          ...props
+        };
+
+        // Mock collections of items to simulate multiple objects
+        const items = [item, item];
+
+        const profiles = items.map((it) => constructProfile(it));
+        const validations: MauroProfileValidationResult[] = profiles.map(
+          (profile) => {
+            return {
+              profile,
+              errors: []
+            };
+          }
+        );
+
+        const expected$ = cold('(a|)', { a: validations });
+        const actual$ = service.validateMany(defaultProfileProvider, profiles);
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+  });
+
+  describe('used profiles', () => {
+    /**
+     * Maps domains and expected metadata keys for those domain types for it.each() tests below.
+     *
+     * Note: the `description` property is assumed to apply to all domain types.
+     */
+    const supportedDomains: [CatalogueItemDomainType, string[]][] = [
+      [
+        CatalogueItemDomainType.DataModel,
+        ['aliases', 'classifications', 'author', 'organisation']
+      ],
+      [
+        CatalogueItemDomainType.DataClass,
+        ['aliases', 'classifications', 'multiplicity']
+      ],
+      [
+        CatalogueItemDomainType.DataElement,
+        ['aliases', 'classifications', 'multiplicity', 'dataType']
+      ],
+      [CatalogueItemDomainType.ModelDataType, ['aliases', 'classifications']],
+      [
+        CatalogueItemDomainType.Terminology,
+        ['aliases', 'classifications', 'author', 'organisation']
+      ],
+      [
+        CatalogueItemDomainType.Term,
+        [
+          'aliases',
+          'classifications',
+          'code',
+          'definition',
+          'terminology',
+          'url'
+        ]
+      ],
+      [
+        CatalogueItemDomainType.CodeSet,
+        ['aliases', 'classifications', 'author', 'organisation']
+      ],
+      [CatalogueItemDomainType.Folder, []],
+      [CatalogueItemDomainType.VersionedFolder, []],
+      [CatalogueItemDomainType.Classifier, []]
+    ];
+
+    it.each(supportedDomains)(
+      'should always say there are no unused profiles for %p',
+      (domainType, _) => {
+        const expected$ = cold('(a|)', { a: [] });
+        const actual$ = service.unusedProfiles({
+          id: '123',
+          domainType,
+          label: 'test'
+        });
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+
+    it.each(supportedDomains)(
+      'should always list the default profile as used for %p item',
+      (domainType, keys) => {
+        const summary: ProfileSummary = {
+          allowsExtraMetadataKeys: false,
+          displayName: 'Default profile',
+          domains: [
+            CatalogueItemDomainType.DataModel,
+            CatalogueItemDomainType.DataClass,
+            CatalogueItemDomainType.DataElement,
+            CatalogueItemDomainType.ModelDataType,
+            CatalogueItemDomainType.Terminology,
+            CatalogueItemDomainType.Term,
+            CatalogueItemDomainType.CodeSet,
+            CatalogueItemDomainType.Folder,
+            CatalogueItemDomainType.VersionedFolder,
+            CatalogueItemDomainType.Classifier
+          ],
+          knownMetadataKeys: ['description', ...keys],
+          metadataNamespace: defaultProfileProvider.namespace,
+          name: defaultProfileProvider.name,
+          namespace: defaultProfileProvider.namespace,
+          providerType: 'Profile',
+          version: defaultProfileProvider.version
+        };
+
+        const expected$ = cold('(a|)', { a: [summary] });
+        const actual$ = service.usedProfiles({
+          id: '123',
+          domainType,
+          label: 'test'
+        });
+        expect(actual$).toBeObservable(expected$);
+      }
+    );
+  });
+});

--- a/src/app/mauro/profiles/default-profile-provider.service.ts
+++ b/src/app/mauro/profiles/default-profile-provider.service.ts
@@ -1,0 +1,627 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import {
+  CatalogueItemDomainType,
+  isContainerDomainType,
+  isModelDomainType,
+  Profile,
+  ProfileField,
+  ProfileProvider,
+  ProfileSection,
+  ProfileSummary,
+  ProfileValidationError
+} from '@maurodatamapper/mdm-resources';
+import { EMPTY, forkJoin, Observable, of, throwError } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { MauroItemProviderService } from '../mauro-item-provider.service';
+import { MauroItemUpdateService } from '../mauro-item-update.service';
+import {
+  MauroIdentifier,
+  MauroItem,
+  MauroProfileUpdatePayload,
+  MauroProfileValidationResult,
+  MauroUpdatePayload
+} from '../mauro-item.types';
+
+/**
+ * Profile provider definition for the Default Profile.
+ */
+export const defaultProfileProvider: ProfileProvider = {
+  name: 'DefaultProfileProviderService',
+  namespace: 'uk.ac.ox.softeng.maurodatamapper.internal.default'
+};
+
+export const defaultProfileSectionName = 'Default';
+
+const descriptionField: ProfileField = {
+  fieldName: 'Description',
+  metadataPropertyName: 'description',
+  dataType: 'text',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const aliasesField: ProfileField = {
+  fieldName: 'Aliases',
+  metadataPropertyName: 'aliases',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const authorField: ProfileField = {
+  fieldName: 'Author',
+  metadataPropertyName: 'author',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const organisationField: ProfileField = {
+  fieldName: 'Organisation',
+  metadataPropertyName: 'organisation',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const classificationsField: ProfileField = {
+  fieldName: 'Classifications',
+  metadataPropertyName: 'classifications',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const multiplicityField: ProfileField = {
+  fieldName: 'Multiplicity',
+  metadataPropertyName: 'multiplicity',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const dataTypeField: ProfileField = {
+  fieldName: 'Data Type',
+  metadataPropertyName: 'dataType',
+  dataType: 'model',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const codeField: ProfileField = {
+  fieldName: 'Code',
+  metadataPropertyName: 'code',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const definitionField: ProfileField = {
+  fieldName: 'Definition',
+  metadataPropertyName: 'definition',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const terminologyField: ProfileField = {
+  fieldName: 'Terminology',
+  metadataPropertyName: 'terminology',
+  dataType: 'model',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+const urlField: ProfileField = {
+  fieldName: 'URL',
+  metadataPropertyName: 'url',
+  dataType: 'string',
+  minMultiplicity: 0,
+  maxMultiplicity: 1
+};
+
+/**
+ * Profile provider service that manages a specific "default" profile for Mauro catalogue items.
+ *
+ * Mauro does not have an implementation of a default profile in the same way as other profiles, because the default
+ * profile is made up of properties hardwired to the catalogue item itself e.g. the description. There are some cases
+ * though where it makes sense to treat the default catalogue item properties as a profile (with sections/fields) in
+ * it's own right, so this provider service is designed to intercept the interactions between Mauro and the made up
+ * profile object.
+ *
+ * All operations must be provided with the {@link defaultProfileProvider} object to ensure that only the Default Profile
+ * is returned/updated. If any other profile namespace/name is provided, nothing will happen.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class DefaultProfileProviderService {
+  constructor(
+    private itemProvider: MauroItemProviderService,
+    private itemUpdater: MauroItemUpdateService
+  ) {}
+
+  /**
+   * Get a profile based on the given Mauro catalogue item identifier and profile provider.
+   *
+   * @param identifier A {@link MauroIdentifier} containing identification information. At least an
+   * ID and domain type is required, but some domain types based on hierarchy require further details.
+   * @param provider The namespace/name of the profile provider to use.
+   * @returns A {@link Profile} which is mapped to the requested catalogue item in an observable stream.
+   */
+  get(
+    identifier: MauroIdentifier,
+    provider: ProfileProvider
+  ): Observable<Profile> {
+    if (!this.isDefaultProvider(provider)) {
+      return EMPTY;
+    }
+
+    return this.itemProvider
+      .get(identifier)
+      .pipe(map((item) => this.mapItemToProfile(item)));
+  }
+
+  /**
+   * Get multiple profiles based on the given Mauro catalogue item identifiers and profile provider.
+   *
+   * @param rootItem The root catalogue item to base all further items under.
+   * @param identifiers An array of {@link MauroIdentifier} objects containing identification information.
+   * At least an ID and domain type is required, but some domain types based on hierarchy require further details.
+   * @param provider The namespace/name of the profile provider to use.
+   * @returns An array of {@link Profile} objects which are mapped to the requested catalogue items in an
+   * observable stream.
+   */
+  getMany(
+    rootItem: MauroItem,
+    identifiers: MauroIdentifier[],
+    provider: ProfileProvider
+  ): Observable<Profile[]> {
+    if (!this.isDefaultProvider(provider)) {
+      return EMPTY;
+    }
+
+    return this.itemProvider
+      .getMany(identifiers)
+      .pipe(map((items) => items.map((item) => this.mapItemToProfile(item))));
+  }
+
+  /**
+   * Save a profile based on the given Mauro catalogue item identifier and profile provider.
+   *
+   * @param identifier A {@link MauroIdentifier} containing identification information. At least an
+   * ID and domain type is required, but some domain types based on hierarchy require further details.
+   * @param provider The namespace/name of the profile provider to use.
+   * @param profile The {@link Profile} object to save back to the catalogue item.
+   * @returns The same profile object if saved successfully, via an observable stream.
+   */
+  save(
+    identifier: MauroIdentifier,
+    provider: ProfileProvider,
+    profile: Profile
+  ): Observable<Profile> {
+    if (!this.isDefaultProvider(provider)) {
+      return EMPTY;
+    }
+
+    const item = this.mapProfileToItem(identifier, profile);
+    return of(item).pipe(
+      switchMap((value) => this.itemUpdater.save(identifier, value)),
+      map((_) => profile)
+    );
+  }
+
+  /**
+   * Save multiple profiles based on the given profile provider and profile and identifers pairs.
+   *
+   * @param rootItem The root catalogue item to base all further items under.
+   * @param provider The namespace/name of the profile provider to use.
+   * @param payloads An array of profile/identifier pairs, containing the data to update.
+   * @returns The same profile objects if saved successfully, via an observable stream.
+   */
+  saveMany(
+    rootItem: MauroItem,
+    provider: ProfileProvider,
+    payloads: MauroProfileUpdatePayload[]
+  ): Observable<Profile[]> {
+    if (!this.isDefaultProvider(provider)) {
+      return EMPTY;
+    }
+
+    const itemPayloads: MauroUpdatePayload[] = payloads.map((payload) => {
+      return {
+        identifier: payload.identifier,
+        item: this.mapProfileToItem(payload.identifier, payload.profile)
+      };
+    });
+
+    return of(itemPayloads).pipe(
+      switchMap((items) => this.itemUpdater.saveMany(items)),
+      map((_) => payloads.map((pl) => pl.profile))
+    );
+  }
+
+  /**
+   * Validates a profile based on the given profile provider.
+   *
+   * @param provider The namespace/name of the profile provider to use.
+   * @param profile The profile to validate.
+   * @returns A result object containing the profile and a possible list of errors found, via an observable stream.
+   */
+  validate(
+    provider: ProfileProvider,
+    profile: Profile
+  ): Observable<MauroProfileValidationResult> {
+    if (!this.isDefaultProvider(provider)) {
+      return EMPTY;
+    }
+
+    const section = profile.sections.find(
+      (sec) => sec.name === defaultProfileSectionName
+    );
+    if (!section) {
+      return throwError(new Error('Cannot find default profile section'));
+    }
+
+    const errors = this.validateSection(profile, section);
+
+    return of({
+      profile,
+      errors
+    });
+  }
+
+  /**
+   * Validates multiple profiles based on the given profile provider.
+   *
+   * @param provider The namespace/name of the profile provider to use.
+   * @param profile The profiles to validate.
+   * @returns An array of result objects containing the profiles and a possible list of errors found, via an observable stream.
+   */
+  validateMany(
+    provider: ProfileProvider,
+    profiles: Profile[]
+  ): Observable<MauroProfileValidationResult[]> {
+    if (!this.isDefaultProvider(provider)) {
+      return EMPTY;
+    }
+
+    return forkJoin(
+      profiles.map((profile) => this.validate(provider, profile))
+    );
+  }
+
+  /**
+   * Identify which profiles from this profile provider have been applied to a Mauro catalogue item.
+   *
+   * @param item The catalogue item to check.
+   * @returns An array of {@link ProfileSummary} objects detailing the profiles applied to this item.
+   */
+  usedProfiles(item: MauroItem): Observable<ProfileSummary[]> {
+    return of([
+      {
+        allowsExtraMetadataKeys: false,
+        displayName: 'Default profile',
+        domains: [
+          CatalogueItemDomainType.DataModel,
+          CatalogueItemDomainType.DataClass,
+          CatalogueItemDomainType.DataElement,
+          CatalogueItemDomainType.ModelDataType,
+          CatalogueItemDomainType.Terminology,
+          CatalogueItemDomainType.Term,
+          CatalogueItemDomainType.CodeSet,
+          CatalogueItemDomainType.Folder,
+          CatalogueItemDomainType.VersionedFolder,
+          CatalogueItemDomainType.Classifier
+        ],
+        knownMetadataKeys: this.getMetadataKeys(item.domainType),
+        metadataNamespace: defaultProfileProvider.namespace,
+        name: defaultProfileProvider.name,
+        namespace: defaultProfileProvider.namespace,
+        providerType: 'Profile',
+        version: defaultProfileProvider.version
+      }
+    ]);
+  }
+
+  /**
+   * Identify which profiles from this profile provider have _not_ been applied to a Mauro catalogue item.
+   *
+   * @param item The catalogue item to check.
+   * @returns An array of {@link ProfileSummary} objects detailing the profiles _not_ applied to this item.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  unusedProfiles(item: MauroItem): Observable<ProfileSummary[]> {
+    // For this provider, every item always has a "default" profile, so there are
+    // never any unused profiles
+    return of([]);
+  }
+
+  private isDefaultProvider(provider: ProfileProvider) {
+    return (
+      provider &&
+      provider.name === defaultProfileProvider.name &&
+      provider.namespace === defaultProfileProvider.namespace
+    );
+  }
+
+  private mapItemToProfile(item: MauroItem): Profile {
+    // All domain types contain at least a "description"
+    const fields: ProfileField[] = [
+      this.mapItemToProfileField(item, descriptionField)
+    ];
+
+    if (!isContainerDomainType(item.domainType)) {
+      fields.push(this.mapItemToProfileField(item, aliasesField));
+      fields.push(this.mapItemToProfileField(item, classificationsField));
+    }
+
+    if (isModelDomainType(item.domainType)) {
+      fields.push(this.mapItemToProfileField(item, authorField));
+      fields.push(this.mapItemToProfileField(item, organisationField));
+    }
+
+    if (
+      item.domainType === CatalogueItemDomainType.DataClass ||
+      item.domainType === CatalogueItemDomainType.DataElement
+    ) {
+      // Multiplicity is a special profile field, as it is a combination of two properties
+      fields.push({
+        ...multiplicityField,
+        currentValue: `${item.minMultiplicity ?? 0}..${
+          item.maxMultiplicity ?? 0
+        }`
+      });
+    }
+
+    if (item.domainType === CatalogueItemDomainType.DataElement) {
+      fields.push(this.mapItemToProfileField(item, dataTypeField));
+    }
+
+    if (item.domainType === CatalogueItemDomainType.Term) {
+      fields.push(this.mapItemToProfileField(item, codeField));
+      fields.push(this.mapItemToProfileField(item, definitionField));
+      fields.push(this.mapItemToProfileField(item, terminologyField));
+      fields.push(this.mapItemToProfileField(item, urlField));
+    }
+
+    return {
+      id: item.id,
+      domainType: item.domainType,
+      label: item.label,
+      sections: [
+        {
+          name: defaultProfileSectionName,
+          fields
+        }
+      ]
+    };
+  }
+
+  private mapProfileToItem(
+    identifier: MauroIdentifier,
+    profile: Profile
+  ): MauroItem {
+    const section = profile.sections.find(
+      (sec) => sec.name === defaultProfileSectionName
+    );
+
+    if (!section) {
+      throw new Error('Cannot find default profile section');
+    }
+
+    const item: MauroItem = {
+      id: identifier.id,
+      domainType: identifier.domainType,
+      label: profile.label
+    };
+
+    this.mapProfileFieldToItem(
+      section,
+      item,
+      descriptionField.metadataPropertyName
+    );
+
+    if (!isContainerDomainType(item.domainType)) {
+      this.mapProfileFieldToItem(
+        section,
+        item,
+        aliasesField.metadataPropertyName
+      );
+      this.mapProfileFieldToItem(
+        section,
+        item,
+        classificationsField.metadataPropertyName
+      );
+    }
+
+    if (isModelDomainType(item.domainType)) {
+      this.mapProfileFieldToItem(
+        section,
+        item,
+        authorField.metadataPropertyName
+      );
+      this.mapProfileFieldToItem(
+        section,
+        item,
+        organisationField.metadataPropertyName
+      );
+    }
+
+    if (
+      item.domainType === CatalogueItemDomainType.DataClass ||
+      item.domainType === CatalogueItemDomainType.DataElement
+    ) {
+      // Multiplicity is a special profile field, as it is a combination of two properties
+      this.mapProfileFieldToItemProps(
+        section,
+        item,
+        multiplicityField.metadataPropertyName,
+        (field, target) => {
+          const multiplicity = field.currentValue;
+          if (!multiplicity) {
+            return;
+          }
+
+          const parts = multiplicity.split('..').map((part) => Number(part));
+          target.minMultiplicity = parts[0];
+          target.maxMultiplicity = parts[1];
+        }
+      );
+    }
+
+    if (item.domainType === CatalogueItemDomainType.DataElement) {
+      this.mapProfileFieldToItem(
+        section,
+        item,
+        dataTypeField.metadataPropertyName
+      );
+    }
+
+    if (item.domainType === CatalogueItemDomainType.Term) {
+      this.mapProfileFieldToItem(section, item, codeField.metadataPropertyName);
+      this.mapProfileFieldToItem(
+        section,
+        item,
+        definitionField.metadataPropertyName
+      );
+      this.mapProfileFieldToItem(
+        section,
+        item,
+        terminologyField.metadataPropertyName
+      );
+      this.mapProfileFieldToItem(section, item, urlField.metadataPropertyName);
+    }
+
+    return item;
+  }
+
+  private mapItemToProfileField(
+    item: MauroItem,
+    field: ProfileField
+  ): ProfileField {
+    return {
+      ...field,
+      currentValue: item[field.metadataPropertyName] ?? ''
+    };
+  }
+
+  private mapProfileFieldToItem(
+    section: ProfileSection,
+    item: MauroItem,
+    metadataPropertyName: string
+  ) {
+    this.mapProfileFieldToItemProps(
+      section,
+      item,
+      metadataPropertyName,
+      (field, target) => (target[metadataPropertyName] = field.currentValue)
+    );
+  }
+
+  private mapProfileFieldToItemProps(
+    section: ProfileSection,
+    item: MauroItem,
+    metadataPropertyName: string,
+    setter: (field: ProfileField, item: MauroItem) => void
+  ) {
+    const field = section.fields.find(
+      (fld) => fld.metadataPropertyName === metadataPropertyName
+    );
+    if (field && field.currentValue) {
+      setter(field, item);
+    }
+  }
+
+  private validateSection(
+    profile: Profile,
+    section: ProfileSection
+  ): ProfileValidationError[] {
+    const errors: ProfileValidationError[] = [];
+    if (
+      profile.domainType === CatalogueItemDomainType.DataClass ||
+      profile.domainType === CatalogueItemDomainType.DataElement
+    ) {
+      errors.push(...this.validateMultiplicity(section));
+    }
+
+    return errors;
+  }
+
+  private validateMultiplicity(
+    section: ProfileSection
+  ): ProfileValidationError[] {
+    const field = section.fields.find(
+      (fld) =>
+        fld.metadataPropertyName === multiplicityField.metadataPropertyName
+    );
+
+    if (!field) {
+      return [];
+    }
+
+    if (!/[0-9]+..[0-9]+/gm.test(field.currentValue)) {
+      return [
+        {
+          fieldName: multiplicityField.fieldName,
+          metadataPropertyName: multiplicityField.metadataPropertyName,
+          message: 'Multiplicity is not in the format "x..y"'
+        }
+      ];
+    }
+
+    return [];
+  }
+
+  private getMetadataKeys(domainType: CatalogueItemDomainType) {
+    const keys = [descriptionField.metadataPropertyName];
+
+    if (!isContainerDomainType(domainType)) {
+      keys.push(aliasesField.metadataPropertyName);
+      keys.push(classificationsField.metadataPropertyName);
+    }
+
+    if (isModelDomainType(domainType)) {
+      keys.push(authorField.metadataPropertyName);
+      keys.push(organisationField.metadataPropertyName);
+    }
+
+    if (
+      domainType === CatalogueItemDomainType.DataClass ||
+      domainType === CatalogueItemDomainType.DataElement
+    ) {
+      keys.push(multiplicityField.metadataPropertyName);
+    }
+
+    if (domainType === CatalogueItemDomainType.DataElement) {
+      keys.push(dataTypeField.metadataPropertyName);
+    }
+
+    if (domainType === CatalogueItemDomainType.Term) {
+      keys.push(codeField.metadataPropertyName);
+      keys.push(definitionField.metadataPropertyName);
+      keys.push(terminologyField.metadataPropertyName);
+      keys.push(urlField.metadataPropertyName);
+    }
+
+    return keys;
+  }
+}


### PR DESCRIPTION
Interception service responsible for mapping catalogue item hardwired properties to a `Profile` object and back. This then allows the profile to be applied to other UI controls that require only a profile.

* Map original Mauro profile operations so that a in-memory profile object can be managed
* Create additional helper services to get/set any kind of Mauro item using only minimal identifier information. This circumvents the usual Mauro APIs which require you to know the domain you're working in upfront
* Full test suite provided

Resolves #591 

**Note:** the `DefaultProfileProviderService` isn't injected anywhere at the moment. Once approved, this is planned to be integrated into the bulk editor in issue #592 