### PR TITLE
MC-9891 Update subscribed catalogue UI due to breaking core changes

### DIFF
--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
@@ -17,49 +17,84 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="heading-container mb-2 forms-heading-container">
-    <h4>
-        <span *ngIf="catalogue.id">Edit Subscribed Catalogue</span>
-        <span *ngIf="!catalogue.id">Add Subscribed Catalogue</span>
-    </h4>
+  <h4>
+    <span *ngIf="catalogueId">Edit Subscribed Catalogue</span>
+    <span *ngIf="!catalogueId">Add Subscribed Catalogue</span>
+  </h4>
 </div>
-<form name="subscribedCatForm" class="mdm--form mb-2">
+<form name="subscribedCatForm" class="mdm--form mb-2" [formGroup]="formGroup">
   <mat-form-field appearance="outline">
     <mat-label>Label</mat-label>
-    <input matInput name="name" [(ngModel)]="catalogue.label" required />
-    <mat-error *ngIf="errors && errors.label">
-      {{errors.label}}
-    </mat-error>
+    <input matInput name="name" formControlName="label" required />
+    <mat-error *ngIf="label?.errors?.required">Label is required</mat-error>
   </mat-form-field>
   <mat-form-field appearance="outline">
     <mat-label>Description</mat-label>
-    <input matInput name="description" [(ngModel)]="catalogue.description" />
+    <input matInput name="description" formControlName="description" />
   </mat-form-field>
-  <mat-form-field appearance="outline" hintLabel="Provide the domain URL to the Mauro system to connect to">
+  <mat-form-field
+    appearance="outline"
+    hintLabel="Provide the domain URL to the Mauro system to connect to"
+  >
     <mat-label>URL</mat-label>
-    <input matInput name="url" [(ngModel)]="catalogue.url" required />
-    <mat-error *ngIf="errors && errors.url">
-      {{errors.url}}
-    </mat-error>
+    <input matInput name="url" formControlName="url" required />
+    <mat-error *ngIf="url?.errors?.required">URL is required</mat-error>
   </mat-form-field>
-  <mat-form-field appearance="outline" hintLabel="An API key is required to view non-public models in the subscribed catalogue">
+  <mat-form-field appearance="outline">
+    <mat-label>Type</mat-label>
+    <mat-select formControlName="type">
+      <mat-option *ngFor="let type of connectionTypes" [value]="type">{{
+        type
+      }}</mat-option>
+    </mat-select>
+    <mat-error *ngIf="type?.errors?.required"
+      >Connection type is required</mat-error
+    >
+  </mat-form-field>
+  <mat-form-field
+    appearance="outline"
+    hintLabel="An API key is required to view non-public models in the subscribed catalogue"
+  >
     <mat-label>API Key</mat-label>
-    <input matInput name="apiKey" [(ngModel)]="catalogue.apiKey" />
-    <mat-error *ngIf="errors && errors.apiKey">
-      {{errors.apiKey}}
-    </mat-error>
+    <input matInput name="apiKey" formControlName="apiKey" />
   </mat-form-field>
-  <mat-form-field appearance="outline" style="max-width: 200px;">
+  <mat-form-field appearance="outline" style="max-width: 200px">
     <mat-label>Refresh period (days)</mat-label>
-    <input type="number" matInput name="refreshPeriod" [(ngModel)]="catalogue.refreshPeriod" />
+    <input
+      type="number"
+      matInput
+      name="refreshPeriod"
+      formControlName="refreshPeriod"
+    />
   </mat-form-field>
   <div>
-    <button mat-button color="warn" type="button" class="mr-1" (click)="cancel()">
+    <button
+      mat-button
+      color="warn"
+      type="button"
+      class="mr-1"
+      (click)="cancel()"
+    >
       Cancel
     </button>
-    <button mat-flat-button color="primary" type="submit" (click)="save()" *ngIf="catalogue.id">
+    <button
+      mat-flat-button
+      color="primary"
+      type="submit"
+      (click)="save()"
+      *ngIf="catalogueId"
+      [disabled]="formGroup.invalid"
+    >
       Update subscription
     </button>
-    <button mat-flat-button color="primary" type="submit" (click)="save()" *ngIf="!catalogue.id">
+    <button
+      mat-flat-button
+      color="primary"
+      type="submit"
+      (click)="save()"
+      *ngIf="!catalogueId"
+      [disabled]="formGroup.invalid"
+    >
       Add subscription
     </button>
   </div>

--- a/src/app/admin/subscribed-catalogues/subscribed-catalogues.component.html
+++ b/src/app/admin/subscribed-catalogues/subscribed-catalogues.component.html
@@ -17,80 +17,174 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="mdm--shadow-block">
-    <div class="heading-container">
-        <div fxFlex fxLayout="row" fxLayout.md="row" fxLayout.sm="row" fxLayout.xs="column"
-            fxLayoutAlign="space-around">
-            <div fxFlex fxLayout="row" fxFlex="80" fxFlex.md="80" fxFlex.sm="80" fxFlex.xs="100"
-                fxLayoutAlign="flex-start center">
-                <h4 class="marginless">
-                    Catalogues <span class="mdm--badge mdm--element-count">{{totalItemCount}}</span>
-                </h4>
-            </div>
-            <div fxFlex fxLayout="row" fxFlex="20" fxFlex.md="20" fxFlex.sm="25" fxFlex.xs="100"
-                fxLayoutAlign="flex-end center" fxLayoutAlign.xs="flex-start center">
-                <mdm-data-type-list-buttons [displayRecords]="records" [showContentDropdown]="false" [showDeleteButton]="false" [add]="addSubscription"></mdm-data-type-list-buttons>
-            </div>
-        </div>
+  <div class="heading-container">
+    <div
+      fxFlex
+      fxLayout="row"
+      fxLayout.md="row"
+      fxLayout.sm="row"
+      fxLayout.xs="column"
+      fxLayoutAlign="space-around"
+    >
+      <div
+        fxFlex
+        fxLayout="row"
+        fxFlex="80"
+        fxFlex.md="80"
+        fxFlex.sm="80"
+        fxFlex.xs="100"
+        fxLayoutAlign="flex-start center"
+      >
+        <h4 class="marginless">
+          Catalogues
+          <span class="mdm--badge mdm--element-count">{{
+            totalItemCount
+          }}</span>
+        </h4>
+      </div>
+      <div
+        fxFlex
+        fxLayout="row"
+        fxFlex="20"
+        fxFlex.md="20"
+        fxFlex.sm="25"
+        fxFlex.xs="100"
+        fxLayoutAlign="flex-end center"
+        fxLayoutAlign.xs="flex-start center"
+      >
+        <mdm-data-type-list-buttons
+          [displayRecords]="records"
+          [showContentDropdown]="false"
+          [showDeleteButton]="false"
+          [add]="addSubscription"
+        ></mdm-data-type-list-buttons>
+      </div>
     </div>
-    <div class="table-responsive">
-        <table mat-table [dataSource]="dataSource" matSort class="mdm--mat-table table table-striped marginless">
-            <ng-container matColumnDef="label">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header style="cursor: pointer; max-width: 40%;" columnName="label" scope="col">
-                    <span>Label</span>
-                </th>
-                <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                    {{record.label}}
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="description">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header style="cursor: pointer; max-width: 40%;" columnName="description" scope="col">
-                    <span>Description</span>
-                </th>
-                <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                    {{record.description}}
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="connection">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header style="cursor: pointer; max-width: 40%;" columnName="connection" scope="col">
-                    <span>Connection</span>
-                </th>
-                <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                    <p><strong>URL:</strong> {{record.url}}</p>
-                    <p *ngIf="record.apiKey"><strong>Key:</strong> {{record.apiKey}}</p>
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="refreshPeriod">
-                <th mat-header-cell *matHeaderCellDef mat-sort-header style="width: 20%; cursor: pointer; max-width: 40%;" columnName="refreshPeriod" scope="col">
-                    <span>Refresh period (days)</span>
-                </th>
-                <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                    {{record.refreshPeriod}}
-                </td>
-            </ng-container>
-            <ng-container matColumnDef="icons">
-                <td mat-header-cell *matHeaderCellDef columnName="icons" style="width: 7%; text-align: center;"></td>
-                <td mat-cell *matCellDef="let record; let i = index" style="text-align: center; word-wrap: break-word;">
-                    <button mat-icon-button color="primary" [matMenuTriggerFor]="actions">
-                        <span class="fas fa-ellipsis-v"></span>
-                    </button>
-                    <mat-menu #actions="matMenu" yPosition="below" xPosition="after">
-                        <button mat-menu-item (click)="testSubscription(record)">
-                            <span class="fas fa-play success"></span> Test subscription
-                        </button>
-                        <button mat-menu-item (click)="editSubscription(record)">
-                            <span class="fas fa-pencil-alt"></span> Edit subscription
-                        </button>
-                        <button mat-menu-item (click)="deleteSubscription(record)">
-                            <span class="far fa-trash-alt warning"></span> Delete subscription
-                        </button>
-                    </mat-menu>
-                </td>
-            </ng-container>
-            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-            <tr mat-row *matRowDef="let record; columns: displayedColumns;"></tr>
-        </table>
-    </div>
-    <div class="mdm--mat-pagination" [ngClass]="{'is-hidden':totalItemCount < 6}">
-        <mdm-paginator [length]="totalItemCount" showFirstLastButtons></mdm-paginator>
-    </div>
+  </div>
+  <div class="table-responsive">
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      matSort
+      class="mdm--mat-table table table-striped marginless"
+    >
+      <ng-container matColumnDef="label">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          style="cursor: pointer; max-width: 40%"
+          columnName="label"
+          scope="col"
+        >
+          <span>Label</span>
+        </th>
+        <td
+          mat-cell
+          *matCellDef="let record"
+          style="text-align: left; word-wrap: break-word"
+        >
+          {{ record.label }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="description">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          style="cursor: pointer; max-width: 40%"
+          columnName="description"
+          scope="col"
+        >
+          <span>Description</span>
+        </th>
+        <td
+          mat-cell
+          *matCellDef="let record"
+          style="text-align: left; word-wrap: break-word"
+        >
+          {{ record.description }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="connection">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          style="cursor: pointer; max-width: 40%"
+          columnName="connection"
+          scope="col"
+        >
+          <span>Connection</span>
+        </th>
+        <td
+          mat-cell
+          *matCellDef="let record"
+          style="text-align: left; word-wrap: break-word"
+        >
+          <p><strong>URL:</strong> {{ record.url }}</p>
+          <p><strong>Type:</strong> {{ record.subscribedCatalogueType }}</p>
+          <p *ngIf="record.apiKey"><strong>Key:</strong> {{ record.apiKey }}</p>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="refreshPeriod">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          style="width: 20%; cursor: pointer; max-width: 40%"
+          columnName="refreshPeriod"
+          scope="col"
+        >
+          <span>Refresh period (days)</span>
+        </th>
+        <td
+          mat-cell
+          *matCellDef="let record"
+          style="text-align: left; word-wrap: break-word"
+        >
+          {{ record.refreshPeriod }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="icons">
+        <td
+          mat-header-cell
+          *matHeaderCellDef
+          columnName="icons"
+          style="width: 7%; text-align: center"
+        ></td>
+        <td
+          mat-cell
+          *matCellDef="let record; let i = index"
+          style="text-align: center; word-wrap: break-word"
+        >
+          <button mat-icon-button color="primary" [matMenuTriggerFor]="actions">
+            <span class="fas fa-ellipsis-v"></span>
+          </button>
+          <mat-menu #actions="matMenu" yPosition="below" xPosition="after">
+            <button mat-menu-item (click)="testSubscription(record)">
+              <span class="fas fa-play success"></span> Test subscription
+            </button>
+            <button mat-menu-item (click)="editSubscription(record)">
+              <span class="fas fa-pencil-alt"></span> Edit subscription
+            </button>
+            <button mat-menu-item (click)="deleteSubscription(record)">
+              <span class="far fa-trash-alt warning"></span> Delete subscription
+            </button>
+          </mat-menu>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let record; columns: displayedColumns"></tr>
+    </table>
+  </div>
+  <div
+    class="mdm--mat-pagination"
+    [ngClass]="{ 'is-hidden': totalItemCount < 6 }"
+  >
+    <mdm-paginator
+      [length]="totalItemCount"
+      showFirstLastButtons
+    ></mdm-paginator>
+  </div>
 </div>

--- a/src/app/model/federated-data-model.ts
+++ b/src/app/model/federated-data-model.ts
@@ -16,7 +16,12 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { AvailableDataModel, CatalogueItemDomainType, SubscribedDataModel } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  PublishedDataModel,
+  PublishedDataModelLink,
+  SubscribedDataModel
+} from '@maurodatamapper/mdm-resources';
 
 export class FederatedDataModel {
   catalogueId: string;
@@ -24,24 +29,33 @@ export class FederatedDataModel {
   label: string;
   description?: string;
   modelType?: CatalogueItemDomainType;
+  dateCreated?: string;
+  datePublished?: string;
+  lastUpdated?: string;
+  links?: PublishedDataModelLink[];
   subscriptionId?: string;
   folderId?: string;
   folderLabel?: string;
-  version? : string;
+  version?: string;
 
   constructor(
     catalogueId: string,
-    available?: AvailableDataModel,
-    subscription?: SubscribedDataModel) {
-      this.catalogueId = catalogueId;
-      this.modelId = available?.modelId;
-      this.label = available?.label;
-      this.description = available?.description;
-      this.version = available?.version;
-      this.modelType = available?.modelType;
-      this.subscriptionId = subscription?.id;
-      this.folderId = subscription?.folderId;
-    }
+    published?: PublishedDataModel,
+    subscription?: SubscribedDataModel
+  ) {
+    this.catalogueId = catalogueId;
+    this.modelId = published?.modelId;
+    this.label = published?.label;
+    this.description = published?.description;
+    this.version = published?.version;
+    this.modelType = published?.modelType;
+    this.dateCreated = published?.dateCreated;
+    this.datePublished = published?.datePublished;
+    this.lastUpdated = published?.lastUpdated;
+    this.links = published?.links;
+    this.subscriptionId = subscription?.id;
+    this.folderId = subscription?.folderId;
+  }
 
   get isSubscribed(): boolean {
     return this.subscriptionId !== undefined;

--- a/src/app/modules/resources/mdm-resources.service.ts
+++ b/src/app/modules/resources/mdm-resources.service.ts
@@ -63,7 +63,8 @@ import {
   CatalogueItemDomainType,
   SearchableItemResource,
   ContainerDomain,
-  MdmAsyncJobsResource
+  MdmAsyncJobsResource,
+  ImportableResource
 } from '@maurodatamapper/mdm-resources';
 import { MdmRestHandlerService } from './mdm-rest-handler.service';
 
@@ -231,6 +232,40 @@ export class MdmResourcesService {
       domainType === CatalogueItemDomainType.VersionedFolder
     ) {
       return this.versionedFolder;
+    }
+
+    return null;
+  }
+
+  getImportableResource(
+    domainType: ModelDomain | CatalogueItemDomainType
+  ): ImportableResource {
+    if (
+      domainType === 'dataModels' ||
+      domainType === CatalogueItemDomainType.DataModel
+    ) {
+      return this.dataModel;
+    }
+
+    if (
+      domainType === 'terminologies' ||
+      domainType === CatalogueItemDomainType.Terminology
+    ) {
+      return this.terminology;
+    }
+
+    if (
+      domainType === 'codeSets' ||
+      domainType === CatalogueItemDomainType.CodeSet
+    ) {
+      return this.codeSet;
+    }
+
+    if (
+      domainType === 'referenceDataModels' ||
+      domainType === CatalogueItemDomainType.ReferenceDataModel
+    ) {
+      return this.referenceDataModel;
     }
 
     return null;

--- a/src/app/services/model-tree.service.ts
+++ b/src/app/services/model-tree.service.ts
@@ -18,12 +18,31 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable, OnDestroy } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { CatalogueItemDomainType, ClassifierDetailResponse, ContainerDomainType, FolderDetailResponse, MdmTreeItem, MdmTreeItemListResponse, Modelable, SubscribedCatalogue, SubscribedCatalogueIndexResponse, Uuid, VersionedFolderDetailResponse } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  ClassifierDetailResponse,
+  ContainerDomainType,
+  FilterQueryParameters,
+  FolderDetailResponse,
+  MdmTreeItem,
+  MdmTreeItemListResponse,
+  Modelable,
+  SubscribedCatalogue,
+  SubscribedCatalogueIndexResponse,
+  Uuid,
+  VersionedFolderDetailResponse
+} from '@maurodatamapper/mdm-resources';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 import { FlatNode } from '@mdm/folders-tree/flat-node';
 import { NewFolderModalComponent } from '@mdm/modals/new-folder-modal/new-folder-modal.component';
-import { NewFolderModalConfiguration, NewFolderModalResponse } from '@mdm/modals/new-folder-modal/new-folder-modal.model';
-import { MdmResourcesService, MdmRestHandlerOptions } from '@mdm/modules/resources';
+import {
+  NewFolderModalConfiguration,
+  NewFolderModalResponse
+} from '@mdm/modals/new-folder-modal/new-folder-modal.model';
+import {
+  MdmResourcesService,
+  MdmRestHandlerOptions
+} from '@mdm/modules/resources';
 import { SubscribedCataloguesService } from '@mdm/subscribed-catalogues/subscribed-catalogues.service';
 import { EMPTY, Observable, of, Subject, throwError } from 'rxjs';
 import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
@@ -39,7 +58,6 @@ import { UserSettingsHandlerService } from './utility/user-settings-handler.serv
   providedIn: 'root'
 })
 export class ModelTreeService implements OnDestroy {
-
   currentNode?: FlatNode;
 
   private unsubscribe$ = new Subject();
@@ -54,12 +72,12 @@ export class ModelTreeService implements OnDestroy {
     private elementTypes: ElementTypesService,
     private broadcast: BroadcastService,
     private dialog: MatDialog,
-    private editing: EditingService) {
-
+    private editing: EditingService
+  ) {
     this.broadcast
       .onCatalogueTreeNodeSelected()
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe(data => this.currentNode = data.node);
+      .subscribe((data) => (this.currentNode = data.node));
   }
 
   ngOnDestroy(): void {
@@ -72,10 +90,12 @@ export class ModelTreeService implements OnDestroy {
     if (this.sharedService.isLoggedIn()) {
       options = {
         queryStringParams: {
-          includeDocumentSuperseded: this.userSettingsHandler.get('includeDocumentSuperseded') || false,
+          includeDocumentSuperseded:
+            this.userSettingsHandler.get('includeDocumentSuperseded') || false,
           // includeModelSuperseded: this.userSettingsHandler.get('includeModelSuperseded') || false,
           includeModelSuperseded: true,
-          includeDeleted: this.userSettingsHandler.get('includeDeleted') || false
+          includeDeleted:
+            this.userSettingsHandler.get('includeDeleted') || false
         }
       };
     }
@@ -85,17 +105,18 @@ export class ModelTreeService implements OnDestroy {
 
     return this.resources.tree
       .list(ContainerDomainType.Folders, options.queryStringParams)
-      .pipe(
-        map((response: MdmTreeItemListResponse) => response.body)
-      );
+      .pipe(map((response: MdmTreeItemListResponse) => response.body));
   }
 
   getSubscribedCatalogueTreeNodes(): Observable<MdmTreeItem[]> {
-    if (!this.sharedService.isLoggedIn(true) || !this.sharedService.features.useSubscribedCatalogues) {
+    if (
+      !this.sharedService.isLoggedIn(true) ||
+      !this.sharedService.features.useSubscribedCatalogues
+    ) {
       return of([]);
     }
 
-    const queryParams = {
+    const queryParams: FilterQueryParameters = {
       sort: 'label',
       order: 'asc'
     };
@@ -110,52 +131,74 @@ export class ModelTreeService implements OnDestroy {
     return this.resources.subscribedCatalogues
       .list(queryParams, restOptions)
       .pipe(
-        map((response: SubscribedCatalogueIndexResponse) => response.body.items ?? []),
-        map((catalogues: SubscribedCatalogue[]) => catalogues.map(item => Object.assign<{}, MdmTreeItem>({}, {
-          id: item.id,
-          domainType: CatalogueItemDomainType.SubscribedCatalogue,
-          hasChildren: true,
-          label: item.label,
-          availableActions: []
-        }))),
-        catchError(error => {
-          this.messageHandler.showError('There was a problem getting the Subscribed Catalogues.', error);
+        map(
+          (response: SubscribedCatalogueIndexResponse) =>
+            response.body.items ?? []
+        ),
+        map((catalogues: SubscribedCatalogue[]) =>
+          catalogues.map((item) =>
+            Object.assign<{}, MdmTreeItem>(
+              {},
+              {
+                id: item.id,
+                domainType: CatalogueItemDomainType.SubscribedCatalogue,
+                hasChildren: true,
+                label: item.label,
+                availableActions: []
+              }
+            )
+          )
+        ),
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem getting the Subscribed Catalogues.',
+            error
+          );
           return EMPTY;
-        }),
+        })
       );
   }
 
   createRootNode(children?: MdmTreeItem[]): MdmTreeItem {
-    return Object.assign<{}, MdmTreeItem>({}, {
-      id: '',
-      domainType: CatalogueItemDomainType.Root,
-      children,
-      hasChildren: true,
-      isRoot: true,
-      availableActions: []
-    });
+    return Object.assign<{}, MdmTreeItem>(
+      {},
+      {
+        id: '',
+        domainType: CatalogueItemDomainType.Root,
+        children,
+        hasChildren: true,
+        isRoot: true,
+        availableActions: []
+      }
+    );
   }
 
   createLocalCatalogueNode(children?: MdmTreeItem[]): MdmTreeItem {
-    return Object.assign<{}, MdmTreeItem>({}, {
-      id: '4aa2444c-ed08-471b-84dd-96f6b3b4a00a',
-      domainType: CatalogueItemDomainType.LocalCatalogue,
-      label: 'This catalogue',
-      hasChildren: true,
-      children,
-      availableActions: []
-    });
+    return Object.assign<{}, MdmTreeItem>(
+      {},
+      {
+        id: '4aa2444c-ed08-471b-84dd-96f6b3b4a00a',
+        domainType: CatalogueItemDomainType.LocalCatalogue,
+        label: 'This catalogue',
+        hasChildren: true,
+        children,
+        availableActions: []
+      }
+    );
   }
 
   createExternalCataloguesNode(children?: MdmTreeItem[]): MdmTreeItem {
-    return Object.assign<{}, MdmTreeItem>({}, {
-      id: '30dca3f9-5cf5-41a8-97eb-fd2dab2d4c20',
-      domainType: CatalogueItemDomainType.ExternalCatalogues,
-      label: 'External catalogues',
-      hasChildren: true,
-      children,
-      availableActions: []
-    });
+    return Object.assign<{}, MdmTreeItem>(
+      {},
+      {
+        id: '30dca3f9-5cf5-41a8-97eb-fd2dab2d4c20',
+        domainType: CatalogueItemDomainType.ExternalCatalogues,
+        label: 'External catalogues',
+        hasChildren: true,
+        children,
+        availableActions: []
+      }
+    );
   }
 
   /**
@@ -171,23 +214,31 @@ export class ModelTreeService implements OnDestroy {
    * @see FederatedDataModel
    */
   getFederatedDataModelNodes(catalogueId: string): Observable<MdmTreeItem[]> {
-    return this.subscribedCatalogues
-      .getFederatedDataModels(catalogueId)
-      .pipe(
-        catchError(error => {
-          this.messageHandler.showError('There was a problem getting federated data models from a subscribed catalogue.', error);
-          return EMPTY;
-        }),
-        map(models => models.map(item => Object.assign<{}, MdmTreeItem>({}, {
-          id: item.modelId,
-          domainType: CatalogueItemDomainType.FederatedDataModel,
-          hasChildren: false,
-          label: item.label,
-          modelVersion: item.version,
-          parentId: item.catalogueId,
-          availableActions: []
-        })))
-      );
+    return this.subscribedCatalogues.getFederatedDataModels(catalogueId).pipe(
+      catchError((error) => {
+        this.messageHandler.showError(
+          'There was a problem getting federated data models from a subscribed catalogue.',
+          error
+        );
+        return EMPTY;
+      }),
+      map((models) =>
+        models.map((item) =>
+          Object.assign<{}, MdmTreeItem>(
+            {},
+            {
+              id: item.modelId,
+              domainType: CatalogueItemDomainType.FederatedDataModel,
+              hasChildren: false,
+              label: item.label,
+              modelVersion: item.version,
+              parentId: item.catalogueId,
+              availableActions: []
+            }
+          )
+        )
+      )
+    );
   }
 
   /**
@@ -198,27 +249,35 @@ export class ModelTreeService implements OnDestroy {
    * @returns An `Observable` containing either a `FolderDetailResponse` or `VersionedFolderDetailResponse`,
    * depending on the options selected in the dialog.
    */
-  createNewFolder(settings: { allowVersioning?: boolean; parentFolderId?: Uuid }): Observable<FolderDetailResponse | VersionedFolderDetailResponse> {
+  createNewFolder(settings: {
+    allowVersioning?: boolean;
+    parentFolderId?: Uuid;
+  }): Observable<FolderDetailResponse | VersionedFolderDetailResponse> {
     return this.editing
-      .openDialog<NewFolderModalComponent, NewFolderModalConfiguration, NewFolderModalResponse>(
+      .openDialog<
         NewFolderModalComponent,
-        {
-          data: {
-            modalTitle: 'Create a new Folder',
-            okBtn: 'Add folder',
-            btnType: 'primary',
-            inputLabel: 'Folder name',
-            message: 'Please enter the name of your Folder.',
-            createRootFolder: !(settings?.parentFolderId),
-            canVersion: settings?.allowVersioning
-          }
-        })
+        NewFolderModalConfiguration,
+        NewFolderModalResponse
+      >(NewFolderModalComponent, {
+        data: {
+          modalTitle: 'Create a new Folder',
+          okBtn: 'Add folder',
+          btnType: 'primary',
+          inputLabel: 'Folder name',
+          message: 'Please enter the name of your Folder.',
+          createRootFolder: !settings?.parentFolderId,
+          canVersion: settings?.allowVersioning
+        }
+      })
       .afterClosed()
       .pipe(
-        filter(response => response?.status === ModalDialogStatus.Ok),
-        switchMap(modal => {
+        filter((response) => response?.status === ModalDialogStatus.Ok),
+        switchMap((modal) => {
           if (modal.useVersionedFolders && modal.isVersioned) {
-            return this.saveVersionedFolder(modal.label, settings?.parentFolderId);
+            return this.saveVersionedFolder(
+              modal.label,
+              settings?.parentFolderId
+            );
           }
 
           return this.saveFolder(modal.label, settings?.parentFolderId);
@@ -233,25 +292,30 @@ export class ModelTreeService implements OnDestroy {
    */
   createNewClassifier(): Observable<ClassifierDetailResponse> {
     return this.editing
-      .openDialog<NewFolderModalComponent, NewFolderModalConfiguration, NewFolderModalResponse>(
+      .openDialog<
         NewFolderModalComponent,
-        {
-          data: {
-            modalTitle: 'Create a new Classifier',
-            okBtn: 'Add Classifier',
-            btnType: 'primary',
-            inputLabel: 'Classifier name',
-            message: 'Please enter the name of your Classifier.'
-          }
-        })
+        NewFolderModalConfiguration,
+        NewFolderModalResponse
+      >(NewFolderModalComponent, {
+        data: {
+          modalTitle: 'Create a new Classifier',
+          okBtn: 'Add Classifier',
+          btnType: 'primary',
+          inputLabel: 'Classifier name',
+          message: 'Please enter the name of your Classifier.'
+        }
+      })
       .afterClosed()
       .pipe(
-        filter(response => response?.status === ModalDialogStatus.Ok),
-        switchMap(modal => this.saveClassifier(modal.label))
+        filter((response) => response?.status === ModalDialogStatus.Ok),
+        switchMap((modal) => this.saveClassifier(modal.label))
       );
   }
 
-  saveFolder(label: string, parentFolderId?: Uuid): Observable<FolderDetailResponse> {
+  saveFolder(
+    label: string,
+    parentFolderId?: Uuid
+  ): Observable<FolderDetailResponse> {
     if (parentFolderId) {
       return this.resources.folder.saveChildrenOf(parentFolderId, { label });
     }
@@ -259,9 +323,14 @@ export class ModelTreeService implements OnDestroy {
     return this.resources.folder.save({ label });
   }
 
-  saveVersionedFolder(label: string, parentFolderId?: Uuid): Observable<VersionedFolderDetailResponse> {
+  saveVersionedFolder(
+    label: string,
+    parentFolderId?: Uuid
+  ): Observable<VersionedFolderDetailResponse> {
     if (parentFolderId) {
-      return this.resources.versionedFolder.saveToFolder(parentFolderId, { label });
+      return this.resources.versionedFolder.saveToFolder(parentFolderId, {
+        label
+      });
     }
 
     return this.resources.versionedFolder.save({ label });
@@ -282,54 +351,68 @@ export class ModelTreeService implements OnDestroy {
                   <p class="marginless">except Administrators.</p>`
         }
       })
-      .pipe(
-        switchMap(() => this.deleteCatalogueItem(item, false))
-      );
+      .pipe(switchMap(() => this.deleteCatalogueItem(item, false)));
   }
 
   deleteCatalogueItemPermanent(item: Modelable): Observable<void> {
-    return this.securityHandler.isAdministrator()
-      .pipe(
-        switchMap(isAdministrator => {
-          if (!isAdministrator) {
-            this.messageHandler.showWarning('Only administrators may permanently delete catalogue items.');
-            return of();
-          }
+    return this.securityHandler.isAdministrator().pipe(
+      switchMap((isAdministrator) => {
+        if (!isAdministrator) {
+          this.messageHandler.showWarning(
+            'Only administrators may permanently delete catalogue items.'
+          );
+          return of();
+        }
 
-          return this.dialog
-            .openDoubleConfirmationAsync({
-              data: {
-                title: 'Permanent deletion',
-                okBtnTitle: 'Yes, delete',
-                btnType: 'warn',
-                message: `Are you sure you want to <span class=\'warning\'>permanently</span> delete '${item.label}'?`
-              }
-            }, {
-              data: {
-                title: 'Confirm permanent deletion',
-                okBtnTitle: 'Confirm deletion',
-                btnType: 'warn',
-                message: '<strong>Note: </strong> This item and all its contents will be deleted <span class=\'warning\'>permanently</span>.'
-              }
-            });
-        }),
-        switchMap(() => this.deleteCatalogueItem(item, true))
-      );
+        return this.dialog.openDoubleConfirmationAsync(
+          {
+            data: {
+              title: 'Permanent deletion',
+              okBtnTitle: 'Yes, delete',
+              btnType: 'warn',
+              message: `Are you sure you want to <span class=\'warning\'>permanently</span> delete '${item.label}'?`
+            }
+          },
+          {
+            data: {
+              title: 'Confirm permanent deletion',
+              okBtnTitle: 'Confirm deletion',
+              btnType: 'warn',
+              message:
+                '<strong>Note: </strong> This item and all its contents will be deleted <span class=\'warning\'>permanently</span>.'
+            }
+          }
+        );
+      }),
+      switchMap(() => this.deleteCatalogueItem(item, true))
+    );
   }
 
-  private deleteCatalogueItem(item: Modelable, permanent: boolean): Observable<void> {
+  private deleteCatalogueItem(
+    item: Modelable,
+    permanent: boolean
+  ): Observable<void> {
     const baseTypes = this.elementTypes.getBaseTypes();
     const type = baseTypes[item.domainType];
     if (!type) {
-      return throwError(`Cannot find resource name for domain type '${item.domainType}'`);
+      return throwError(
+        `Cannot find resource name for domain type '${item.domainType}'`
+      );
     }
 
     return this.resources[type.resourceName]
       .remove(item.id, { permanent })
       .pipe(
-        map(() => this.messageHandler.showSuccess(`Successfully deleted '${item.label}'`)),
-        catchError(error => {
-          this.messageHandler.showError(`There was a problem deleting '${item.label}'.`, error);
+        map(() =>
+          this.messageHandler.showSuccess(
+            `Successfully deleted '${item.label}'`
+          )
+        ),
+        catchError((error) => {
+          this.messageHandler.showError(
+            `There was a problem deleting '${item.label}'.`,
+            error
+          );
           return EMPTY;
         })
       );

--- a/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.html
+++ b/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.html
@@ -17,73 +17,148 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="panel panel-default mdm--shadow-block">
-    <form name="form" disable-submit-on-enter>
-        <div class="panel-body">
-            <h4 class="inline-block marginless">
-                <span class="dataModelTypeIcon">
-                    <span matTooltip="Data Standard" class="fas fa-external-link-alt"></span>
-                </span>
-                <mdm-inline-text-edit [readOnly]="true" [(ngModel)]="dataModel.label" name="labelName"
-                    [inEditMode]="false" [styleCss]="'dataTypeDetailsLabel'">
-                </mdm-inline-text-edit>
-            </h4>
-            <small *ngIf="dataModel.isSubscribed">
-                <span class="badge badge-success ml-1">Subscribed</span>
-            </small>
-            <div class="detail-icons">
-                <div class="text-muted">
-                    <small>
-                        <span class="fas fa-cube" matTooltip="Item type"></span>
-                        <span><strong>Item type: </strong><span class="item-type">Federated Data Model</span></span>
-                    </small>
-                </div>
-                <div class="text-muted">
-                    <small>
-                        <span class="fas fa-file-code" matTooltip="Model type"></span>
-                        <span><strong>Model type: </strong><span class="fas {{getModelTypeIcon()}}"
-                                matTooltip="Model type"></span>{{dataModel.modelType}}</span>
-                    </small>
-                </div>
-            </div>
+  <form name="form" disable-submit-on-enter>
+    <div class="panel-body">
+      <h4 class="inline-block marginless">
+        <span class="dataModelTypeIcon">
+          <span
+            matTooltip="Data Standard"
+            class="fas fa-external-link-alt"
+          ></span>
+        </span>
+        <mdm-inline-text-edit
+          [readOnly]="true"
+          [(ngModel)]="dataModel.label"
+          name="labelName"
+          [inEditMode]="false"
+          [styleCss]="'dataTypeDetailsLabel'"
+        >
+        </mdm-inline-text-edit>
+      </h4>
+      <small *ngIf="dataModel.isSubscribed">
+        <span class="badge badge-success ml-1">Subscribed</span>
+      </small>
+      <div class="detail-icons">
+        <div class="text-muted">
+          <small>
+            <span class="fas fa-cube" matTooltip="Item type"></span>
+            <span
+              ><strong>Item type: </strong
+              ><span class="item-type">Federated Data Model</span></span
+            >
+          </small>
         </div>
-        <table class="table table-bordered mdm--table-fixed">
-            <tbody>
-                <tr>
-                    <th class="detailsRowHeader" scope="col">Description</th>
-                    <td class="elementDetailDescription">
-                        <mdm-content-editor  [inEditMode]="false" [(content)]="dataModel.description" [element]="dataModel"
-                            [property]="'description'">
-                        </mdm-content-editor>
-                    </td>
-                </tr>
-                <tr>
-                    <th class="detailsRowHeader" scope="col">Folder</th>
-                    <td class="elementDetailDescription">
-                        <mdm-inline-text-edit [readOnly]="true" [inEditMode]="false"
-                            [(ngModel)]="dataModel.folderLabel" class="dataModelDetailsLabel" name="folder">
-                        </mdm-inline-text-edit>
-                    </td>
-                </tr>
-                <tr>
-                    <td colspan="2" style="text-align: right;">
-                        <div *ngIf="!dataModel.isSubscribed" class="mr-1" style="float: right;">
-                            <button mat-stroked-button color="accent" type="button" class=" warning"
-                                matTooltip="Subscribe" aria-label="Subscribe" [disabled]="processing" (click)="subscribeToModel()">
-                                <span class="fas fa-plus"></span><span class="ml-1">Subscribe</span>
-                            </button>
-                        </div>
-                        <div *ngIf="dataModel.isSubscribed" class="mr-1" style="float: right;">
-                            <button mat-stroked-button color="warn" type="button" class=" warning"
-                                matTooltip="Unsubscribe" aria-label="Unsubscribe" [disabled]="processing" (click)="unsubscribeFromModel()">
-                                <span class="fas fa-minus"></span><span class="ml-1">Unsubscribe</span>
-                            </button>
-                        </div>
-                          <div style="clear: both;" *ngIf="processing">
-                            <mat-progress-bar value="50" bufferValue="75" color="accent" mode="indeterminate"></mat-progress-bar>
-                        </div>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </form>
+        <div class="text-muted">
+          <small>
+            <span class="fas fa-file-code" matTooltip="Model type"></span>
+            <span
+              ><strong>Model type: </strong
+              ><span
+                class="fas {{ getModelTypeIcon() }}"
+                matTooltip="Model type"
+              ></span
+              >{{dataModel?.modelType ?? 'Model'}}</span
+            >
+          </small>
+        </div>
+      </div>
+    </div>
+    <table class="table table-bordered mdm--table-fixed">
+      <tbody>
+        <tr>
+          <th class="detailsRowHeader" scope="col">Description</th>
+          <td class="elementDetailDescription">
+            <mdm-content-editor
+              [inEditMode]="false"
+              [(content)]="dataModel.description"
+              [element]="dataModel"
+              [property]="'description'"
+            >
+            </mdm-content-editor>
+          </td>
+        </tr>
+        <tr *ngIf="dataModel.dateCreated">
+          <th class="detailsRowHeader" scope="col">Created</th>
+          <td class="elementDetailDescription">
+            {{ dataModel.dateCreated | date: 'dd-MM-yyyy HH:mm:ss' }}
+          </td>
+        </tr>
+        <tr *ngIf="dataModel.datePublished">
+          <th class="detailsRowHeader" scope="col">Published</th>
+          <td class="elementDetailDescription">
+            {{ dataModel.datePublished | date: 'dd-MM-yyyy HH:mm:ss' }}
+          </td>
+        </tr>
+        <tr *ngIf="dataModel.lastUpdated">
+          <th class="detailsRowHeader" scope="col">Last updated</th>
+          <td class="elementDetailDescription">
+            {{ dataModel.lastUpdated | date: 'dd-MM-yyyy HH:mm:ss' }}
+          </td>
+        </tr>
+        <tr>
+          <th class="detailsRowHeader" scope="col">Folder</th>
+          <td class="elementDetailDescription">
+            <mdm-inline-text-edit
+              [readOnly]="true"
+              [inEditMode]="false"
+              [(ngModel)]="dataModel.folderLabel"
+              class="dataModelDetailsLabel"
+              name="folder"
+            >
+            </mdm-inline-text-edit>
+          </td>
+        </tr>
+        <tr>
+          <td colspan="2" style="text-align: right">
+            <div
+              *ngIf="!dataModel.isSubscribed"
+              class="mr-1"
+              style="float: right"
+            >
+              <button
+                mat-stroked-button
+                color="accent"
+                type="button"
+                class="warning"
+                matTooltip="Subscribe"
+                aria-label="Subscribe"
+                [disabled]="processing"
+                (click)="subscribeToModel()"
+              >
+                <span class="fas fa-plus"></span
+                ><span class="ml-1">Subscribe</span>
+              </button>
+            </div>
+            <div
+              *ngIf="dataModel.isSubscribed"
+              class="mr-1"
+              style="float: right"
+            >
+              <button
+                mat-stroked-button
+                color="warn"
+                type="button"
+                class="warning"
+                matTooltip="Unsubscribe"
+                aria-label="Unsubscribe"
+                [disabled]="processing"
+                (click)="unsubscribeFromModel()"
+              >
+                <span class="fas fa-minus"></span
+                ><span class="ml-1">Unsubscribe</span>
+              </button>
+            </div>
+            <div style="clear: both" *ngIf="processing">
+              <mat-progress-bar
+                value="50"
+                bufferValue="75"
+                color="accent"
+                mode="indeterminate"
+              ></mat-progress-bar>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </form>
 </div>

--- a/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.ts
@@ -21,12 +21,22 @@ import { Title } from '@angular/platform-browser';
 import { FederatedDataModel } from '@mdm/model/federated-data-model';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { MatDialog } from '@angular/material/dialog';
-import { catchError, filter, finalize, switchMap } from 'rxjs/operators';
+import { catchError, filter, finalize, map, switchMap } from 'rxjs/operators';
 import { MessageHandlerService } from '@mdm/services';
-import { NewFederatedSubscriptionModalComponent, NewFederatedSubscriptionModalConfig, NewFederatedSubscriptionModalResponse } from '../new-federated-subscription-modal/new-federated-subscription-modal.component';
+import {
+  NewFederatedSubscriptionModalComponent,
+  NewFederatedSubscriptionModalConfig,
+  NewFederatedSubscriptionModalResponse
+} from '../new-federated-subscription-modal/new-federated-subscription-modal.component';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
-import { FolderDetailResponse } from '@maurodatamapper/mdm-resources';
+import {
+  FolderDetailResponse,
+  Importer,
+  ImporterIndexResponse,
+  SubscribedDataModelPayload
+} from '@maurodatamapper/mdm-resources';
 import { getCatalogueItemDomainTypeIcon } from '@mdm/folders-tree/flat-node';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'mdm-federated-data-model-detail',
@@ -34,7 +44,6 @@ import { getCatalogueItemDomainTypeIcon } from '@mdm/folders-tree/flat-node';
   styleUrls: ['./federated-data-model-detail.component.scss']
 })
 export class FederatedDataModelDetailComponent implements OnInit {
-
   @Input() dataModel: FederatedDataModel;
   @Output() reloading = new EventEmitter();
 
@@ -44,7 +53,8 @@ export class FederatedDataModelDetailComponent implements OnInit {
     private resources: MdmResourcesService,
     private dialog: MatDialog,
     private messageHandler: MessageHandlerService,
-    private title: Title) {}
+    private title: Title
+  ) {}
 
   ngOnInit(): void {
     this.title.setTitle(`Federated Data Model - ${this.dataModel.label}`);
@@ -52,37 +62,72 @@ export class FederatedDataModelDetailComponent implements OnInit {
   }
 
   getModelTypeIcon() {
-    return getCatalogueItemDomainTypeIcon(this.dataModel.modelType);
+    return this.dataModel.modelType
+      ? getCatalogueItemDomainTypeIcon(this.dataModel.modelType)
+      : 'fa-database';
   }
 
   subscribeToModel() {
-    this.dialog
-      .open<NewFederatedSubscriptionModalComponent, NewFederatedSubscriptionModalConfig, NewFederatedSubscriptionModalResponse>(
-        NewFederatedSubscriptionModalComponent,
-        {
-          data: {
-            modalTitle: 'Subscribe to Data Model',
-            btnType: 'primary',
-            inputLabel: 'Folder name',
-            message: 'Please select the folder to subscribe this data model to.'
-          }
-        }
-      )
-      .afterClosed()
+    const importable = this.resources.getImportableResource(
+      this.dataModel.modelType
+    );
+
+    const importersRequest$: Observable<Importer[]> = importable
+      ? importable
+          .importers()
+          .pipe(map((response: ImporterIndexResponse) => response.body))
+      : of([]);
+
+    importersRequest$
       .pipe(
-        filter(response => response?.status === ModalDialogStatus.Ok),
-        switchMap(response => {
+        switchMap((importers) => {
+          return this.dialog
+            .open<
+              NewFederatedSubscriptionModalComponent,
+              NewFederatedSubscriptionModalConfig,
+              NewFederatedSubscriptionModalResponse
+            >(NewFederatedSubscriptionModalComponent, {
+              data: {
+                contentLinks: this.dataModel.links,
+                importers
+              },
+              minWidth: 600
+            })
+            .afterClosed();
+        }),
+        filter((response) => response?.status === ModalDialogStatus.Ok),
+        switchMap((response) => {
           this.processing = true;
-          return this.resources.subscribedCatalogues.saveSubscribedModel(
-            this.dataModel.catalogueId,
-            {
+
+          const payload: SubscribedDataModelPayload = {
+            subscribedModel: {
               subscribedModelId: this.dataModel.modelId,
               subscribedModelType: this.dataModel.modelType,
               folderId: response.folder.id
-            });
+            },
+            ...(response.contentLink && {
+              url: response.contentLink.url,
+              contentType: response.contentLink.contentType
+            }),
+            ...(response.importer && {
+              importerProviderService: {
+                name: response.importer.name,
+                namespace: response.importer.namespace,
+                version: response.importer.version
+              }
+            })
+          };
+
+          return this.resources.subscribedCatalogues.saveSubscribedModel(
+            this.dataModel.catalogueId,
+            payload
+          );
         }),
-        catchError(error => {
-          this.messageHandler.showError('There was a problem subscribing to the data model.', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem subscribing to the data model.',
+            error
+          );
           return [];
         }),
         finalize(() => {
@@ -91,8 +136,62 @@ export class FederatedDataModelDetailComponent implements OnInit {
         })
       )
       .subscribe(() => {
-        this.messageHandler.showSuccess('Successfully subscribed to data model.');
+        this.messageHandler.showSuccess(
+          'Successfully subscribed to data model.'
+        );
       });
+
+    // this.dialog
+    //   .open<
+    //     NewFederatedSubscriptionModalComponent,
+    //     NewFederatedSubscriptionModalConfig,
+    //     NewFederatedSubscriptionModalResponse
+    //   >(NewFederatedSubscriptionModalComponent, {
+    //     data: {
+    //       contentLinks: this.dataModel.links
+    //     },
+    //     minWidth: 600
+    //   })
+    //   .afterClosed()
+    //   .pipe(
+    //     filter((response) => response?.status === ModalDialogStatus.Ok),
+    //     switchMap((response) => {
+    //       this.processing = true;
+
+    //       const payload: SubscribedDataModelPayload = {
+    //         subscribedModel: {
+    //           subscribedModelId: this.dataModel.modelId,
+    //           subscribedModelType: this.dataModel.modelType,
+    //           folderId: response.folder.id
+    //         },
+    //         ...(response.contentLink && {
+    //           url: response.contentLink.url,
+    //           contentType: response.contentLink.contentType
+    //         })
+    //       };
+
+    //       return this.resources.subscribedCatalogues.saveSubscribedModel(
+    //         this.dataModel.catalogueId,
+    //         payload
+    //       );
+    //     }),
+    //     catchError((error) => {
+    //       this.messageHandler.showError(
+    //         'There was a problem subscribing to the data model.',
+    //         error
+    //       );
+    //       return [];
+    //     }),
+    //     finalize(() => {
+    //       this.processing = false;
+    //       this.reloading.emit();
+    //     })
+    //   )
+    //   .subscribe(() => {
+    //     this.messageHandler.showSuccess(
+    //       'Successfully subscribed to data model.'
+    //     );
+    //   });
   }
 
   unsubscribeFromModel() {
@@ -110,7 +209,8 @@ export class FederatedDataModelDetailComponent implements OnInit {
           this.processing = true;
           return this.resources.subscribedCatalogues.removeSubscribedModel(
             this.dataModel.catalogueId,
-            this.dataModel.subscriptionId);
+            this.dataModel.subscriptionId
+          );
         }),
         finalize(() => {
           this.processing = false;
@@ -118,18 +218,28 @@ export class FederatedDataModelDetailComponent implements OnInit {
         })
       )
       .subscribe(
-        () => this.messageHandler.showSuccess('Successfully unsubscribed from data model.'),
-        error => this.messageHandler.showError('There was a problem unsubscribing from the data model.', error));
+        () =>
+          this.messageHandler.showSuccess(
+            'Successfully unsubscribed from data model.'
+          ),
+        (error) =>
+          this.messageHandler.showError(
+            'There was a problem unsubscribing from the data model.',
+            error
+          )
+      );
   }
 
-   setFolderLabelToForm() {
+  setFolderLabelToForm() {
     if (!this.dataModel.folderId) {
       return;
     }
 
     this.resources.folder
-      .get(this.dataModel.folderId, {}, {handleGetErrors : false})
-      .subscribe((response: FolderDetailResponse) => this.dataModel.folderLabel = response.body.label);
-
-}
+      .get(this.dataModel.folderId, {}, { handleGetErrors: false })
+      .subscribe(
+        (response: FolderDetailResponse) =>
+          (this.dataModel.folderLabel = response.body.label)
+      );
+  }
 }

--- a/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.ts
@@ -140,58 +140,6 @@ export class FederatedDataModelDetailComponent implements OnInit {
           'Successfully subscribed to data model.'
         );
       });
-
-    // this.dialog
-    //   .open<
-    //     NewFederatedSubscriptionModalComponent,
-    //     NewFederatedSubscriptionModalConfig,
-    //     NewFederatedSubscriptionModalResponse
-    //   >(NewFederatedSubscriptionModalComponent, {
-    //     data: {
-    //       contentLinks: this.dataModel.links
-    //     },
-    //     minWidth: 600
-    //   })
-    //   .afterClosed()
-    //   .pipe(
-    //     filter((response) => response?.status === ModalDialogStatus.Ok),
-    //     switchMap((response) => {
-    //       this.processing = true;
-
-    //       const payload: SubscribedDataModelPayload = {
-    //         subscribedModel: {
-    //           subscribedModelId: this.dataModel.modelId,
-    //           subscribedModelType: this.dataModel.modelType,
-    //           folderId: response.folder.id
-    //         },
-    //         ...(response.contentLink && {
-    //           url: response.contentLink.url,
-    //           contentType: response.contentLink.contentType
-    //         })
-    //       };
-
-    //       return this.resources.subscribedCatalogues.saveSubscribedModel(
-    //         this.dataModel.catalogueId,
-    //         payload
-    //       );
-    //     }),
-    //     catchError((error) => {
-    //       this.messageHandler.showError(
-    //         'There was a problem subscribing to the data model.',
-    //         error
-    //       );
-    //       return [];
-    //     }),
-    //     finalize(() => {
-    //       this.processing = false;
-    //       this.reloading.emit();
-    //     })
-    //   )
-    //   .subscribe(() => {
-    //     this.messageHandler.showSuccess(
-    //       'Successfully subscribed to data model.'
-    //     );
-    //   });
   }
 
   unsubscribeFromModel() {

--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.html
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.html
@@ -17,19 +17,27 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="full-width">
-    <mdm-federated-data-model-detail *ngIf="dataModel" [dataModel]="dataModel" (reloading)="onReloading()">
-    </mdm-federated-data-model-detail>
-    <mat-tab-group *ngIf="dataModel && catalogueId" #tab animationDuration="0ms" [selectedIndex]="activeTab"
-        (selectedIndexChange)="tabSelected($event)">
-        <mat-tab *ngIf="showNewerVersionsTab" label="Newer Versions">
-            <ng-template matTabContent>
-              <mdm-newer-versions
-                [catalogueItem]="dataModel"
-                [catalogueId]="catalogueId"
-                (hasErrored)="onNewerVersionsHasErrored()"
-              >
-              </mdm-newer-versions>
-            </ng-template>
-          </mat-tab>
-    </mat-tab-group>
+  <mdm-federated-data-model-detail
+    *ngIf="dataModel"
+    [dataModel]="dataModel"
+    (reloading)="onReloading()"
+  >
+  </mdm-federated-data-model-detail>
+  <mat-tab-group
+    *ngIf="dataModel && catalogueId"
+    #tab
+    animationDuration="0ms"
+    [selectedIndex]="activeTab"
+  >
+    <mat-tab *ngIf="showNewerVersionsTab" label="Newer Versions">
+      <ng-template matTabContent>
+        <mdm-newer-versions
+          [catalogueItem]="dataModel"
+          [catalogueId]="catalogueId"
+          (hasErrored)="onNewerVersionsHasErrored()"
+        >
+        </mdm-newer-versions>
+      </ng-template>
+    </mat-tab>
+  </mat-tab-group>
 </div>

--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
@@ -30,15 +30,14 @@ import { SubscribedCataloguesService } from '../subscribed-catalogues.service';
   templateUrl: './federated-data-model-main.component.html',
   styleUrls: ['./federated-data-model-main.component.scss']
 })
-export class FederatedDataModelMainComponent extends BaseComponent implements OnInit {
-
+export class FederatedDataModelMainComponent
+  extends BaseComponent
+  implements OnInit {
   catalogueId: string;
   modelId: string;
   dataModel: FederatedDataModel;
   activeTab: any;
-  tabs = new TabCollection([
-    'newVersion'
-  ]);
+  tabs = new TabCollection(['newVersion']);
   showNewerVersionsTab = true;
 
   constructor(
@@ -46,7 +45,8 @@ export class FederatedDataModelMainComponent extends BaseComponent implements On
     private stateHandler: StateHandlerService,
     private messageHandler: MessageHandlerService,
     private subscribedCatalogues: SubscribedCataloguesService,
-    private title: Title) {
+    private title: Title
+  ) {
     super();
   }
 
@@ -91,13 +91,21 @@ export class FederatedDataModelMainComponent extends BaseComponent implements On
     this.subscribedCatalogues
       .getFederatedDataModels(this.catalogueId)
       .subscribe(
-        models => {
-          this.dataModel = models.find(model => model.modelId === this.modelId);
+        (models) => {
+          this.dataModel = models.find(
+            (model) => model.modelId === this.modelId
+          );
+
           if (reloadView) {
             this.reloadView();
           }
         },
-        errors => this.messageHandler.showError('There was a problem getting the Federated Data Model', errors));
+        (errors) =>
+          this.messageHandler.showError(
+            'There was a problem getting the Federated Data Model',
+            errors
+          )
+      );
   }
 
   private reloadView() {
@@ -109,6 +117,7 @@ export class FederatedDataModelMainComponent extends BaseComponent implements On
       },
       {
         reload: true
-      });
+      }
+    );
   }
 }

--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
@@ -82,11 +82,6 @@ export class FederatedDataModelMainComponent
     this.getFederatedDataModel(true);
   }
 
-  tabSelected(index: number) {
-    const tab = this.tabs.getByIndex(index);
-    this.stateHandler.Go('dataModel', { tabView: tab.name }, { notify: false });
-  }
-
   onNewerVersionsHasErrored() {
     this.showNewerVersionsTab = false;
   }

--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.ts
@@ -54,11 +54,15 @@ export class FederatedDataModelMainComponent
     this.catalogueId = this.uiRouterGlobals.params.parentId;
     if (!this.catalogueId || !this.isGuid(this.catalogueId)) {
       this.stateHandler.NotFound({ location: false });
+      return;
     }
 
     this.modelId = this.uiRouterGlobals.params.id;
-    if (!this.modelId || !this.isGuid(this.modelId)) {
+    // modelId may not be in a UUID format, this depends on the catalogue type e.g. Atom. There
+    // should definitely be a modelId passed through the query string though
+    if (!this.modelId) {
       this.stateHandler.NotFound({ location: false });
+      return;
     }
 
     this.title.setTitle('Federated Data Model');

--- a/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.html
+++ b/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.html
@@ -17,20 +17,60 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="modal-header pxy-2">
-    <h4 class='modal-title marginless'>{{modalTitle}}</h4>
+  <h4 class="modal-title marginless">Subscribe to Model</h4>
 </div>
 <div class="modal-body pxy-2">
-    <p [innerHtml]="message"></p>
-    <mdm-model-selector-tree
-        ngDefaultControl
-        name="Folder"
-        [(ngModel)]="selectedFolders"
+  <form role="form" [formGroup]="formGroup">
+    <div class="mb-2">
+      <p>Select the folder to import this model to.</p>
+      <mdm-model-selector-tree
+        [ngModel]="folder.value"
+        (ngModelChange)="folder.setValue($event)"
+        [ngModelOptions]="{ standalone: true }"
         [treeSearchDomainType]="'Folder'"
         [justShowFolders]="true"
-        [accepts]="['Folder']" >
-    </mdm-model-selector-tree>
+        [accepts]="['Folder']"
+      >
+      </mdm-model-selector-tree>
+    </div>
+    <p>You may also choose the following optional settings:</p>
+    <div>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Select content type</mat-label>
+        <mat-select formControlName="format">
+          <mat-option *ngFor="let link of contentLinks" [value]="link">
+            {{ link.contentType }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div *ngIf="importers && importers.length > 0">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Select importer</mat-label>
+        <mat-select formControlName="importer">
+          <mat-option></mat-option>
+          <mat-option *ngFor="let importer of importers" [value]="importer">
+            {{ importer.displayName }}
+          </mat-option>
+        </mat-select>
+        <mat-hint
+          >Leave this blank to let Mauro determine an importer to use</mat-hint
+        >
+      </mat-form-field>
+    </div>
+  </form>
 </div>
 <div class="modal-footer pxy-2">
-    <button mat-button color="warn" class="mr-1" type="button" (click)="cancel()">{{cancelBtn}}</button>
-    <button mat-flat-button color="{{btnType}}" type="button" [disabled]="!folder" (click)="confirm()">{{okBtn}}</button>
+  <button mat-button color="warn" class="mr-1" type="button" (click)="cancel()">
+    Cancel
+  </button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="formGroup.invalid"
+    (click)="confirm()"
+  >
+    Subscribe
+  </button>
 </div>

--- a/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.spec.ts
+++ b/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.spec.ts
@@ -16,42 +16,29 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { CommonModule } from '@angular/common';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent
+} from '@mdm/testing/testing.helpers';
 
 import { NewFederatedSubscriptionModalComponent } from './new-federated-subscription-modal.component';
 
 describe('NewFederatedSubscriptionModalComponent', () => {
-  let component: NewFederatedSubscriptionModalComponent;
-  let fixture: ComponentFixture<NewFederatedSubscriptionModalComponent>;
+  let harness: ComponentHarness<NewFederatedSubscriptionModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        CommonModule,
-        FormsModule,
-        MatButtonModule,
-        MatDialogModule
-      ],
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent<
+      NewFederatedSubscriptionModalComponent
+    >(NewFederatedSubscriptionModalComponent, {
       providers: [
         { provide: MAT_DIALOG_DATA, useValue: {} },
-        { provide: MatDialogRef, useValue: {} },
-      ],
-      declarations: [ NewFederatedSubscriptionModalComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(NewFederatedSubscriptionModalComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+        { provide: MatDialogRef, useValue: {} }
+      ]
+    });
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(harness.isComponentCreated).toBeTruthy();
   });
 });

--- a/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.ts
+++ b/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.ts
@@ -17,22 +17,25 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { FolderDetail } from '@maurodatamapper/mdm-resources';
+import {
+  FolderDetail,
+  Importer,
+  PublishedDataModelLink
+} from '@maurodatamapper/mdm-resources';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 
 export interface NewFederatedSubscriptionModalConfig {
-  okBtn?: string;
-  cancelBtn?: string;
-  btnType?: string;
-  modalTitle?: string;
-  message?: string;
-  inputLabel?: string;
+  contentLinks: PublishedDataModelLink[];
+  importers: Importer[];
 }
 
 export interface NewFederatedSubscriptionModalResponse {
   status: ModalDialogStatus;
   folder?: FolderDetail;
+  contentLink?: PublishedDataModelLink;
+  importer?: Importer;
 }
 
 @Component({
@@ -41,40 +44,53 @@ export interface NewFederatedSubscriptionModalResponse {
   styleUrls: ['./new-federated-subscription-modal.component.scss']
 })
 export class NewFederatedSubscriptionModalComponent implements OnInit {
+  contentLinks: PublishedDataModelLink[];
+  importers: Importer[];
 
-  okBtn: string;
-  cancelBtn: string;
-  btnType: string;
-  modalTitle: string;
-  message: string;
-  inputLabel: string;
-  selectedFolders: FolderDetail[];
+  formGroup: FormGroup = new FormGroup({
+    folder: new FormControl(null, [Validators.required]), // eslint-disable-line @typescript-eslint/unbound-method
+    format: new FormControl(null),
+    importer: new FormControl(null)
+  });
 
-  get folder(): FolderDetail {
-    if (this.selectedFolders && this.selectedFolders[0]) {
-      return this.selectedFolders[0];
-    }
+  get format() {
+    return this.formGroup.get('format');
+  }
 
-    return undefined;
+  get folder() {
+    return this.formGroup.get('folder');
+  }
+
+  get importer() {
+    return this.formGroup.get('importer');
   }
 
   constructor(
-    private dialogRef: MatDialogRef<NewFederatedSubscriptionModalComponent, NewFederatedSubscriptionModalResponse>,
-    @Inject(MAT_DIALOG_DATA) public data: NewFederatedSubscriptionModalConfig) { }
+    private dialogRef: MatDialogRef<
+      NewFederatedSubscriptionModalComponent,
+      NewFederatedSubscriptionModalResponse
+    >,
+    @Inject(MAT_DIALOG_DATA) public data: NewFederatedSubscriptionModalConfig
+  ) {}
 
   ngOnInit(): void {
-    this.okBtn = this.data.okBtn ? this.data.okBtn : 'Subscribe';
-    this.btnType = this.data.btnType ? this.data.btnType : 'primary';
-    this.cancelBtn = this.data.cancelBtn ? this.data.cancelBtn : 'Cancel';
-    this.inputLabel = this.data.inputLabel ? this.data.inputLabel : '';
-    this.modalTitle = this.data.modalTitle ? this.data.modalTitle : '';
-    this.message = this.data.message;
+    this.contentLinks = this.data.contentLinks;
+    this.importers = this.data.importers ?? [];
   }
 
   confirm() {
-    if (this.folder) {
-      this.dialogRef.close({ status: ModalDialogStatus.Ok, folder: this.folder });
+    if (this.formGroup.invalid) {
+      return;
     }
+
+    const selectedFolders = this.folder.value as FolderDetail[];
+
+    this.dialogRef.close({
+      status: ModalDialogStatus.Ok,
+      folder: selectedFolders[0],
+      contentLink: this.format.value,
+      importer: this.importer.value
+    });
   }
 
   cancel() {

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
@@ -71,7 +71,6 @@ SPDX-License-Identifier: Apache-2.0
       <th
         mat-header-cell
         *matHeaderCellDef
-        mat-sort-header="version"
         style="max-width: 5%; width: 5%"
         columnName="navigate"
         scope="col"

--- a/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.html
+++ b/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.html
@@ -17,36 +17,59 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="panel panel-default mdm--shadow-block">
-    <form editable-form name="form" disable-submit-on-enter>
-        <div class="panel-body">
-            <h4 class="marginless">
-                <span class="dataModelTypeIcon">
-                    <span matTooltip="Data Standard" class="fas fa-rss"></span>
-                </span>
-                <mdm-inline-text-edit [readOnly]="true" [(ngModel)]="subscribedCatalogue.label" name="labelName"
-                    [inEditMode]="false" [styleCss]="'dataTypeDetailsLabel'">
-                </mdm-inline-text-edit>
-            </h4>
-            <div class="detail-icons">
-                <div class="text-muted">
-                    <small>
-                        <span class="fas fa-cube" matTooltip="Item type"></span>
-                        <span><strong>Item type: </strong><span class="item-type">Subscribed Catalogue</span></span>
-                    </small>
-                </div>
-            </div>
+  <form editable-form name="form" disable-submit-on-enter>
+    <div class="panel-body">
+      <h4 class="marginless">
+        <span class="dataModelTypeIcon">
+          <span matTooltip="Data Standard" class="fas fa-rss"></span>
+        </span>
+        <mdm-inline-text-edit
+          [readOnly]="true"
+          [(ngModel)]="subscribedCatalogue.label"
+          name="labelName"
+          [inEditMode]="false"
+          [styleCss]="'dataTypeDetailsLabel'"
+        >
+        </mdm-inline-text-edit>
+      </h4>
+      <div class="detail-icons">
+        <div class="text-muted">
+          <small>
+            <span class="fas fa-cube" matTooltip="Item type"></span>
+            <span
+              ><strong>Item type: </strong
+              ><span class="item-type">Subscribed Catalogue</span></span
+            >
+          </small>
         </div>
-        <table class="table table-bordered mdm--table-fixed">
-            <tbody>
-                <tr>
-                    <th class="detailsRowHeader" scope="col">Description</th>
-                    <td class="elementDetailDescription">
-                        <mdm-content-editor [content]="subscribedCatalogue.description" [element]="subscribedCatalogue"
-                            [property]="'description'">
-                        </mdm-content-editor>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </form>
+      </div>
+    </div>
+    <table class="table table-bordered mdm--table-fixed">
+      <tbody>
+        <tr>
+          <th class="detailsRowHeader" scope="col">Catalogue type</th>
+          <td class="elementDetailDescription">
+            {{ subscribedCatalogue.subscribedCatalogueType }}
+          </td>
+        </tr>
+        <tr>
+          <th class="detailsRowHeader" scope="col">URL</th>
+          <td class="elementDetailDescription">
+            {{ subscribedCatalogue.url }}
+          </td>
+        </tr>
+        <tr>
+          <th class="detailsRowHeader" scope="col">Description</th>
+          <td class="elementDetailDescription">
+            <mdm-content-editor
+              [content]="subscribedCatalogue.description"
+              [element]="subscribedCatalogue"
+              [property]="'description'"
+            >
+            </mdm-content-editor>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </form>
 </div>

--- a/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
+++ b/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
@@ -26,15 +26,18 @@ describe('SubscribedCatalogueDetailComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SubscribedCatalogueDetailComponent ]
-    })
-    .compileComponents();
+      declarations: [SubscribedCatalogueDetailComponent]
+    }).compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SubscribedCatalogueDetailComponent);
     component = fixture.componentInstance;
-    component.subscribedCatalogue = { url: '', label: '' };
+    component.subscribedCatalogue = {
+      url: '',
+      label: '',
+      subscribedCatalogueType: 'test'
+    };
     fixture.detectChanges();
   });
 

--- a/src/app/subscribed-catalogues/subscribed-catalogues.service.ts
+++ b/src/app/subscribed-catalogues/subscribed-catalogues.service.ts
@@ -17,9 +17,17 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
-import { AvailableDataModel, AvailableDataModelIndexResponse, SubscribedDataModel, SubscribedDataModelIndexResponse } from '@maurodatamapper/mdm-resources';
+import {
+  PublishedDataModel,
+  PublishedDataModelIndexResponse,
+  SubscribedDataModel,
+  SubscribedDataModelIndexResponse
+} from '@maurodatamapper/mdm-resources';
 import { FederatedDataModel } from '@mdm/model/federated-data-model';
-import { MdmResourcesService, MdmRestHandlerOptions } from '@mdm/modules/resources';
+import {
+  MdmResourcesService,
+  MdmRestHandlerOptions
+} from '@mdm/modules/resources';
 import { combineLatest, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -27,8 +35,7 @@ import { map } from 'rxjs/operators';
   providedIn: 'root'
 })
 export class SubscribedCataloguesService {
-
-  constructor(private resources: MdmResourcesService) { }
+  constructor(private resources: MdmResourcesService) {}
 
   /**
    * Combines the endpoint responses from `listPublishedModels()` and `listSubscribedModels()` to produce a collection of
@@ -36,22 +43,29 @@ export class SubscribedCataloguesService {
    *
    * @param catalogueId The UUID of the subscribed catalogue to search under.
    */
-  getFederatedDataModels(catalogueId: string): Observable<FederatedDataModel[]> {
+  getFederatedDataModels(
+    catalogueId: string
+  ): Observable<FederatedDataModel[]> {
     return combineLatest([
       this.listPublishedModels(catalogueId),
       this.listSubscribedModels(catalogueId)
-    ])
-    .pipe(
+    ]).pipe(
       map(([publishedModels, subscribedModels]) => {
-        return publishedModels.map(publishedModel => {
-          const subscribed = subscribedModels.find(item => item.subscribedModelId === (publishedModel.modelId ?? ''));
-          return new FederatedDataModel(catalogueId, publishedModel, subscribed);
+        return publishedModels.map((publishedModel) => {
+          const subscribed = subscribedModels.find(
+            (item) => item.subscribedModelId === (publishedModel.modelId ?? '')
+          );
+          return new FederatedDataModel(
+            catalogueId,
+            publishedModel,
+            subscribed
+          );
         });
       })
     );
   }
 
-  listPublishedModels(catalogueId: string): Observable<AvailableDataModel[]> {
+  listPublishedModels(catalogueId: string): Observable<PublishedDataModel[]> {
     // Handle any HTTP errors manually. This covers the scenario where this is unable to
     // get available models from the subscribed catalogue e.g. the subscribed catalogue instance is not
     // available/offline
@@ -62,7 +76,10 @@ export class SubscribedCataloguesService {
     return this.resources.subscribedCatalogues
       .listPublishedModels(catalogueId, {}, restOptions)
       .pipe(
-        map((response: AvailableDataModelIndexResponse) => response.body.items ?? [])
+        map(
+          (response: PublishedDataModelIndexResponse) =>
+            response.body.items ?? []
+        )
       );
   }
 
@@ -70,7 +87,10 @@ export class SubscribedCataloguesService {
     return this.resources.subscribedCatalogues
       .listSubscribedModels(catalogId)
       .pipe(
-        map((response: SubscribedDataModelIndexResponse) => response.body.items ?? [])
+        map(
+          (response: SubscribedDataModelIndexResponse) =>
+            response.body.items ?? []
+        )
       );
   }
 }


### PR DESCRIPTION
**Note:** this depends on MauroDataMapper/mdm-resources#71

* Update admin setup forms to use Angular reactive forms
* Add new connection type field to add/edit subscribed catalogue
* Display connection type of each subscribed catalogue in the list view
* Handle case where published model type is not known
* Display published data model dates
* Update Subscribe Data Model dialog to use Angular reactive forms
* Send additional properties during subscribed model creation - content link and/or importer

# Screenshots

Admin screen of subscribed catalogues with subscribed catalogue types:

![image](https://user-images.githubusercontent.com/3219480/179973341-d2f13a58-62e9-4af1-9da8-c5935a43eb43.png)

Inclusion of dates from published data models:

![image](https://user-images.githubusercontent.com/3219480/179973522-9263d1d7-a59b-4475-8642-56fdfbedb0f4.png)

Updates to subscribe dialog:

![image](https://user-images.githubusercontent.com/3219480/179973644-70f1ec16-f21a-45d2-8200-a6fd759e5f81.png)
