### PR TITLE
gh-588 Update Favourites view to be a tree view

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -38,7 +38,7 @@ import { ModalModule } from './modals/modal.module';
 import { AdminModule } from './modules/admin/admin.module';
 import { CatalogueModule } from './modules/catalogue/catalogue.module';
 import { MdmResourcesModule } from './modules/resources/mdm-resources.module';
-import { SharedModule } from './modules/shared/shared.module';
+import { SharedModule } from './shared/shared.module';
 import { UsersModule } from './modules/users/users.module';
 import { SharedService } from './services/shared.service';
 import { UiViewComponent } from './shared/ui-view/ui-view.component';

--- a/src/app/bulk-edit/bulk-edit.module.ts
+++ b/src/app/bulk-edit/bulk-edit.module.ts
@@ -25,7 +25,7 @@ import { MaterialModule } from '@mdm/modules/material/material.module';
 import { FormsModule } from '@angular/forms';
 import { CheckboxCellRendererComponent } from './bulk-edit-editor/cell-renderers/checkbox-cell-renderer/checkbox-cell-renderer.component';
 import { DateCellEditorComponent } from './bulk-edit-editor/cell-editors/date-cell-editor/date-cell-editor.component';
-import { SharedModule } from '@mdm/modules/shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 import { BulkEditSelectComponent } from './bulk-edit-select/bulk-edit-select.component';
 import { BulkEditEditorGroupComponent } from './bulk-edit-editor-group/bulk-edit-editor-group.component';
 import { TextAreaCellEditorComponent } from './bulk-edit-editor/cell-editors/text-area-cell-editor/text-area-cell-editor.component';

--- a/src/app/catalogue-search/catalogue-search.module.ts
+++ b/src/app/catalogue-search/catalogue-search.module.ts
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SharedModule } from '@mdm/modules/shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 import { MaterialModule } from '@mdm/modules/material/material.module';
 import { CatalogueSearchComponent } from './catalogue-search/catalogue-search.component';
 import { CatalogueSearchFormComponent } from './catalogue-search-form/catalogue-search-form.component';

--- a/src/app/folders-tree/flat-node.ts
+++ b/src/app/folders-tree/flat-node.ts
@@ -18,7 +18,10 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { FlatTreeControl } from '@angular/cdk/tree';
-import { CatalogueItemDomainType, MdmTreeItem } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  MdmTreeItem
+} from '@maurodatamapper/mdm-resources';
 import { Access } from '@mdm/model/access';
 
 /** Wrapper for source node to support Material Flat Tree */
@@ -28,7 +31,8 @@ export class FlatNode {
   constructor(
     public node: MdmTreeItem,
     public level: number,
-    public readonly access: Access) { }
+    public readonly access: Access
+  ) {}
 
   /**
    * Getter and Setter passthrough to source node.
@@ -118,12 +122,31 @@ export class FlatNode {
   }
 }
 
-type FlatNodeIconCallback = (fnode: FlatNode, treeControl: FlatTreeControl<FlatNode>) => string;
+export interface FlatNodeType {
+  [key: string]: any;
+}
+
+type FlatNodeIconCallback = (
+  fnode: FlatNodeType,
+  treeControl: FlatTreeControl<FlatNodeType>
+) => string;
 
 const domainTypeIcons = new Map<CatalogueItemDomainType, FlatNodeIconCallback>([
-  [CatalogueItemDomainType.Folder, (fnode, treeControl) => treeControl?.isExpanded(fnode) ? 'fa-folder-open' : 'fa-folder'],
-  [CatalogueItemDomainType.VersionedFolder, (fnode, treeControl) => treeControl?.isExpanded(fnode) ? 'fa-box-open' : 'fa-box'],
-  [CatalogueItemDomainType.DataModel, (fnode, _) => fnode?.type === 'Data Standard' ? 'fa-file-alt' : 'fa-database'],
+  [
+    CatalogueItemDomainType.Folder,
+    (fnode, treeControl) =>
+      treeControl?.isExpanded(fnode) ? 'fa-folder-open' : 'fa-folder'
+  ],
+  [
+    CatalogueItemDomainType.VersionedFolder,
+    (fnode, treeControl) =>
+      treeControl?.isExpanded(fnode) ? 'fa-box-open' : 'fa-box'
+  ],
+  [
+    CatalogueItemDomainType.DataModel,
+    (fnode, _) =>
+      fnode?.type === 'Data Standard' ? 'fa-file-alt' : 'fa-database'
+  ],
   [CatalogueItemDomainType.Terminology, () => 'fa-book'],
   [CatalogueItemDomainType.CodeSet, () => 'fa-list'],
   [CatalogueItemDomainType.Classifier, () => 'fa-tags'],
@@ -137,7 +160,11 @@ const domainTypeIcons = new Map<CatalogueItemDomainType, FlatNodeIconCallback>([
   [CatalogueItemDomainType.DataElement, () => 'fa-atom']
 ]);
 
-export const getCatalogueItemDomainTypeIcon = (domain: CatalogueItemDomainType, fnode?: FlatNode, treeControl?: FlatTreeControl<FlatNode>) => {
+export const getCatalogueItemDomainTypeIcon = (
+  domain: CatalogueItemDomainType,
+  fnode?: FlatNodeType,
+  treeControl?: FlatTreeControl<FlatNodeType>
+) => {
   if (!domainTypeIcons.has(domain)) {
     return null;
   }

--- a/src/app/mauro/mauro-item.types.ts
+++ b/src/app/mauro/mauro-item.types.ts
@@ -25,6 +25,13 @@ import {
   Uuid
 } from '@maurodatamapper/mdm-resources';
 
+export interface MauroIdentifierFetchOptions {
+  /**
+   * If true, will not throw a global error if unable to fetch this item.
+   */
+  failSilently?: boolean;
+}
+
 /**
  * Represents a generic identifier to locate any Mauro catalogue item.
  */
@@ -43,6 +50,8 @@ export interface MauroIdentifier extends Required<CatalogueItem> {
    * If locating a Data Element, provide the unique identifier of the parent Data Class.
    */
   dataClass?: Uuid;
+
+  fetchOptions?: MauroIdentifierFetchOptions;
 }
 
 /**

--- a/src/app/merge-diff/merge-diff.module.ts
+++ b/src/app/merge-diff/merge-diff.module.ts
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { SharedModule } from '@mdm/modules/shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 import { MaterialModule } from '@mdm/modules/material/material.module';
 import { MergeDiffContainerComponent } from '@mdm/merge-diff/merge-diff-container/merge-diff-container.component';
 import { MergeItemSelectorComponent } from './merge-item-selector/merge-item-selector.component';
@@ -40,14 +40,7 @@ import { NumberConflictEditorComponent } from './conflict-editor/number-conflict
     StringConflictEditorComponent,
     NumberConflictEditorComponent
   ],
-  imports: [
-    CommonModule,
-    SharedModule,
-    MaterialModule,
-    CatalogueModule
-  ],
-  exports: [
-    MergeDiffContainerComponent
-  ]
+  imports: [CommonModule, SharedModule, MaterialModule, CatalogueModule],
+  exports: [MergeDiffContainerComponent]
 })
-export class MergeDiffModule { }
+export class MergeDiffModule {}

--- a/src/app/modals/modal.module.ts
+++ b/src/app/modals/modal.module.ts
@@ -36,7 +36,7 @@ import { MaterialModule } from '@mdm/modules/material/material.module';
 import { FinaliseModalComponent } from './finalise-modal/finalise-modal.component';
 import { CheckInModalComponent } from './check-in-modal/check-in-modal.component';
 import { ResolveMergeConflictModalComponent } from './resolve-merge-conflict-modal/resolve-merge-conflict-modal.component';
-import { SharedModule } from '@mdm/modules/shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 import { AddRuleRepresentationModalComponent } from './add-rule-representation-modal/add-rule-representation-modal.component';
 import { AddRuleModalComponent } from './add-rule-modal/add-rule-modal.component';
 import { ApiKeysModalComponent } from './api-keys-modal/api-keys-modal.component';

--- a/src/app/modules/admin/admin.module.ts
+++ b/src/app/modules/admin/admin.module.ts
@@ -20,7 +20,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AdminAppContainerComponent } from '@mdm/admin/app-container/app-container.component';
 import { AdminRoutesModule } from '../admin-routes/admin-routes.module';
-import { SharedModule } from '../shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 import { EmailsComponent } from '@mdm/admin/emails/emails.component';
 import { GroupMemberTableComponent } from '@mdm/admin/group-member-table/group-member-table.component';
 import { UserComponent } from '@mdm/admin/user/user.component';

--- a/src/app/modules/catalogue/catalogue.module.ts
+++ b/src/app/modules/catalogue/catalogue.module.ts
@@ -24,7 +24,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FoldersTreeModule } from '@mdm/folders-tree/folders-tree.module';
 import { AdminModule } from '../admin/admin.module';
-import { SharedModule } from '../shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 import { UsersModule } from '../users/users.module';
 import { FolderComponent } from '@mdm/folder/folder.component';
 import { FolderDetailComponent } from '@mdm/folder/folder-detail.component';

--- a/src/app/modules/users/users.module.ts
+++ b/src/app/modules/users/users.module.ts
@@ -23,7 +23,7 @@ import { ProfileComponent } from '@mdm/userArea/profile/profile.component';
 import { ImgCroppieComponent } from '@mdm/shared/img-croppie/img-croppie.component';
 import { UserDetailsComponent } from '@mdm/userArea/user-details/user-details.component';
 import { ImageCropperModule } from 'ngx-image-cropper';
-import { SharedModule } from '../shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 import { UsersRoutesModule } from '../users-routes/users-routes.module';
 import { ChangePasswordComponent } from '@mdm/userArea/change-password/change-password.component';
 import { ApiKeysComponent } from '@mdm/userArea/api-keys/api-keys.component';

--- a/src/app/services/handlers/favourite-handler.service.ts
+++ b/src/app/services/handlers/favourite-handler.service.ts
@@ -22,22 +22,22 @@ import { MessageHandlerService } from '../utility/message-handler.service';
 import { BroadcastService } from '../broadcast.service';
 import { CatalogueItem } from '@maurodatamapper/mdm-resources';
 
+export type Favourite = Required<CatalogueItem>;
 
 @Injectable({
   providedIn: 'root'
 })
 export class FavouriteHandlerService {
-
   constructor(
     private userSettingsHandler: UserSettingsHandlerService,
     private messageHandler: MessageHandlerService,
-    private broadcast: BroadcastService) {
-  }
+    private broadcast: BroadcastService
+  ) {}
 
   add(element: CatalogueItem) {
-    const favorites = this.userSettingsHandler.get('favourites');
+    const favorites = this.get();
     let fvt = false;
-    favorites.forEach(favorite => {
+    favorites.forEach((favorite) => {
       if (favorite.id === element.id) {
         fvt = true;
         return;
@@ -48,23 +48,31 @@ export class FavouriteHandlerService {
     }
 
     this.userSettingsHandler.update('favourites', favorites);
-    this.userSettingsHandler.saveOnServer().subscribe(() => {
-      this.messageHandler.showSuccess(`${element.domainType} added to Favorites successfully.`);
-      this.broadcast.favouritesChanged({ name: 'add', element });
-    }, error => {
-      this.messageHandler.showError('There was a problem updating the Favorites.', error);
-    });
+    this.userSettingsHandler.saveOnServer().subscribe(
+      () => {
+        this.messageHandler.showSuccess(
+          `${element.domainType} added to Favorites successfully.`
+        );
+        this.broadcast.favouritesChanged({ name: 'add', element });
+      },
+      (error) => {
+        this.messageHandler.showError(
+          'There was a problem updating the Favorites.',
+          error
+        );
+      }
+    );
     return favorites;
   }
 
-  get() {
-    return this.userSettingsHandler.get('favourites');
+  get(): Favourite[] {
+    return this.userSettingsHandler.get<Favourite[]>('favourites');
   }
 
   isAdded(element: CatalogueItem) {
-    const favorites = this.userSettingsHandler.get('favourites');
+    const favorites = this.get();
     let fvt = false;
-    favorites.forEach(favorite => {
+    favorites.forEach((favorite) => {
       if (favorite.id === element.id) {
         fvt = true;
         return;
@@ -74,29 +82,33 @@ export class FavouriteHandlerService {
   }
 
   remove(element: CatalogueItem) {
-    const favorites = this.userSettingsHandler.get('favourites');
-    const index = favorites.findIndex(favorite =>
-      favorite.id === element.id
-    );
+    const favorites = this.get();
+    const index = favorites.findIndex((favorite) => favorite.id === element.id);
     if (index === -1) {
       return;
     }
 
     favorites.splice(index, 1);
     this.userSettingsHandler.update('favourites', favorites);
-    this.userSettingsHandler.saveOnServer().subscribe(() => {
-      this.messageHandler.showSuccess('Removed from Favorites successfully.');
-      this.broadcast.favouritesChanged({ name: 'remove', element });
-    }, (error) => {
-      this.messageHandler.showError('There was a problem updating the Favorites.', error);
-    });
+    this.userSettingsHandler.saveOnServer().subscribe(
+      () => {
+        this.messageHandler.showSuccess('Removed from Favorites successfully.');
+        this.broadcast.favouritesChanged({ name: 'remove', element });
+      },
+      (error) => {
+        this.messageHandler.showError(
+          'There was a problem updating the Favorites.',
+          error
+        );
+      }
+    );
   }
 
   toggle(element: CatalogueItem) {
-    const favorites = this.userSettingsHandler.get('favourites');
+    const favorites = this.get();
     let processFinish = false;
     let fvt = false;
-    favorites.forEach(favorite => {
+    favorites.forEach((favorite) => {
       if (favorite.id === element.id) {
         fvt = true;
         return;

--- a/src/app/shared/favourites/favourites.component.ts
+++ b/src/app/shared/favourites/favourites.component.ts
@@ -21,17 +21,22 @@ import {
   OnInit,
   Output,
   EventEmitter,
-  ViewChild,
   OnDestroy
 } from '@angular/core';
-import { FavouriteHandlerService } from '@mdm/services/handlers/favourite-handler.service';
-import { ElementTypesService } from '@mdm/services/element-types.service';
-import { MdmResourcesService } from '@mdm/modules/resources';
-import { forkJoin, of, Subject } from 'rxjs';
-import { MatMenuTrigger } from '@angular/material/menu';
-import { catchError, map, takeUntil } from 'rxjs/operators';
+import {
+  Favourite,
+  FavouriteHandlerService
+} from '@mdm/services/handlers/favourite-handler.service';
+import { Subject } from 'rxjs';
+import { finalize, map, takeUntil } from 'rxjs/operators';
 import { BroadcastService } from '@mdm/services';
-import { CatalogueItem } from '@maurodatamapper/mdm-resources';
+import { MauroItemProviderService } from '@mdm/mauro/mauro-item-provider.service';
+import { MauroIdentifier, MauroItem } from '@mdm/mauro/mauro-item.types';
+import {
+  FLAT_TREE_LEVEL_START,
+  isDomainExpandable,
+  MauroItemTreeFlatNode
+} from '../mauro-item-tree/mauro-item-tree.types';
 
 @Component({
   selector: 'mdm-favourites',
@@ -39,28 +44,16 @@ import { CatalogueItem } from '@maurodatamapper/mdm-resources';
   styleUrls: ['./favourites.component.sass']
 })
 export class FavouritesComponent implements OnInit, OnDestroy {
-  @Output() favouriteClick = new EventEmitter<any>();
-  @Output() favouriteDbClick = new EventEmitter<any>();
-  @ViewChild(MatMenuTrigger, { static: false }) contextMenu: MatMenuTrigger;
+  @Output() selectionChange = new EventEmitter<MauroItemTreeFlatNode>();
 
   reloading = false;
-  allFavourites: Array<Favorite>;
-  storedFavourites :  Array<Favorite>;
-  selectedFavourite:  any;
-  menuOptions = [];
+  treeNodes: MauroItemTreeFlatNode[] = [];
+  favourites: Favourite[] = [];
 
-  favourites = [];
-  formData = {
-    filterCriteria: ''
-  };
-
-  contextMenuPosition = { x: '0px', y: '0px' };
-
-  private $unsubscribe = new Subject();
+  private unsubscribe$ = new Subject<void>();
 
   constructor(
-    private resources: MdmResourcesService,
-    private elementTypes: ElementTypesService,
+    private itemProvider: MauroItemProviderService,
     private favouriteHandler: FavouriteHandlerService,
     private broadcast: BroadcastService
   ) {}
@@ -70,138 +63,60 @@ export class FavouritesComponent implements OnInit, OnDestroy {
 
     this.broadcast
       .onFavouritesChanged()
-      .pipe(takeUntil(this.$unsubscribe))
+      .pipe(takeUntil(this.unsubscribe$))
       .subscribe(() => this.loadFavourites());
   }
 
   ngOnDestroy(): void {
-    this.$unsubscribe.next();
-    this.$unsubscribe.complete();
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 
   loadFavourites = () => {
     this.reloading = true;
-    const queries = [];
-    this.allFavourites = [];
     this.favourites = [];
-    this.storedFavourites = this.favouriteHandler.get();
 
-    const domainTypes = this.elementTypes.getBaseTypes();
-
-    this.storedFavourites.forEach((favourite) => {
-      const resourceName = domainTypes[favourite.domainType].resourceName;
-      // make sure we have a resource name for it
-      if (!this.resources[resourceName]) {
-        return;
-      }
-
-      queries.push(
-        this.resources[resourceName]
-          .get(favourite.id, {}, { handleGetErrors: false })
-          .pipe(
-            map((res) => res),
-            catchError(() => of('Not Found'))
-          )
-      );
-    });
-
-    if (queries.length === 0) {
-      this.reloading = false;
-    }
-
-    forkJoin(queries).subscribe((results) => {
-      let index = 0;
-      results.forEach((res: any) => {
-        if (res !== 'Not Found') {
-          const result = res.body;
-          this.allFavourites[index] = result;
-          index++;
-        }
+    const identifiers: MauroIdentifier[] = this.favouriteHandler
+      .get()
+      .map((favourite) => {
+        return {
+          ...favourite,
+          fetchOptions: {
+            failSilently: true
+          }
+        };
       });
-      this.reloading = false;
-      this.favourites = this.filter(
-        Object.assign([], this.allFavourites),
-        this.formData.filterCriteria
-      );
-    });
+
+    this.itemProvider
+      .getMany(identifiers)
+      .pipe(
+        map((items) => this.cleanUnusedFavourites(items)),
+        map((items) => items.sort((a, b) => a.label.localeCompare(b.label))),
+        finalize(() => (this.reloading = false))
+      )
+      .subscribe((items) => {
+        this.favourites = items;
+        this.treeNodes = items.map((item) => {
+          return {
+            ...item,
+            level: FLAT_TREE_LEVEL_START,
+            expandable: isDomainExpandable(item.domainType)
+          };
+        });
+      });
   };
 
-  filter = (allFavourites, text) => {
-    let i = allFavourites.length - 1;
-    while (i >= 0) {
-      if (
-        allFavourites[i].label
-          .trim()
-          .toLowerCase()
-          .indexOf(text.trim().toLowerCase()) === -1
-      ) {
-        allFavourites.splice(i, 1);
-      }
-      i--;
-    }
-    return allFavourites;
-  };
-
-  nodeClick = ($event, favourite) => {
-    this.click($event, favourite);
-  };
-
-  nodeDbClick = ($event, favourite) => {
-    this.click($event, favourite);
-  };
-
-  click = ($event, favourite) => {
-    favourite.selected = !favourite.selected;
-
-    if (this.selectedFavourite) {
-      this.selectedFavourite.selected = false;
-    }
-    this.selectedFavourite = favourite;
-
-    if (this.favouriteDbClick) {
-      this.favouriteDbClick.emit(favourite);
-    }
-  };
-
-  dataModelContextMenu(favourite : CatalogueItem) {
-    const subMenu = [
-      {
-        name: 'Remove from Favourites',
-        action: () => {
-          this.favouriteHandler.remove(favourite);
-        }
-      }
-    ];
-    return subMenu;
+  selected(node: MauroItemTreeFlatNode) {
+    this.selectionChange.emit(node);
   }
 
-  rightClick = (event, favourite) => {
-    if (favourite.domainType === 'DataModel') {
-      this.menuOptions = this.dataModelContextMenu(favourite);
-    }
-    event.preventDefault();
-    this.contextMenuPosition.x = `${event.clientX}px`;
-    this.contextMenuPosition.y = `${event.clientY}px`;
-    this.contextMenu.menuData = { favourite };
-    this.contextMenu.menu.focusFirstItem('mouse');
+  private cleanUnusedFavourites(items: MauroItem[]) {
+    // Identify catalogue items that were favourites but have been removed from the catalogue
+    // Then clear them from the user favourites to not be issues anymore
+    items
+      .filter((item) => item.error)
+      .forEach((item) => this.favouriteHandler.remove(item));
 
-    this.contextMenu.openMenu();
-  };
-
-  onSearchInputKeyDown() {
-    this.search();
-  };
-
-  search = () => {
-    this.favourites = this.filter(
-      Object.assign([], this.allFavourites),
-      this.formData.filterCriteria
-    );
-  };
-}
-
-export interface Favorite
-{
-  id:string;
-  domainType:string;
+    return items.filter((item) => !item.error);
+  }
 }

--- a/src/app/shared/mauro-item-tree/mauro-item-tree.component.html
+++ b/src/app/shared/mauro-item-tree/mauro-item-tree.component.html
@@ -1,0 +1,83 @@
+<!--
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+  <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
+    <button mat-icon-button disabled></button>
+    <!-- Use #nodeTemplate ng-template and pass in node as default context. -->
+    <ng-container
+      *ngTemplateOutlet="nodeTemplate; context: { $implicit: node }"
+    ></ng-container>
+  </mat-tree-node>
+  <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
+    <button
+      mat-icon-button
+      [attr.aria-label]="'Toggle ' + node.label"
+      matTreeNodeToggle
+    >
+      <mat-icon
+        class="mat-icon-rtl-mirror"
+        fontSet="fas"
+        fontIcon="{{ treeControl.isExpanded(node) ? 'fa-minus' : 'fa-plus' }}"
+      >
+      </mat-icon>
+    </button>
+    <!-- Use #nodeTemplate ng-template and pass in node as default context. -->
+    <ng-container
+      *ngTemplateOutlet="nodeTemplate; context: { $implicit: node }"
+    ></ng-container>
+  </mat-tree-node>
+</mat-tree>
+
+<ng-template #nodeTemplate let-node>
+  <div
+    class="mat-tree-node-content"
+    [ngClass]="{
+      'mat-tree-node-active': node === selected,
+      'mat-tree-node-inactive': node !== selected
+    }"
+  >
+    <mat-icon
+      *ngIf="hasIcon(node)"
+      fontSet="fas"
+      [fontIcon]="getIcon(node)"
+      [attr.aria-label]="node.type + ' icon'"
+    ></mat-icon>
+    <span
+      [title]="node.label"
+      (click)="nodeClicked(node)"
+      [ngClass]="{
+        'mat-tree-node-active': node === selected,
+        'node-title': node !== selected
+      }"
+    >
+      {{ node.label }}
+    </span>
+    <small *ngIf="!node.finalised && node.branchName" class="ml-1 text-muted">
+      <span> | </span>
+      <span class="fas fa-code-branch"></span>
+      {{ node.branchName }}
+    </small>
+    <small *ngIf="node.finalised && node.modelVersion" class="ml-1 text-muted">
+      <span> | </span>
+      <span class="fas fa-file-alt"></span>
+      <span *ngIf="node.modelVersion">{{ node.modelVersion }}</span>
+      <span *ngIf="node.version">{{ node.version }}</span>
+    </small>
+  </div>
+</ng-template>

--- a/src/app/shared/mauro-item-tree/mauro-item-tree.component.scss
+++ b/src/app/shared/mauro-item-tree/mauro-item-tree.component.scss
@@ -1,4 +1,4 @@
-<!--
+/*
 Copyright 2020-2022 University of Oxford
 and Health and Social Care Information Centre, also known as NHS Digital
 
@@ -15,25 +15,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
--->
-<div style="margin-top: 2px">
-  <mdm-mauro-item-tree
-    [nodes]="treeNodes"
-    (selectionChange)="selected($event)"
-  ></mdm-mauro-item-tree>
-  <div class="loading-spinner" *ngIf="reloading">
-    <div>
-      <span class="fas fa-sync-alt fa-spin"></span>
-    </div>
-  </div>
-  <div
-    *ngIf="favourites && favourites.length === 0 && !reloading"
-    class="noFavourites"
-  >
-    <div class="title">You currently have no favourite items.</div>
-    <div class="content">
-      To add a favourite, click on the star beside its name in the details
-      panel, or right-click on the item in Models tree view.
-    </div>
-  </div>
-</div>
+*/

--- a/src/app/shared/mauro-item-tree/mauro-item-tree.component.spec.ts
+++ b/src/app/shared/mauro-item-tree/mauro-item-tree.component.spec.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { ModelTreeService } from '@mdm/services/model-tree.service';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent
+} from '@mdm/testing/testing.helpers';
+import { MauroItemTreeComponent } from './mauro-item-tree.component';
+
+describe('MauroItemTreeComponent', () => {
+  let harness: ComponentHarness<MauroItemTreeComponent>;
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(MauroItemTreeComponent, {
+      providers: [
+        {
+          provide: MdmResourcesService,
+          useValue: jest.fn()
+        },
+        {
+          provide: ModelTreeService,
+          useValue: jest.fn()
+        }
+      ]
+    });
+  });
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+  });
+});

--- a/src/app/shared/mauro-item-tree/mauro-item-tree.component.ts
+++ b/src/app/shared/mauro-item-tree/mauro-item-tree.component.ts
@@ -1,0 +1,100 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { FlatTreeControl } from '@angular/cdk/tree';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges
+} from '@angular/core';
+import { getCatalogueItemDomainTypeIcon } from '@mdm/folders-tree/flat-node';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { ModelTreeService } from '@mdm/services/model-tree.service';
+import {
+  MauroItemTreeFlatNode,
+  MauroTreeViewDataSource
+} from './mauro-item-tree.types';
+
+@Component({
+  selector: 'mdm-mauro-item-tree',
+  templateUrl: './mauro-item-tree.component.html',
+  styleUrls: ['./mauro-item-tree.component.scss']
+})
+export class MauroItemTreeComponent implements OnChanges {
+  /**
+   * The collection of root level nodes to display.
+   */
+  @Input() nodes: MauroItemTreeFlatNode[] = [];
+
+  /**
+   * Event emitted when the selected node has changed.
+   */
+  @Output() selectionChange = new EventEmitter<MauroItemTreeFlatNode>();
+
+  treeControl: FlatTreeControl<MauroItemTreeFlatNode>;
+  dataSource: MauroTreeViewDataSource;
+  selected?: MauroItemTreeFlatNode;
+
+  constructor(
+    private resources: MdmResourcesService,
+    private modelTree: ModelTreeService
+  ) {
+    this.treeControl = new FlatTreeControl<MauroItemTreeFlatNode>(
+      this.getLevel,
+      this.isExpandable
+    );
+
+    this.dataSource = new MauroTreeViewDataSource(
+      this.treeControl,
+      this.resources,
+      this.modelTree
+    );
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.nodes) {
+      this.dataSource.data = this.nodes;
+    }
+  }
+
+  getLevel = (node: MauroItemTreeFlatNode) => node.level;
+
+  isExpandable = (node: MauroItemTreeFlatNode) => node.expandable;
+
+  hasChild = (_: number, node: MauroItemTreeFlatNode) => node.expandable;
+
+  getIcon(node: MauroItemTreeFlatNode) {
+    return getCatalogueItemDomainTypeIcon(
+      node.domainType,
+      node,
+      this.treeControl
+    );
+  }
+
+  hasIcon(node: MauroItemTreeFlatNode) {
+    return this.getIcon(node) !== null;
+  }
+
+  nodeClicked(node: MauroItemTreeFlatNode) {
+    this.selected = node;
+    this.selectionChange.emit(node);
+  }
+}

--- a/src/app/shared/mauro-item-tree/mauro-item-tree.types.ts
+++ b/src/app/shared/mauro-item-tree/mauro-item-tree.types.ts
@@ -1,0 +1,204 @@
+/*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import {
+  CollectionViewer,
+  DataSource,
+  SelectionChange
+} from '@angular/cdk/collections';
+import { FlatTreeControl } from '@angular/cdk/tree';
+import {
+  CatalogueItemDomainType,
+  MdmTreeItemListResponse,
+  Uuid
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { ModelTreeService } from '@mdm/services/model-tree.service';
+import { BehaviorSubject, merge, Observable, of, Subject } from 'rxjs';
+import { finalize, map, takeUntil } from 'rxjs/operators';
+
+export const FLAT_TREE_LEVEL_START = 0;
+
+export const isDomainExpandable = (domain: CatalogueItemDomainType) => {
+  return (
+    domain === CatalogueItemDomainType.Folder ||
+    domain === CatalogueItemDomainType.VersionedFolder ||
+    domain === CatalogueItemDomainType.DataModel ||
+    domain === CatalogueItemDomainType.DataClass ||
+    domain === CatalogueItemDomainType.Terminology ||
+    domain === CatalogueItemDomainType.Term
+  );
+};
+
+export interface MauroItemTreeFlatNode {
+  id: Uuid;
+  domainType: CatalogueItemDomainType;
+  label: string;
+  level: number;
+  expandable: boolean;
+  isLoading?: boolean;
+  modelId?: Uuid;
+  parentId?: Uuid;
+  finalised?: boolean;
+  branchName?: string;
+  modelVersion?: string;
+}
+
+export class MauroTreeViewDataSource extends DataSource<MauroItemTreeFlatNode> {
+  dataChange = new BehaviorSubject<MauroItemTreeFlatNode[]>([]);
+
+  private unsubscribe$ = new Subject<void>();
+
+  get data(): MauroItemTreeFlatNode[] {
+    return this.dataChange.value;
+  }
+  set data(value: MauroItemTreeFlatNode[]) {
+    this.treeControl.dataNodes = value;
+    this.dataChange.next(value);
+  }
+
+  constructor(
+    private treeControl: FlatTreeControl<MauroItemTreeFlatNode>,
+    private resources: MdmResourcesService,
+    private modelTree: ModelTreeService
+  ) {
+    super();
+  }
+
+  connect(
+    collectionViewer: CollectionViewer
+  ): Observable<readonly MauroItemTreeFlatNode[]> {
+    this.treeControl.expansionModel.changed
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((change) => {
+        // "added" collection means a node is about to be expanded
+        // "removed" collection means a node is about to be collapsed
+        if (change.added || change.removed) {
+          this.handleExpandCollapse(change);
+        }
+      });
+
+    return merge(collectionViewer.viewChange, this.dataChange).pipe(
+      map(() => this.data)
+    );
+  }
+
+  disconnect(_: CollectionViewer): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  handleExpandCollapse(change: SelectionChange<MauroItemTreeFlatNode>) {
+    if (change.added) {
+      change.added.forEach((node) => this.expandNode(node));
+    }
+
+    if (change.removed) {
+      change.removed
+        .slice()
+        .reverse()
+        .forEach((node) => this.collapseNode(node));
+    }
+  }
+
+  expandNode(node: MauroItemTreeFlatNode) {
+    const index = this.data.indexOf(node);
+    if (index < 0) {
+      return;
+    }
+
+    const request$ = this.requestTreeItems(node);
+
+    node.isLoading = true;
+
+    request$
+      .pipe(
+        map((response) =>
+          response.body.map<MauroItemTreeFlatNode>((treeItem) => {
+            return {
+              ...treeItem,
+              label: treeItem.label,
+              level: node.level + 1,
+              expandable: treeItem.hasChildren ?? false
+            };
+          })
+        ),
+        finalize(() => (node.isLoading = false))
+      )
+      .subscribe((children) => {
+        this.data.splice(index + 1, 0, ...children);
+
+        // Notify the change
+        this.dataChange.next(this.data);
+        node.isLoading = false;
+      });
+  }
+
+  collapseNode(node: MauroItemTreeFlatNode) {
+    const index = this.data.indexOf(node);
+    if (index < 0) {
+      return;
+    }
+
+    node.isLoading = true;
+
+    // Find start/end nodes to remove
+    let count = 0;
+    for (
+      let i = index + 1;
+      i < this.data.length && this.data[i].level > node.level;
+      i++, count++
+    ) {}
+
+    this.data.splice(index + 1, count);
+
+    // Notify the change
+    this.dataChange.next(this.data);
+    node.isLoading = false;
+  }
+
+  private requestTreeItems(
+    node: MauroItemTreeFlatNode
+  ): Observable<MdmTreeItemListResponse> {
+    switch (node.domainType) {
+      case CatalogueItemDomainType.Folder:
+      case CatalogueItemDomainType.VersionedFolder: {
+        // VersionedFolders are treated the same as Folders
+        return this.resources.tree.getFolder(node.id);
+      }
+      case CatalogueItemDomainType.DataModel:
+        return this.resources.tree.get('folders', 'dataModels', node.id);
+      case CatalogueItemDomainType.DataClass:
+        return this.resources.tree.get('folders', 'dataClasses', node.id);
+      case CatalogueItemDomainType.Terminology:
+        return this.resources.tree.get('folders', 'terminologies', node.id);
+      case CatalogueItemDomainType.Term:
+        return this.resources.tree.get('folders', 'terms', node.id);
+      case CatalogueItemDomainType.SubscribedCatalogue:
+        return this.modelTree.getFederatedDataModelNodes(node.id).pipe(
+          map((items) => {
+            return {
+              body: items
+            };
+          })
+        );
+      default:
+        return of({ body: [] });
+    }
+  }
+}

--- a/src/app/shared/models/models.component.html
+++ b/src/app/shared/models/models.component.html
@@ -17,220 +17,396 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="leftTab">
-    <div class="container-inner">
-        <mat-tab-group [selectedIndex]="activeTab" (selectedIndexChange)="tabSelected($event)">
-            <mat-tab>
-                <ng-template mat-tab-label>
-                    <span class="fas fa-sitemap"></span>&nbsp; Models
-                </ng-template>
-                <div style="margin-top: 2px;">
-                    <div style="position: relative;">
-                        <div style="float: left;" class="full-width">
-                            <div class="input-group">
-                                <label for="search-models-input" class="sr-only">Search models</label>
-                                <input #searchbox type="search" id="search-models-input" class="form-control outlined-input" [(ngModel)]="formData.filterCriteria" placeholder="Search models..." (keyup)="onSearchInputKeyDown($event)" (search)="onSearchInputKeyDown($event)">
-                                <span class="tree-top-actions">
-
-                                    <button type="button" mat-stroked-button [disabled]="levels.current === 1" matTooltipPosition="below" matTooltip="Search" (click)="search()" aria-label="Search">
-                                        <span class="fas fa-search"></span>
-                                    </button>
-                                    <button type="button" mat-stroked-button [matMenuTriggerFor]="filterMenu" *ngIf="isLoggedIn()" matTooltipPosition="below" matTooltip="Filters" [disabled]="levels.current === 1" (click)="toggleFilterMenu()" aria-label="Filter">
-                                        <span class="fas fa-filter" [ngClass]="{'':!showFilters, 'filterIcon':showFilters}"></span>
-                                    </button>
-                                    <mat-menu #filterMenu="matMenu" class="filterMenu">
-                                        <!-- <div mat-menu-item>
+  <div class="container-inner">
+    <mat-tab-group
+      [selectedIndex]="activeTab"
+      (selectedIndexChange)="tabSelected($event)"
+    >
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="fas fa-sitemap"></span>&nbsp; Models
+        </ng-template>
+        <div style="margin-top: 2px">
+          <div style="position: relative">
+            <div style="float: left" class="full-width">
+              <div class="input-group">
+                <label for="search-models-input" class="sr-only"
+                  >Search models</label
+                >
+                <input
+                  #searchbox
+                  type="search"
+                  id="search-models-input"
+                  class="form-control outlined-input"
+                  [(ngModel)]="formData.filterCriteria"
+                  placeholder="Search models..."
+                  (keyup)="onSearchInputKeyDown($event)"
+                  (search)="onSearchInputKeyDown($event)"
+                />
+                <span class="tree-top-actions">
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    [disabled]="levels.current === 1"
+                    matTooltipPosition="below"
+                    matTooltip="Search"
+                    (click)="search()"
+                    aria-label="Search"
+                  >
+                    <span class="fas fa-search"></span>
+                  </button>
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    [matMenuTriggerFor]="filterMenu"
+                    *ngIf="isLoggedIn()"
+                    matTooltipPosition="below"
+                    matTooltip="Filters"
+                    [disabled]="levels.current === 1"
+                    (click)="toggleFilterMenu()"
+                    aria-label="Filter"
+                  >
+                    <span
+                      class="fas fa-filter"
+                      [ngClass]="{ '': !showFilters, filterIcon: showFilters }"
+                    ></span>
+                  </button>
+                  <mat-menu #filterMenu="matMenu" class="filterMenu">
+                    <!-- <div mat-menu-item>
                                             <mat-checkbox name="includeModelSuperseded" (ngModelChange)="toggleFilters('includeModelSuperseded')" [(ngModel)]="includeModelSuperseded">
                                                 Show Superseded Models
                                             </mat-checkbox>
                                         </div> -->
-                                        <div *ngIf="isAdministrator" mat-menu-item>
-                                            <mat-checkbox name="includeDeleted" (ngModelChange)="toggleFilters('includeDeleted')" [(ngModel)]="includeDeleted">
-                                                Show Deleted Models
-                                            </mat-checkbox>
-                                        </div>
-                                    </mat-menu>
+                    <div *ngIf="isAdministrator" mat-menu-item>
+                      <mat-checkbox
+                        name="includeDeleted"
+                        (ngModelChange)="toggleFilters('includeDeleted')"
+                        [(ngModel)]="includeDeleted"
+                      >
+                        Show Deleted Models
+                      </mat-checkbox>
+                    </div>
+                  </mat-menu>
 
-                                    <button type="button" mat-stroked-button *ngIf="isLoggedIn()" matTooltip="Reload Data Models Tree" [disabled]="levels.current === 1" (click)="reloadTree()" aria-label="Reload data models tree">
-                                        <span class="fas fa-sync-alt"></span>
-                                    </button>
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    *ngIf="isLoggedIn()"
+                    matTooltip="Reload Data Models Tree"
+                    [disabled]="levels.current === 1"
+                    (click)="reloadTree()"
+                    aria-label="Reload data models tree"
+                  >
+                    <span class="fas fa-sync-alt"></span>
+                  </button>
 
-                                    <button type="button" mat-stroked-button *ngIf="isLoggedIn()" [matMenuTriggerFor]="exportMenu" matTooltip="Export Models" aria-label="Export Models">
-                                        <span class="fas fa-download"></span>
-                                    </button>
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    *ngIf="isLoggedIn()"
+                    [matMenuTriggerFor]="exportMenu"
+                    matTooltip="Export Models"
+                    aria-label="Export Models"
+                  >
+                    <span class="fas fa-download"></span>
+                  </button>
 
-                                    <mat-menu #exportMenu="matMenu" class="filterMenu">
-                                      <button mat-menu-item (click)="changeState('export','dataModels')">
-                                        <span class="fas fa-file-alt dataModelTypeIcon marginless"></span> Export Data Models
-                                      </button>
-                                      <button mat-menu-item (click)="changeState('export','terminologies')">
-                                        <span class="fas fa-book dataModelTypeIcon marginless"></span>  Export Terminologies
-                                      </button>
-                                      <!-- <button mat-menu-item (click)="changeState('export','codeSets')">
+                  <mat-menu #exportMenu="matMenu" class="filterMenu">
+                    <button
+                      mat-menu-item
+                      (click)="changeState('export', 'dataModels')"
+                    >
+                      <span
+                        class="fas fa-file-alt dataModelTypeIcon marginless"
+                      ></span>
+                      Export Data Models
+                    </button>
+                    <button
+                      mat-menu-item
+                      (click)="changeState('export', 'terminologies')"
+                    >
+                      <span
+                        class="fas fa-book dataModelTypeIcon marginless"
+                      ></span>
+                      Export Terminologies
+                    </button>
+                    <!-- <button mat-menu-item (click)="changeState('export','codeSets')">
                                         <span class="fas fa-list dataModelTypeIcon marginless"></span> Export Code Sets
                                       </button> -->
-                                      <!-- <button mat-menu-item (click)="changeState('export','referenceDataModels')">
+                    <!-- <button mat-menu-item (click)="changeState('export','referenceDataModels')">
                                         <span class="fas fa-file-contract dataModelTypeIcon marginless"></span> Export Reference Data
                                       </button> -->
-                                    </mat-menu>
+                  </mat-menu>
 
-                                    <button type="button" mat-stroked-button *ngIf="isLoggedIn()" [matMenuTriggerFor]="importMenu" matTooltip="Import Models" aria-label="Import Models">
-                                        <span class="fas fa-upload"></span>
-                                    </button>
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    *ngIf="isLoggedIn()"
+                    [matMenuTriggerFor]="importMenu"
+                    matTooltip="Import Models"
+                    aria-label="Import Models"
+                  >
+                    <span class="fas fa-upload"></span>
+                  </button>
 
-                                    <mat-menu #importMenu="matMenu" class="filterMenu">
-                                      <button mat-menu-item (click)="changeState('import','dataModels')">
-                                        <span class="fas fa-file-alt dataModelTypeIcon marginless"></span> Import Data Models
-                                      </button>
-                                      <button mat-menu-item (click)="changeState('import','terminologies')">
-                                        <span class="fas fa-book dataModelTypeIcon marginless"></span> Import Terminologies
-                                      </button>
-                                      <!-- <button mat-menu-item (click)="changeState('import','codeSets')">
+                  <mat-menu #importMenu="matMenu" class="filterMenu">
+                    <button
+                      mat-menu-item
+                      (click)="changeState('import', 'dataModels')"
+                    >
+                      <span
+                        class="fas fa-file-alt dataModelTypeIcon marginless"
+                      ></span>
+                      Import Data Models
+                    </button>
+                    <button
+                      mat-menu-item
+                      (click)="changeState('import', 'terminologies')"
+                    >
+                      <span
+                        class="fas fa-book dataModelTypeIcon marginless"
+                      ></span>
+                      Import Terminologies
+                    </button>
+                    <!-- <button mat-menu-item (click)="changeState('import','codeSets')">
                                         <span class="fas fa-list dataModelTypeIcon marginless"></span> Import Code Sets
                                       </button> -->
-                                      <button mat-menu-item (click)="changeState('import','referenceDataModels')">
-                                        <span class="fas fa-file-contract dataModelTypeIcon marginless"></span> Import Reference Data
-                                      </button>
-                                    </mat-menu>
+                    <button
+                      mat-menu-item
+                      (click)="changeState('import', 'referenceDataModels')"
+                    >
+                      <span
+                        class="fas fa-file-contract dataModelTypeIcon marginless"
+                      ></span>
+                      Import Reference Data
+                    </button>
+                  </mat-menu>
 
-                                    <button type="button" mat-stroked-button *ngIf="isLoggedIn() && ((isAdministrator && isRootFolderRestricted) || !isRootFolderRestricted)" matTooltip="Create a new Folder" [disabled]="levels.current === 1" (click)="onFolderAddModal()" aria-label="Create a new Folder">
-                                        <span class="fas fa-folder-plus"></span>
-                                    </button>
-                                </span>
-                            </div>
-                        </div>
-                    </div>
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    *ngIf="
+                      isLoggedIn() &&
+                      ((isAdministrator && isRootFolderRestricted) ||
+                        !isRootFolderRestricted)
+                    "
+                    matTooltip="Create a new Folder"
+                    [disabled]="levels.current === 1"
+                    (click)="onFolderAddModal()"
+                    aria-label="Create a new Folder"
+                  >
+                    <span class="fas fa-folder-plus"></span>
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style="
+            width: 100%;
+            clear: left;
+            height: calc(100vh - 168px);
+            overflow-y: auto;
+          "
+        >
+          <div
+            style="margin: 3px 0px 0px 0px"
+            *ngIf="
+              levels.currentFocusedElement &&
+              filteredModels.children &&
+              filteredModels.children.length != 0
+            "
+          >
+            <button
+              mat-button
+              color="primary"
+              type="button"
+              class="paddingless"
+              matTooltip="Previous level"
+              aria-label="Previous level"
+              [disabled]="levels.current === 0"
+              (click)="levels.backToTree()"
+            >
+              <span class="fas fa-arrow-left"></span>
+            </button>
+
+            <button
+              mat-button
+              color="primary"
+              type="button"
+              class="paddingless"
+              matTooltip="Next level"
+              aria-label="Next level"
+              [disabled]="
+                (levels.current === 0 && !levels.currentFocusedElement) ||
+                levels.current === 1
+              "
+              (click)="levels.focusTreeItem(null)"
+            >
+              <span class="fas fa-arrow-right"></span>
+            </button>
+          </div>
+
+          <div *ngIf="filteredModels && !reloading">
+            <mdm-folders-tree
+              [treeName]="'Models'"
+              [inSearchMode]="inSearchMode"
+              [rememberExpandedStates]="true"
+              [node]="filteredModels"
+              [searchCriteria]="searchText"
+              (loadModelsToCompareEvent)="loadModelsToCompare($event)"
+              [enableDragAndDrop]="true"
+              [enableContextMenu]="true"
+              (nodeDbClickEvent)="onNodeDbClick($event)"
+              (nodeConfirmClickEvent)="onNodeConfirmClick($event)"
+              (nodeAdded)="onNodeAdded()"
+            >
+            </mdm-folders-tree>
+          </div>
+          <div class="loading-spinner" *ngIf="reloading">
+            <div>
+              <span class="fas fa-sync-alt fa-spin"></span>
+            </div>
+          </div>
+
+          <div
+            *ngIf="
+              filteredModels &&
+              filteredModels.children &&
+              filteredModels.children.length == 0
+            "
+          >
+            <div *ngIf="!isLoggedIn()">
+              <div class="noDataModel">
+                <div class="title">
+                  There are no Data Models to display publicly.
                 </div>
-                <div style="width:100%; clear:left;height: calc(100vh - 168px);overflow-y: auto">
-
-                    <div style="margin:3px 0px 0px 0px" *ngIf="levels.currentFocusedElement && filteredModels.children && filteredModels.children.length!=0">
-                        <button mat-button
-                                color="primary"
-                                type="button"
-                                class="paddingless"
-                                matTooltip="Previous level"
-                                aria-label="Previous level"
-                                [disabled]="levels.current === 0"
-                                (click)="levels.backToTree()">
-                            <span class="fas fa-arrow-left"></span>
-                        </button>
-
-                        <button mat-button
-                                color="primary"
-                                type="button"
-                                class="paddingless"
-                                matTooltip="Next level"
-                                aria-label="Next level"
-                                [disabled]="(levels.current === 0 && !levels.currentFocusedElement) || levels.current === 1"
-                                (click)="levels.focusTreeItem(null)">
-                            <span class="fas fa-arrow-right"></span>
-                        </button>
-                    </div>
-
-
-
-                    <div *ngIf="filteredModels && !reloading">
-                        <mdm-folders-tree [treeName]="'Models'"
-                                        [inSearchMode]="inSearchMode"
-                                        [rememberExpandedStates]="true"
-                                        [node]="filteredModels"
-                                        [searchCriteria]="searchText"
-                                        (loadModelsToCompareEvent)="loadModelsToCompare($event)"
-                                        [enableDragAndDrop]="true"
-                                        [enableContextMenu]="true"
-                                        (nodeDbClickEvent)="onNodeDbClick($event)"
-                                        (nodeConfirmClickEvent)="onNodeConfirmClick($event)"
-                                        (nodeAdded)="onNodeAdded()">
-                            </mdm-folders-tree>
-                    </div>
-                    <div class="loading-spinner" *ngIf="reloading">
-                        <div>
-                            <span class="fas fa-sync-alt fa-spin"></span>
-                        </div>
-                    </div>
-
-                    <div *ngIf="filteredModels && filteredModels.children && filteredModels.children.length==0">
-                        <div *ngIf="!isLoggedIn()">
-                            <div class="noDataModel">
-                                <div class="title">
-                                    There are no Data Models to display publicly.
-                                </div>
-                                <div class="content">
-                                    * Please login or register to view Data Models.
-                                </div>
-                            </div>
-
-                        </div>
-                        <div *ngIf="isLoggedIn()">
-                            <div class="noDataModel">
-                                <div class="title">
-                                    There are no Data Models to display.
-                                </div>
-                                <div class="content">
-                                    Please ask Administrator (or Data Model owner) to grant you access.
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <div class="content">
+                  * Please login or register to view Data Models.
                 </div>
-
-            </mat-tab>
-            <mat-tab>
-                <ng-template mat-tab-label>
-                    <span class="fas fa-tags"></span>&nbsp; Classifications
-                </ng-template>
-                <div style="margin-top: 2px;">
-                    <div>
-                        <div style="float: left;" class="full-width">
-                            <div class="input-group">
-                                <input type="text" class="form-control outlined-input" [(ngModel)]="formData.ClassificationFilterCriteria" placeholder="Search classifications..." (ngModelChange)="filterClassifications()">
-                                <span class="tree-top-actions">
-                                    <button type="button" mat-stroked-button matTooltipPosition="below" matTooltip="Search"  (click)="filterClassifications()" aria-label="Search">
-                                        <span class="fas fa-search"></span>
-                                    </button>
-                                    <button type="button" mat-stroked-button *ngIf="isLoggedIn() && ((isAdministrator && isClassifierCreateRestricted) || !isClassifierCreateRestricted)" matTooltipPosition="below" matTooltip="Create a new Classification"  (click)="onAddClassifier()" aria-label="Create a new classification">
-                                        <span class="fas fa-folder-plus"></span>
-                                    </button>
-                                </span>
-                            </div>
-                        </div>
-                    </div>
+              </div>
+            </div>
+            <div *ngIf="isLoggedIn()">
+              <div class="noDataModel">
+                <div class="title">There are no Data Models to display.</div>
+                <div class="content">
+                  Please ask Administrator (or Data Model owner) to grant you
+                  access.
                 </div>
-                <div class="treeHolder" style="width:100%; clear:left;height: calc(80vh - 50px);overflow-y: auto">
-                    <mdm-folders-tree *ngIf="classifiers" [treeName]="'Classifiers'" [searchCriteria]="formData.ClassificationFilterCriteria" [rememberExpandedStates]="true" [node]="classifiers" (nodeClickEvent)="classifierTreeOnSelect($event)"></mdm-folders-tree>
-                    <div *ngIf="allClassifiers && allClassifiers.length==0">
-                        <div *ngIf="!isLoggedIn()">
-                            <div class="noClassification">
-                                <div class="title">
-                                    There are no Classifications to display publicly.
-                                </div>
-                                <div class="content">
-                                    * Please login or register to view Classifications.
-                                </div>
-                            </div>
-                        </div>
-                        <div *ngIf="isLoggedIn()">
-                            <div class="noClassification">
-                                <div class="title">
-                                    There are no Classifications to display.
-                                </div>
-                                <div class="content">
-                                    Please ask Administrator (or Classification owner) to grant you access.
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span class="fas fa-tags"></span>&nbsp; Classifications
+        </ng-template>
+        <div style="margin-top: 2px">
+          <div>
+            <div style="float: left" class="full-width">
+              <div class="input-group">
+                <input
+                  type="text"
+                  class="form-control outlined-input"
+                  [(ngModel)]="formData.ClassificationFilterCriteria"
+                  placeholder="Search classifications..."
+                  (ngModelChange)="filterClassifications()"
+                />
+                <span class="tree-top-actions">
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    matTooltipPosition="below"
+                    matTooltip="Search"
+                    (click)="filterClassifications()"
+                    aria-label="Search"
+                  >
+                    <span class="fas fa-search"></span>
+                  </button>
+                  <button
+                    type="button"
+                    mat-stroked-button
+                    *ngIf="
+                      isLoggedIn() &&
+                      ((isAdministrator && isClassifierCreateRestricted) ||
+                        !isClassifierCreateRestricted)
+                    "
+                    matTooltipPosition="below"
+                    matTooltip="Create a new Classification"
+                    (click)="onAddClassifier()"
+                    aria-label="Create a new classification"
+                  >
+                    <span class="fas fa-folder-plus"></span>
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="treeHolder"
+          style="
+            width: 100%;
+            clear: left;
+            height: calc(80vh - 50px);
+            overflow-y: auto;
+          "
+        >
+          <mdm-folders-tree
+            *ngIf="classifiers"
+            [treeName]="'Classifiers'"
+            [searchCriteria]="formData.ClassificationFilterCriteria"
+            [rememberExpandedStates]="true"
+            [node]="classifiers"
+            (nodeClickEvent)="classifierTreeOnSelect($event)"
+          ></mdm-folders-tree>
+          <div *ngIf="allClassifiers && allClassifiers.length == 0">
+            <div *ngIf="!isLoggedIn()">
+              <div class="noClassification">
+                <div class="title">
+                  There are no Classifications to display publicly.
                 </div>
-            </mat-tab>
-
-            <mat-tab *ngIf="isLoggedIn()">
-                <ng-template mat-tab-label>
-                    <span class="fas fa-star"></span> &nbsp; Favourites
-                </ng-template>
-                <div class="treeHolder" style="width: 100%; clear: left; height: calc(80vh - 0px); overflow-y: auto" *ngIf="currentTab === 'favourites'">
-                    <mdm-favourites (favouriteDbClick)="onFavouriteDbClick($event)" (favouriteClick)="onFavouriteClick($event)"></mdm-favourites>
+                <div class="content">
+                  * Please login or register to view Classifications.
                 </div>
-            </mat-tab>
+              </div>
+            </div>
+            <div *ngIf="isLoggedIn()">
+              <div class="noClassification">
+                <div class="title">
+                  There are no Classifications to display.
+                </div>
+                <div class="content">
+                  Please ask Administrator (or Classification owner) to grant
+                  you access.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </mat-tab>
 
-        </mat-tab-group>
-    </div>
+      <mat-tab *ngIf="isLoggedIn()">
+        <ng-template mat-tab-label>
+          <span class="fas fa-star"></span> &nbsp; Favourites
+        </ng-template>
+        <div
+          class="treeHolder"
+          style="
+            width: 100%;
+            clear: left;
+            height: calc(80vh - 0px);
+            overflow-y: auto;
+          "
+          *ngIf="currentTab === 'favourites'"
+        >
+          <mdm-favourites
+            (selectionChange)="favouriteSelected($event)"
+          ></mdm-favourites>
+        </div>
+      </mat-tab>
+    </mat-tab-group>
+  </div>
 </div>

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -29,7 +29,7 @@ import { InlineTextEditComponent } from '@mdm/shared/inline-text-edit/inline-tex
 import { FooterComponent } from '@mdm/shared/footer/footer.component';
 import { MetadataCompareComponent } from '@mdm/shared/metadata-compare/metadata-compare.component';
 import { EnumerationCompareComponent } from '@mdm/shared/enumeration-compare/enumeration-compare.component';
-import { MaterialModule } from '../material/material.module';
+import { MaterialModule } from '@mdm/modules/material/material.module';
 import { NgxJsonViewerModule } from 'ngx-json-viewer';
 import { ErrorComponent } from '@mdm/errors/error.component';
 import { FlexLayoutModule } from '@angular/flex-layout';
@@ -48,9 +48,9 @@ import { BranchSelectorComponent } from '@mdm/shared/branch-selector/branch-sele
 import { ResizableDirective } from '@mdm/directives/resizable.directive';
 import { DataTypeListButtonsComponent } from '@mdm/shared/data-type-list-buttons/data-type-list-buttons.component';
 import { ModelIconComponent } from '@mdm/shared/model-icon/model-icon.component';
-import { PathNameComponent } from '../../shared/path-name/path-name.component';
-import { FavoriteButtonComponent } from '../../shared/favorite-button/favorite-button.component';
-import { CatalogueItemPropertiesComponent } from '../../shared/catalogue-item-properties/catalogue-item-properties.component';
+import { PathNameComponent } from './path-name/path-name.component';
+import { FavoriteButtonComponent } from './favorite-button/favorite-button.component';
+import { CatalogueItemPropertiesComponent } from './catalogue-item-properties/catalogue-item-properties.component';
 import { ElementIconComponent } from '@mdm/shared/element-icon/element-icon.component';
 import { ContentEditorComponent } from '@mdm/utility/content-editor/content-editor.component';
 import { HtmlEditorComponent } from '@mdm/utility/html-editor/html-editor.component';
@@ -61,6 +61,7 @@ import { SortByComponent } from '@mdm/shared/sort-by/sort-by.component';
 import { BreadcrumbComponent } from '@mdm/shared/breadcrumb/breadcrumb.component';
 import { MarkedPipe } from '@mdm/pipes/marked.pipe';
 import { FileSizePipe } from '@mdm/directives/file-size.pipe';
+import { MauroItemTreeComponent } from './mauro-item-tree/mauro-item-tree.component';
 
 @NgModule({
   declarations: [
@@ -96,7 +97,8 @@ import { FileSizePipe } from '@mdm/directives/file-size.pipe';
     SortByComponent,
     BreadcrumbComponent,
     MarkedPipe,
-    FileSizePipe
+    FileSizePipe,
+    MauroItemTreeComponent
   ],
   imports: [
     CommonModule,
@@ -155,7 +157,8 @@ import { FileSizePipe } from '@mdm/directives/file-size.pipe';
     SortByComponent,
     BreadcrumbComponent,
     MarkedPipe,
-    FileSizePipe
+    FileSizePipe,
+    MauroItemTreeComponent
   ]
 })
 export class SharedModule {}

--- a/src/app/testing/testing.module.ts
+++ b/src/app/testing/testing.module.ts
@@ -26,7 +26,7 @@ import { MdmResourcesModule } from '@mdm/modules/resources/mdm-resources.module'
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
-import { SharedModule } from '@mdm/modules/shared/shared.module';
+import { SharedModule } from '@mdm/shared/shared.module';
 
 @NgModule({
   declarations: [],
@@ -38,7 +38,7 @@ import { SharedModule } from '@mdm/modules/shared/shared.module';
     ReactiveFormsModule,
     UIRouterModule.forRoot({ useHash: true }),
     ToastrModule.forRoot(),
-    MdmResourcesModule.forRoot({ }),
+    MdmResourcesModule.forRoot({}),
     HttpClientTestingModule,
     NgxSkeletonLoaderModule,
     SharedModule
@@ -51,5 +51,4 @@ import { SharedModule } from '@mdm/modules/shared/shared.module';
     SharedModule
   ]
 })
-export class TestingModule { }
-
+export class TestingModule {}

--- a/src/style/_main.scss
+++ b/src/style/_main.scss
@@ -17,7 +17,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-
 /* Large Devices, Wide Screens */
 @media only screen and (max-width: 2400px) {
   .resizableLeft {
@@ -122,7 +121,6 @@ SPDX-License-Identifier: Apache-2.0
   background-color: #f9f9f9;
 }
 
-
 // .breadcrumb > li + li:before {
 //   padding: 0px 0px 0px 5px !important;
 //   content: "/" !important;
@@ -161,7 +159,6 @@ SPDX-License-Identifier: Apache-2.0
 .panel-table {
   padding: 5px 10px !important;
 }
-
 
 .elementDetailMCType {
   font-size: 12px;
@@ -300,7 +297,6 @@ ul.myTree li:focus {
   opacity: 0;
 }
 
-
 /*** Style the buttons ***/
 .searchResults {
   .ng-table-header {
@@ -320,11 +316,9 @@ ul.myTree li:focus {
   }
 }
 
-
 .onlineUser {
   color: #268c21;
 }
-
 
 .MCElementType {
   font-size: 11px;
@@ -360,7 +354,6 @@ th.metadataNamespaceHeader {
   font-weight: bold !important;
 }
 
-
 #paper-html-elements {
   position: relative;
   border: 1px solid gray;
@@ -374,8 +367,6 @@ th.metadataNamespaceHeader {
 #paper-html-elements svg .link {
   z-index: 2;
 }
-
-
 
 div.diagram-tool-box {
   color: #000;
@@ -418,7 +409,6 @@ div.mcSelectItem.current {
   cursor: pointer;
 }
 
-
 div.noClassification {
   color: #686868;
   padding: 5px;
@@ -438,10 +428,6 @@ div.noFavourites {
   .title {
     font-size: 16px;
     font-weight: bold;
-  }
-  .content {
-    font-style: italic;
-    padding-left: 3px;
   }
 }
 
@@ -477,7 +463,6 @@ img.profilePicture {
   cursor: pointer;
 }
 
-
 .deletedDataModelTitle {
   text-decoration: line-through;
 }
@@ -485,7 +470,6 @@ img.profilePicture {
 .supersededByItem {
   opacity: 0.6;
 }
-
 
 .not-allowed-cursor {
   cursor: not-allowed;
@@ -569,7 +553,7 @@ img.profilePicture {
 .alias > li + li:before {
   padding: 0px 0px 0px 3px;
   color: #000;
-  content: "/";
+  content: '/';
 }
 
 ul.aliasSearchResult {
@@ -589,11 +573,9 @@ li.aliasSearchResult {
   border-bottom: 1px solid #ddd;
 }
 
-
-
 .copyElementSuccess {
   color: #5cb85c;
-//   font-size: 26px;
+  //   font-size: 26px;
 }
 
 .copyElementError {
@@ -616,7 +598,7 @@ small.simpleView.elementType {
 ///.....................................................................................................................
 
 .mat-dialog-container {
-//   padding: 3px !important;
+  //   padding: 3px !important;
   // overflow: hidden !important;
 }
 .mat-table-row-select {
@@ -626,20 +608,19 @@ small.simpleView.elementType {
 mat-tab-label {
   min-width: 50px !important;
 }
-.mat-tab-label, .mat-tab-link {
-  color: rgba(0,0,0,.97);
+.mat-tab-label,
+.mat-tab-link {
+  color: rgba(0, 0, 0, 0.97);
 }
 
 .mat-menu-panel {
   min-height: 32px !important;
 }
 
-
-
 .leftTab .nav > li > a {
-	padding: 5px 7px;
-	font-size: 12px;
-	font-weight: bold;
+  padding: 5px 7px;
+  font-size: 12px;
+  font-weight: bold;
 }
 
 .full-width-dialog .mat-dialog-container {
@@ -647,7 +628,8 @@ mat-tab-label {
   width: 100vw;
 }
 
-.badge.item-type-imported, .badge.item-type-extended {
+.badge.item-type-imported,
+.badge.item-type-extended {
   font-style: italic;
   font-size: 0.8rem;
 }


### PR DESCRIPTION
Resolves #588 

* Move `SharedModule` to correct sub-folder
* Create new `MauroItemTreeComponent` to create simplified tree view of catalogue items. Uses a custom Angular `DataSource` to handle fetching child items efficiently
* Simplify existing `FavouritesComponent` to fetch favourites items and display the tree view
* Match existing styles of tree views e.g. selection, show branch/versions, domain icons etc
* Navigate to any item selected in the tree, whether a favourite (root item) or expanded child
* Handle case where favourite catalogue items have been deleted by someone else

![image](https://user-images.githubusercontent.com/3219480/187951298-8acc9952-7ee4-4278-9043-8c4dd0621608.png)
