### PR TITLE
small change to better manage large descriptions

### DIFF
--- a/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.html
+++ b/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.html
@@ -40,10 +40,8 @@ SPDX-License-Identifier: Apache-2.0
       *ngIf="item.description"
       class="mdm-catalogue-item-search-result__content"
     >
-      <mdm-content-editor
-        [inEditMode]="false"
-        [content]="item.description"
-      ></mdm-content-editor>
+    <mdm-more-description [description]="item.description">
+    </mdm-more-description>
     </div>
     <div class="mdm-catalogue-item-search-result__footer">
       <a [href]="linkUrl">View Details</a>


### PR DESCRIPTION
Using the more-description component to manage large descriptions. See ss for new page.

![image](https://user-images.githubusercontent.com/85611988/179782680-95982b65-88a8-43b7-b175-7a0a808c2b9b.png)
