### PR TITLE
gh-618 Show mark as deleted data models to admins

### DIFF
--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -30,6 +30,7 @@ import { MessageService, SecurityHandlerService, FavouriteHandlerService, StateH
 import { ModelTreeService } from '@mdm/services/model-tree.service';
 import { catchError, takeUntil } from 'rxjs/operators';
 import { CatalogueItemDomainType, isContainerDomainType, isModelDomainType, MdmTreeItem } from '@maurodatamapper/mdm-resources';
+import { UserSettingsHandlerService } from '../services/utility/user-settings-handler.service';
 
 /**
  * Event arguments for confirming a click of a node in the FoldersTreeComponent.
@@ -140,7 +141,9 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
     private broadcast: BroadcastService,
     public dialog: MatDialog,
     private modelTree: ModelTreeService,
-    private shared: SharedService) {
+    private shared: SharedService,
+    private userSettingsHandler: UserSettingsHandlerService) {
+
     this.loadFavourites();
     this.subscriptions.add(this.messages.on('favourites', () => {
       this.loadFavourites();
@@ -285,11 +288,20 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
   }
 
   async expand(node: MdmTreeItem) {
+  let options: any = {};
+    if (this.shared.isLoggedIn()) {
+      options = {
+          queryStringParams: {
+          includeDeleted: this.userSettingsHandler.get('includeDeleted') || false
+        }
+      };
+    }
+
     try {
       switch (node.domainType) {
         case CatalogueItemDomainType.Folder:
         case CatalogueItemDomainType.VersionedFolder: { // VersionedFolders are treated the same as Folders
-          const folderResponse = await this.resources.tree.getFolder(node.id).toPromise();
+          const folderResponse = await this.resources.tree.getFolder(node.id, options.queryStringParams).toPromise();
           return folderResponse.body;
         }
         case CatalogueItemDomainType.DataModel: {


### PR DESCRIPTION
When an admin user selects the Show Deleted Models filter option, the data models that are marked as deleted should show in the browse tree with a strikethrough font.