### PR TITLE
MC-9621 Allow UI to make updates to profiles editable after finalisation

### DIFF
--- a/src/app/modals/add-profile-modal/add-profile-modal.component.html
+++ b/src/app/modals/add-profile-modal/add-profile-modal.component.html
@@ -16,38 +16,45 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div  style="width: 700px">
-<div class="modal-header pxy-2">
-  <h4 mat-dialog-title>Add New Profile</h4>
-</div>
-<div class="modal-body pxy-2" >
-  <div *ngIf="showProfileSelector">
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Select Profile : </mat-label>
-      <mat-select [(ngModel)]="data.selectedProfile">
-        <mat-option
-          *ngFor="let option of allUnusedProfiles"
-          [value]="option.value"
-          >{{ option.display }}</mat-option
-        >
-      </mat-select>
-    </mat-form-field>
+<div style="width: 700px">
+  <div class="modal-header pxy-2">
+    <h4 mat-dialog-title>Add New Profile</h4>
   </div>
-  <div  *ngIf="!showProfileSelector">
-    <p>There are no available profiles</p>
+  <div class="modal-body pxy-2">
+    <mdm-alert *ngIf="data.finalised" alertStyle="info" showIcon="true">
+      Only the following profiles may be added after finalisation.
+    </mdm-alert>
+    <div *ngIf="profiles">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Select Profile : </mat-label>
+        <mat-select [(ngModel)]="data.selectedProfile">
+          <mat-option *ngFor="let option of profiles" [value]="option.value">{{
+            option.display
+          }}</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div *ngIf="!profiles">
+      <p>There are no available profiles</p>
+    </div>
+    <div class="modal-footer pxy-2">
+      <button
+        mat-button
+        color="warn"
+        style="margin-right: 8px"
+        (click)="onCancel()"
+      >
+        Cancel
+      </button>
+      <button
+        mat-flat-button
+        color="primary"
+        (click)="save()"
+        [disabled]="!data.selectedProfile"
+        class="custom"
+      >
+        Save Changes
+      </button>
+    </div>
   </div>
-  <div class="modal-footer pxy-2">
-    <button
-      mat-button
-      color="warn"
-      style="margin-right: 8px"
-      (click)="onCancel()"
-    >
-      Cancel
-    </button>
-    <button mat-flat-button color="primary" (click)="save()" [disabled]="!showProfileSelector" class="custom">
-      Save Changes
-    </button>
-  </div>
-</div>
 </div>

--- a/src/app/modals/add-profile-modal/add-profile-modal.component.ts
+++ b/src/app/modals/add-profile-modal/add-profile-modal.component.ts
@@ -19,8 +19,21 @@ SPDX-License-Identifier: Apache-2.0
 /* eslint-disable id-blacklist */
 import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { ProfileSummaryIndexResponse } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  ProfileSummary,
+  ProfileSummaryIndexResponse,
+  Uuid
+} from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
+import { map } from 'rxjs/operators';
+
+export interface AddProfileModalConfiguration {
+  domainId: Uuid;
+  domainType: CatalogueItemDomainType;
+  finalised?: boolean;
+  selectedProfile?: ProfileSummary;
+}
 
 @Component({
   selector: 'mdm-add-profile-modal',
@@ -28,32 +41,45 @@ import { MdmResourcesService } from '@mdm/modules/resources';
   styleUrls: ['./add-profile-modal.component.scss']
 })
 export class AddProfileModalComponent implements OnInit {
-  allUnusedProfiles: Array<any> = [];
-  showProfileSelector = false;
+  profiles: ProfileSummary[];
 
   constructor(
     public dialogRef: MatDialogRef<AddProfileModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(MAT_DIALOG_DATA) public data: AddProfileModalConfiguration,
     protected resourcesSvc: MdmResourcesService
   ) {}
 
   ngOnInit(): void {
     this.resourcesSvc.profile
       .unusedProfiles(this.data.domainType, this.data.domainId)
-      .subscribe((profiles: ProfileSummaryIndexResponse) => {
-        profiles.body.forEach((profile) => {
-          const prof: any = [];
-          prof['display'] = `${profile.displayName} (${profile.version})`;
-          prof['value'] = `${profile.namespace}/${profile.name}/${profile.version}`;
-          this.allUnusedProfiles.push(prof);
-          this.showProfileSelector = true;
-        });
+      .pipe(
+        map((response: ProfileSummaryIndexResponse) => {
+          if (this.data.finalised) {
+            // If the catalogue item is finalised, only allow profiles that are allowed
+            // to be edited
+            return response.body.filter(
+              (profile) => profile.editableAfterFinalisation
+            );
+          }
+
+          return response.body;
+        }),
+        map((profiles: ProfileSummary) =>
+          profiles.map((profile) => {
+            return {
+              ...profile,
+              display: `${profile.displayName} (${profile.version})`,
+              value: `${profile.namespace}/${profile.name}/${profile.version}`
+            };
+          })
+        )
+      )
+      .subscribe((profiles: ProfileSummary[]) => {
+        this.profiles = profiles;
       });
   }
 
   save() {
-    // Save Changes
-    console.log(this.data.selectedProfile);
     this.dialogRef.close(this.data.selectedProfile);
   }
 

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
@@ -29,7 +29,15 @@ SPDX-License-Identifier: Apache-2.0
     enctype="multipart/form-data"
     method="POST"
   >
-    <table *ngIf="this.profileData" class="table table-bordered" role="presentation">
+    <mdm-alert *ngIf="data.finalised" alertStyle="info" showIcon="true">
+      Only certain fields can be edited on this profile as the catalogue item is
+      finalised.
+    </mdm-alert>
+    <table
+      *ngIf="this.profileData"
+      class="table table-bordered"
+      role="presentation"
+    >
       <tbody *ngFor="let section of this.profileData?.sections">
         <tr>
           <td [attr.colspan]="2" class="detailsRowHeader">
@@ -52,7 +60,7 @@ SPDX-License-Identifier: Apache-2.0
             <mdm-content-editor
               [(content)]="field.currentValue"
               id="{{ field.fieldName }}"
-              [inEditMode]="!field.uneditable"
+              [inEditMode]="!field.readOnly"
               *ngIf="field.dataType === 'text'"
             ></mdm-content-editor>
 
@@ -69,7 +77,7 @@ SPDX-License-Identifier: Apache-2.0
               (change)="field.currentValue = $event.target.checked"
               name="{{ field.fieldName }} + {{ section.name }}"
               [required]="field.minMultiplicity > 0"
-              [disabled]="field.uneditable"
+              [disabled]="field.readOnly"
             />
             <div
               *ngIf="
@@ -84,9 +92,9 @@ SPDX-License-Identifier: Apache-2.0
                 field.dataType != 'enumeration'
               "
             >
-              <span *ngIf="field.uneditable">{{field.currentValue}}</span>
+              <span *ngIf="field.readOnly">{{ field.currentValue }}</span>
               <input
-                *ngIf="!field.uneditable"
+                *ngIf="!field.readOnly"
                 matInput
                 type="{{ formOptionsMap[field.dataType] }}"
                 name="{{ field.fieldName }} + {{ section.name }}"
@@ -111,7 +119,7 @@ SPDX-License-Identifier: Apache-2.0
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
               [required]="field.minMultiplicity > 0"
-              [disabled]="field.uneditable"
+              [disabled]="field.readOnly"
             />
             <input
               *ngIf="field.dataType === 'datetime'"
@@ -125,7 +133,7 @@ SPDX-License-Identifier: Apache-2.0
                   formOptionsMap[field.dataType] != 'checkbox'
               }"
               [required]="field.minMultiplicity > 0"
-              [disabled]="field.uneditable"
+              [disabled]="field.readOnly"
             />
             <div *ngIf="field.dataType === 'model'">
               <input
@@ -140,10 +148,10 @@ SPDX-License-Identifier: Apache-2.0
                     formOptionsMap[field.dataType] != 'checkbox'
                 }"
                 [required]="field.minMultiplicity > 0"
-                [disabled]="field.uneditable"
+                [disabled]="field.readOnly"
               />
               <button
-                *ngIf="!field.uneditable"
+                *ngIf="!field.readOnly"
                 mat-stroked-button
                 type="button"
                 color="primary"
@@ -159,7 +167,7 @@ SPDX-License-Identifier: Apache-2.0
                 <mat-select
                   [(ngModel)]="field.currentValue"
                   name="{{ field.fieldName }} + {{ section.name }}"
-                  [disabled]="field.uneditable"
+                  [disabled]="field.readOnly"
                 >
                   <mat-option
                     *ngFor="let value of sortBy(field.allowedValues)"
@@ -202,8 +210,11 @@ SPDX-License-Identifier: Apache-2.0
       Profile is valid
     </span>
     <span *ngIf="validationErrors.total > 0" class="mr-2">
-      <span class="fas fa-exclamation-triangle warning" style="color: #f19e3f"></span>
-      There are {{validationErrors.total}} field(s) with issues
+      <span
+        class="fas fa-exclamation-triangle warning"
+        style="color: #f19e3f"
+      ></span>
+      There are {{ validationErrors.total }} field(s) with issues
     </span>
     <button
       mat-button

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.ts
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.ts
@@ -25,15 +25,23 @@ import {
   MatDialogRef,
   MAT_DIALOG_DATA
 } from '@angular/material/dialog';
-import { Profile, ProfileField, ProfileValidationError, ProfileValidationErrorList } from '@maurodatamapper/mdm-resources';
+import {
+  Profile,
+  ProfileField,
+  ProfileValidationError,
+  ProfileValidationErrorList
+} from '@maurodatamapper/mdm-resources';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { ElementSelectorComponent } from '@mdm/utility/element-selector.component';
 import { MarkdownParserService } from '@mdm/utility/markdown/markdown-parser/markdown-parser.service';
 import { EMPTY } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { EditProfileModalConfiguration, EditProfileModalResult } from './edit-profile-modal.model';
-import {EditingService} from '@mdm/services/editing.service';
+import {
+  EditProfileModalConfiguration,
+  EditProfileModalResult
+} from './edit-profile-modal.model';
+import { EditingService } from '@mdm/services/editing.service';
 @Component({
   selector: 'mdm-edit-profile-modal',
   templateUrl: './edit-profile-modal.component.html',
@@ -61,12 +69,16 @@ export class EditProfileModalComponent implements OnInit {
   };
 
   constructor(
-    public dialogRef: MatDialogRef<EditProfileModalComponent, EditProfileModalResult>,
+    public dialogRef: MatDialogRef<
+      EditProfileModalComponent,
+      EditProfileModalResult
+    >,
     @Inject(MAT_DIALOG_DATA) public data: EditProfileModalConfiguration,
     private markdownParser: MarkdownParserService,
     protected resources: MdmResourcesService,
     private dialog: MatDialog,
-    protected editing: EditingService) {
+    protected editing: EditingService
+  ) {
     data.profile.sections.forEach((section) => {
       section.fields.forEach((field) => {
         if (data.isNew && field.defaultValue) {
@@ -84,6 +96,8 @@ export class EditProfileModalComponent implements OnInit {
             field.currentValue = JSON.parse(field.currentValue);
           }
         }
+
+        this.attachReadOnlyPropertyToField(field);
       });
     });
 
@@ -94,7 +108,7 @@ export class EditProfileModalComponent implements OnInit {
     this.validate();
   }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
   save() {
     // Save Changes
@@ -150,16 +164,20 @@ export class EditProfileModalComponent implements OnInit {
       });
   }
 
-  getValidationError(metadataPropertyName: string): ProfileValidationError | undefined {
+  getValidationError(
+    metadataPropertyName: string
+  ): ProfileValidationError | undefined {
     if (this.validationErrors.fieldTotal === 0) {
       return undefined;
     }
 
-    return this.validationErrors.errors.find(e => e.metadataPropertyName === metadataPropertyName);
+    return this.validationErrors.errors.find(
+      (e) => e.metadataPropertyName === metadataPropertyName
+    );
   }
 
   sortBy(items: []) {
-    return items.sort((a, b) => a > b ? 1 : a === b ? 0 : -1);
+    return items.sort((a, b) => (a > b ? 1 : a === b ? 0 : -1));
   }
 
   showAddElementToMarkdown(field: ProfileField) {
@@ -173,5 +191,11 @@ export class EditProfileModalComponent implements OnInit {
         field.currentValue = mkData;
       });
     });
-  };
+  }
+
+  private attachReadOnlyPropertyToField(field: ProfileField) {
+    field.readOnly =
+      field.uneditable ||
+      (this.data.finalised && !field.editableAfterFinalisation);
+  }
 }

--- a/src/app/modals/edit-profile-modal/edit-profile-modal.model.ts
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.model.ts
@@ -27,6 +27,7 @@ export interface EditProfileModalConfiguration {
   isNew: boolean;
   description?: string;
   okBtn?: string;
+  finalised?: boolean;
 }
 
 export interface EditProfileModalResult {

--- a/src/app/shared/profile-data-view/profile-data-view.component.html
+++ b/src/app/shared/profile-data-view/profile-data-view.component.html
@@ -56,8 +56,12 @@ SPDX-License-Identifier: Apache-2.0
             >
             <mat-divider></mat-divider>
             <mat-option value="other">Other properties</mat-option>
-            <mat-divider *ngIf="canAddMetadata"></mat-divider>
-            <mat-option *ngIf="canAddMetadata" value="addnew"
+            <mat-divider
+              *ngIf="canAddMetadata || canAddProfilesAfterFinalisation"
+            ></mat-divider>
+            <mat-option
+              *ngIf="canAddMetadata || canAddProfilesAfterFinalisation"
+              value="addnew"
               >Add new profile...</mat-option
             >
           </mat-select>
@@ -79,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
             currentView !== 'default' &&
             currentView !== 'other' &&
             currentView !== 'addnew' &&
-            canEdit
+            canEditCustomProfile
           "
           color="primary"
           type="button"
@@ -112,10 +116,18 @@ SPDX-License-Identifier: Apache-2.0
         </button>
 
         <mat-menu #editMenu="matMenu">
-          <button mat-menu-item data-cy="edit-description" (click)="editDefaultProfileDescription()">
+          <button
+            mat-menu-item
+            data-cy="edit-description"
+            (click)="editDefaultProfileDescription()"
+          >
             <span class="fas fa-pencil-alt"></span> Edit Description
           </button>
-          <button mat-menu-item data-cy="edit-all" (click)="editDefaultProfileFull()">
+          <button
+            mat-menu-item
+            data-cy="edit-all"
+            (click)="editDefaultProfileFull()"
+          >
             <span class="fas fa-pencil-alt"></span> Edit
           </button>
         </mat-menu>
@@ -129,10 +141,10 @@ SPDX-License-Identifier: Apache-2.0
             matTooltip="Submit this catalogue item to a Digital Object Identifier (DOI) system"
             [matMenuTriggerFor]="doiSubmitActions"
           >
-            <span class="fas fa-paper-plane has-text-green"></span> DOI submission
+            <span class="fas fa-paper-plane has-text-green"></span> DOI
+            submission
           </button>
-          <mat-divider *ngIf="canSubmitForDoi">
-          </mat-divider>
+          <mat-divider *ngIf="canSubmitForDoi"> </mat-divider>
           <button
             mat-menu-item
             *ngIf="isCurrentViewCustomProfile && canDeleteProfile"
@@ -177,6 +189,14 @@ SPDX-License-Identifier: Apache-2.0
       </div>
     </div>
   </div>
+
+  <mdm-alert
+    *ngIf="catalogueItem.finalised && canEditCustomProfile"
+    alertStyle="info"
+    showIcon="true"
+  >
+    This profile can be edited even after finalisation
+  </mdm-alert>
 
   <mdm-profile-details
     *ngIf="currentProfile"

--- a/src/app/shared/profile-data-view/profile-data-view.component.ts
+++ b/src/app/shared/profile-data-view/profile-data-view.component.ts
@@ -16,8 +16,16 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
-import {MatDialog} from '@angular/material/dialog';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges
+} from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import {
   ApiProperty,
   ApiPropertyIndexResponse,
@@ -39,19 +47,48 @@ import {
   SecurableModel,
   Uuid
 } from '@maurodatamapper/mdm-resources';
-import {ModalDialogStatus} from '@mdm/constants/modal-dialog-status';
-import {AddProfileModalComponent} from '@mdm/modals/add-profile-modal/add-profile-modal.component';
-import {DefaultProfileEditorModalComponent} from '@mdm/modals/default-profile-editor-modal/default-profile-editor-modal.component';
-import {EditProfileModalComponent} from '@mdm/modals/edit-profile-modal/edit-profile-modal.component';
-import {EditProfileModalConfiguration, EditProfileModalResult} from '@mdm/modals/edit-profile-modal/edit-profile-modal.model';
-import {DefaultProfileItem, DefaultProfileModalConfiguration, DefaultProfileModalResponse} from '@mdm/model/defaultProfileModel';
-import {MdmHttpHandlerOptions, MdmResourcesService} from '@mdm/modules/resources';
-import {MessageHandlerService, SecurityHandlerService, SharedService} from '@mdm/services';
-import {EditingService} from '@mdm/services/editing.service';
-import {EMPTY, from, Observable, Subject, zip} from 'rxjs';
-import {catchError, filter, map, mergeMap, switchMap, tap} from 'rxjs/operators';
-import {doiProfileNamespace, getDefaultProfileData, ProfileDataViewType, ProfileSummaryListItem} from './profile-data-view.model';
-import {GridService} from '@mdm/services/grid.service';
+import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
+import {
+  AddProfileModalComponent,
+  AddProfileModalConfiguration
+} from '@mdm/modals/add-profile-modal/add-profile-modal.component';
+import { DefaultProfileEditorModalComponent } from '@mdm/modals/default-profile-editor-modal/default-profile-editor-modal.component';
+import { EditProfileModalComponent } from '@mdm/modals/edit-profile-modal/edit-profile-modal.component';
+import {
+  EditProfileModalConfiguration,
+  EditProfileModalResult
+} from '@mdm/modals/edit-profile-modal/edit-profile-modal.model';
+import {
+  DefaultProfileItem,
+  DefaultProfileModalConfiguration,
+  DefaultProfileModalResponse
+} from '@mdm/model/defaultProfileModel';
+import {
+  MdmHttpHandlerOptions,
+  MdmResourcesService
+} from '@mdm/modules/resources';
+import {
+  MessageHandlerService,
+  SecurityHandlerService,
+  SharedService
+} from '@mdm/services';
+import { EditingService } from '@mdm/services/editing.service';
+import { EMPTY, from, Observable, Subject, zip } from 'rxjs';
+import {
+  catchError,
+  filter,
+  map,
+  mergeMap,
+  switchMap,
+  tap
+} from 'rxjs/operators';
+import {
+  doiProfileNamespace,
+  getDefaultProfileData,
+  ProfileDataViewType,
+  ProfileSummaryListItem
+} from './profile-data-view.model';
+import { GridService } from '@mdm/services/grid.service';
 
 @Component({
   selector: 'mdm-profile-data-view',
@@ -59,10 +96,13 @@ import {GridService} from '@mdm/services/grid.service';
   styleUrls: ['./profile-data-view.component.scss']
 })
 export class ProfileDataViewComponent implements OnInit, OnChanges {
-  @Input() catalogueItem: Modelable & ModelableDetail & SecurableModel & {
-    [key: string]: any;
-    model?: Uuid;
-  };
+  @Input() catalogueItem: Modelable &
+    ModelableDetail &
+    SecurableModel &
+    Finalisable & {
+      [key: string]: any;
+      model?: Uuid;
+    };
 
   @Output() savingDefault = new EventEmitter<DefaultProfileItem[]>();
 
@@ -82,28 +122,66 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   otherDefaultProfileView: string;
   useDefaultProfileSimplifiedEntry = false;
 
-  private readonly defaultProfileNamespacePropertyKey = 'ui.default.profile.namespace';
-  private readonly useDefaultProfileSimplifiedEntryPropertyKey = 'ui.default.profile.simplified_entry';
+  private readonly defaultProfileNamespacePropertyKey =
+    'ui.default.profile.namespace';
+  private readonly useDefaultProfileSimplifiedEntryPropertyKey =
+    'ui.default.profile.simplified_entry';
+
+  get canEditCustomProfile() {
+    if (
+      this.currentView === 'default' ||
+      this.currentView === 'other' ||
+      this.currentView === 'addnew'
+    ) {
+      return false;
+    }
+
+    const profileSummary = this.usedProfiles.find(
+      (summary) => summary.value === this.currentView
+    );
+
+    return this.canEdit || profileSummary?.editableAfterFinalisation;
+  }
+
+  get canAddProfilesAfterFinalisation() {
+    if (!this.catalogueItem.finalised) {
+      return false;
+    }
+
+    return this.unusedProfiles.some(
+      (profile) => profile.editableAfterFinalisation
+    );
+  }
 
   get isCurrentViewCustomProfile() {
-    return this.currentView !== 'default' && this.currentView !== 'other' && this.currentView !== 'addnew';
+    return (
+      this.currentView !== 'default' &&
+      this.currentView !== 'other' &&
+      this.currentView !== 'addnew'
+    );
   }
 
   get isDoiProfile() {
-    return this.shared.features.useDigitalObjectIdentifiers && this.currentProfile?.namespace === doiProfileNamespace;
+    return (
+      this.shared.features.useDigitalObjectIdentifiers &&
+      this.currentProfile?.namespace === doiProfileNamespace
+    );
   }
 
   get canSubmitForDoi() {
     // DOI profiles can only be submitted for finalised, public items
-    return this.shared.features.useDigitalObjectIdentifiers
-      && this.isEditablePostFinalise
-      && this.isReadableByEveryone
-      && this.doiState !== 'retired';
+    return (
+      this.shared.features.useDigitalObjectIdentifiers &&
+      this.isEditablePostFinalise &&
+      this.isReadableByEveryone &&
+      this.doiState !== 'retired'
+    );
   }
 
   get showAdditionalActions() {
     const showDoiSubmitAction = this.canSubmitForDoi;
-    const showRemoveAction = this.isCurrentViewCustomProfile && this.canDeleteProfile;
+    const showRemoveAction =
+      this.isCurrentViewCustomProfile && this.canDeleteProfile;
     return showRemoveAction || showDoiSubmitAction;
   }
 
@@ -118,30 +196,41 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
     private messageHandler: MessageHandlerService,
     private editing: EditingService,
     private gridService: GridService,
-    private shared: SharedService) { }
+    private shared: SharedService
+  ) {}
 
   ngOnInit(): void {
-      this.resources.apiProperties
-        .listPublic()
-        .pipe(
-          catchError(errors => {
-            this.messageHandler.showError('There was a problem getting the configuration properties.', errors);
-            return [];
-          })
-        )
-        .subscribe((response: ApiPropertyIndexResponse) => {
-          this.loadDefaultCustomProfile(response.body.items);
-        });
+    this.resources.apiProperties
+      .listPublic()
+      .pipe(
+        catchError((errors) => {
+          this.messageHandler.showError(
+            'There was a problem getting the configuration properties.',
+            errors
+          );
+          return [];
+        })
+      )
+      .subscribe((response: ApiPropertyIndexResponse) => {
+        this.loadDefaultCustomProfile(response.body.items);
+      });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.catalogueItem && this.catalogueItem) {
       this.setAccess();
       if (!this.catalogueItem.domainType) {
-        this.catalogueItem.domainType = changes.catalogueItem.previousValue.domainType;
+        this.catalogueItem.domainType =
+          changes.catalogueItem.previousValue.domainType;
       }
-      this.loadUsedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
-      this.loadUnusedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
+      this.loadUsedProfiles(
+        this.catalogueItem.domainType,
+        this.catalogueItem.id
+      );
+      this.loadUnusedProfiles(
+        this.catalogueItem.domainType,
+        this.catalogueItem.id
+      );
 
       if (this.shared.features.useDigitalObjectIdentifiers) {
         this.getDoiStatus();
@@ -179,26 +268,29 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   editCustomProfile(isNew?: boolean) {
     const selected = this.usedProfiles
       .concat(this.unusedProfiles)
-      .find(item => item.value === this.currentView);
+      .find((item) => item.value === this.currentView);
 
     const oldProfile: Profile = JSON.parse(JSON.stringify(this.currentProfile));
 
     this.editing
-      .openDialog<EditProfileModalComponent, EditProfileModalConfiguration, EditProfileModalResult>(
+      .openDialog<
         EditProfileModalComponent,
-        {
-          data: {
-            profile: this.currentProfile,
-            profileName: selected.display,
-            catalogueItem: this.catalogueItem,
-            isNew: isNew ?? false
-          },
-          disableClose: true,
-          panelClass: 'full-width-dialog'
-        })
+        EditProfileModalConfiguration,
+        EditProfileModalResult
+      >(EditProfileModalComponent, {
+        data: {
+          profile: this.currentProfile,
+          profileName: selected.display,
+          catalogueItem: this.catalogueItem,
+          isNew: isNew ?? false,
+          finalised: this.catalogueItem.finalised
+        },
+        disableClose: true,
+        panelClass: 'full-width-dialog'
+      })
       .afterClosed()
       .pipe(
-        tap(result => {
+        tap((result) => {
           if (!result.profile && isNew) {
             this.currentView = this.lastView;
             this.changeProfile();
@@ -207,19 +299,22 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
             this.currentProfile = oldProfile;
           }
         }),
-        filter(result => result.status === ModalDialogStatus.Ok),
-        switchMap(result => {
-          return this.resources.profile
-            .saveProfile(
-              this.catalogueItem.domainType,
-              this.catalogueItem.id,
-              selected.namespace,
-              selected.name,
-              result.profile,
-              selected.version);
+        filter((result) => result.status === ModalDialogStatus.Ok),
+        switchMap((result) => {
+          return this.resources.profile.saveProfile(
+            this.catalogueItem.domainType,
+            this.catalogueItem.id,
+            selected.namespace,
+            selected.name,
+            result.profile,
+            selected.version
+          );
         }),
-        catchError(error => {
-          this.messageHandler.showError('There was a problem saving the profile.', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem saving the profile.',
+            error
+          );
           return EMPTY;
         })
       )
@@ -230,10 +325,15 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
 
         if (isNew) {
           this.messageHandler.showSuccess('Profile added.');
-          this.loadUsedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
-          this.loadUnusedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
-        }
-        else {
+          this.loadUsedProfiles(
+            this.catalogueItem.domainType,
+            this.catalogueItem.id
+          );
+          this.loadUnusedProfiles(
+            this.catalogueItem.domainType,
+            this.catalogueItem.id
+          );
+        } else {
           this.messageHandler.showSuccess('Profile edited successfully.');
         }
       });
@@ -263,23 +363,40 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
             this.currentProfile.version
           );
         }),
-        catchError(error => {
+        catchError((error) => {
           this.messageHandler.showError('Unable to remove profile', error);
           return EMPTY;
         })
       )
       .subscribe(() => {
         let notCurrentOtherDefaultProfileView: string;
-        if (this.otherDefaultProfileView !== undefined && this.currentView !== this.otherDefaultProfileView) {
+        if (
+          this.otherDefaultProfileView !== undefined &&
+          this.currentView !== this.otherDefaultProfileView
+        ) {
           notCurrentOtherDefaultProfileView = this.otherDefaultProfileView;
         }
         this.messageHandler.showSuccess('Profile removed successfully');
-        this.currentView = this.usedProfiles.find(e => e.value === this.defaultProfileView &&
-            !(e.namespace === this.currentProfile.namespace && e.name === this.currentProfile.name && e.version === this.currentProfile.version)
-          )?.value
-          ?? notCurrentOtherDefaultProfileView ?? 'default';
-        this.loadUsedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
-        this.loadUnusedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
+        this.currentView =
+          this.usedProfiles.find(
+            (e) =>
+              e.value === this.defaultProfileView &&
+              !(
+                e.namespace === this.currentProfile.namespace &&
+                e.name === this.currentProfile.name &&
+                e.version === this.currentProfile.version
+              )
+          )?.value ??
+          notCurrentOtherDefaultProfileView ??
+          'default';
+        this.loadUsedProfiles(
+          this.catalogueItem.domainType,
+          this.catalogueItem.id
+        );
+        this.loadUnusedProfiles(
+          this.catalogueItem.domainType,
+          this.catalogueItem.id
+        );
         this.changeProfile();
       });
   }
@@ -307,44 +424,47 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   }
 
   private loadUsedProfiles(domainType: CatalogueItemDomainType, id: Uuid) {
-    this.loadProfileItems('used', domainType, id)
-      .subscribe(items => {
-        if (items && items.length > 0) {
-          this.usedProfiles = items;
+    this.loadProfileItems('used', domainType, id).subscribe((items) => {
+      if (items && items.length > 0) {
+        this.usedProfiles = items;
 
-          // Set a default value
-          this.loadDefaultProfilePropertyValue(domainType, id)
-              .subscribe(defaultValues => {
-               if (defaultValues && (defaultValues.length > 0)) {
-                  this.defaultProfileView = defaultValues[0].value;
-                  if (defaultValues.length > 1) {
-                    this.otherDefaultProfileView = defaultValues[1].value;
-                  } else {
-                    this.otherDefaultProfileView = undefined;
-                  }
-               }
+        // Set a default value
+        this.loadDefaultProfilePropertyValue(domainType, id).subscribe(
+          (defaultValues) => {
+            if (defaultValues && defaultValues.length > 0) {
+              this.defaultProfileView = defaultValues[0].value;
+              if (defaultValues.length > 1) {
+                this.otherDefaultProfileView = defaultValues[1].value;
+              } else {
+                this.otherDefaultProfileView = undefined;
+              }
+            }
             if (!this.currentView && this.defaultProfileView) {
               // Get the item in usedProfiles that matches the otherProperties value
-              this.currentView = this.usedProfiles.find(e => e.value === this.defaultProfileView)?.value ?? 'default';
+              this.currentView =
+                this.usedProfiles.find(
+                  (e) => e.value === this.defaultProfileView
+                )?.value ?? 'default';
             } else if (!this.currentView) {
               this.currentView = 'default';
             }
             this.changeProfile();
-             });
-        } else {
-          this.usedProfiles = items;
-          if (!this.currentView) {
-            this.currentView = 'default';
           }
+        );
+      } else {
+        this.usedProfiles = items;
+        if (!this.currentView) {
+          this.currentView = 'default';
         }
-        this.changeProfile();
-
-      });
+      }
+      this.changeProfile();
+    });
   }
 
   private loadUnusedProfiles(domainType: CatalogueItemDomainType, id: any) {
-    this.loadProfileItems('unused', domainType, id)
-      .subscribe(items => this.unusedProfiles = items);
+    this.loadProfileItems('unused', domainType, id).subscribe(
+      (items) => (this.unusedProfiles = items)
+    );
   }
 
   private loadParentModelForDoiState() {
@@ -355,12 +475,15 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
 
     request
       .pipe(
-        catchError(error => {
-          this.messageHandler.showError('There was a problem getting the parent model.', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem getting the parent model.',
+            error
+          );
           return EMPTY;
         })
       )
-      .subscribe(response => {
+      .subscribe((response) => {
         const parentModel = response.body;
 
         // Fetch the parent model to find out if that is a public, finalised model. Required to know if
@@ -372,10 +495,14 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
       });
   }
 
-  private getParentModel(): Observable<MdmResponse<CatalogueItem & SecurableModel & Finalisable>> | undefined {
-    if (isDataType(this.catalogueItem.domainType)
-      || this.catalogueItem.domainType === CatalogueItemDomainType.DataClass
-      || this.catalogueItem.domainType === CatalogueItemDomainType.DataElement) {
+  private getParentModel():
+    | Observable<MdmResponse<CatalogueItem & SecurableModel & Finalisable>>
+    | undefined {
+    if (
+      isDataType(this.catalogueItem.domainType) ||
+      this.catalogueItem.domainType === CatalogueItemDomainType.DataClass ||
+      this.catalogueItem.domainType === CatalogueItemDomainType.DataElement
+    ) {
       return this.resources.dataModel.get(this.catalogueItem.model);
     }
 
@@ -389,24 +516,30 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   private loadProfileItems(
     type: 'used' | 'unused',
     domainType: CatalogueItemDomainType,
-    id: any): Observable<ProfileSummaryListItem[]> {
-    const request: Observable<ProfileSummaryIndexResponse> = type === 'used'
-      ? this.resources.profile.usedProfiles(domainType, id)
-      : this.resources.profile.unusedProfiles(domainType, id);
+    id: any
+  ): Observable<ProfileSummaryListItem[]> {
+    const request: Observable<ProfileSummaryIndexResponse> =
+      type === 'used'
+        ? this.resources.profile.usedProfiles(domainType, id)
+        : this.resources.profile.unusedProfiles(domainType, id);
 
     return request.pipe(
-      catchError(error => {
-        this.messageHandler.showError('There was a problem getting the list of unused profiles.', error);
+      catchError((error) => {
+        this.messageHandler.showError(
+          'There was a problem getting the list of unused profiles.',
+          error
+        );
         return EMPTY;
       }),
       map((response: ProfileSummaryIndexResponse) => {
-        return response.body.map(summary => {
+        return response.body.map((summary) => {
           return {
             display: `${summary.displayName} (${summary.version})`,
             value: `${summary.namespace}/${summary.name}/${summary.version}`,
             namespace: summary.namespace,
             name: summary.name,
-            version: summary.version
+            version: summary.version,
+            editableAfterFinalisation: summary.editableAfterFinalisation
           };
         });
       })
@@ -422,15 +555,15 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
       >(DefaultProfileEditorModalComponent, {
         data: {
           items,
-          parentCatalogueItem: this.catalogueItem.breadcrumbs ? this.catalogueItem.breadcrumbs[0] : null
+          parentCatalogueItem: this.catalogueItem.breadcrumbs
+            ? this.catalogueItem.breadcrumbs[0]
+            : null
         },
         panelClass: 'full-width-dialog'
       })
       .afterClosed()
-      .pipe(
-        filter(result => result.status === ModalDialogStatus.Ok)
-      )
-      .subscribe(result => {
+      .pipe(filter((result) => result.status === ModalDialogStatus.Ok))
+      .subscribe((result) => {
         this.savingDefault.emit(result.items);
       });
   }
@@ -438,14 +571,25 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   private selectCustomProfile() {
     this.lastView = this.currentView;
 
-    const [namespace, name, version] = this.getNamespaceNameAndVersion(this.currentView);
+    const [namespace, name, version] = this.getNamespaceNameAndVersion(
+      this.currentView
+    );
 
     if (namespace && name && version) {
       this.resources.profile
-        .profile(this.catalogueItem.domainType, this.catalogueItem.id, namespace, name, version)
+        .profile(
+          this.catalogueItem.domainType,
+          this.catalogueItem.id,
+          namespace,
+          name,
+          version
+        )
         .pipe(
-          catchError(error => {
-            this.messageHandler.showError('There was a problem getting the selected profile.', error);
+          catchError((error) => {
+            this.messageHandler.showError(
+              'There was a problem getting the selected profile.',
+              error
+            );
             return EMPTY;
           })
         )
@@ -464,21 +608,37 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
     }
 
     this.editing
-      .openDialog(AddProfileModalComponent, {
+      .openDialog<
+        AddProfileModalComponent,
+        AddProfileModalConfiguration,
+        string
+      >(AddProfileModalComponent, {
         data: {
           domainType: this.catalogueItem.domainType,
-          domainId: this.catalogueItem.id
+          domainId: this.catalogueItem.id,
+          finalised: this.catalogueItem.finalised
         }
       })
       .afterClosed()
       .subscribe((newProfile) => {
         if (newProfile) {
-          const [namespace, name, version] = this.getNamespaceNameAndVersion(newProfile);
+          const [namespace, name, version] = this.getNamespaceNameAndVersion(
+            newProfile
+          );
           this.resources.profile
-            .profile(this.catalogueItem.domainType, this.catalogueItem.id, namespace, name, version)
+            .profile(
+              this.catalogueItem.domainType,
+              this.catalogueItem.id,
+              namespace,
+              name,
+              version
+            )
             .pipe(
-              catchError(error => {
-                this.messageHandler.showError('There was a problem getting the selected profile.', error);
+              catchError((error) => {
+                this.messageHandler.showError(
+                  'There was a problem getting the selected profile.',
+                  error
+                );
                 return EMPTY;
               })
             )
@@ -489,15 +649,19 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
               this.currentProfile.name = name;
               this.editCustomProfile(true);
             });
-        }
-        else {
+        } else {
           this.currentView = this.lastView;
           this.changeProfile();
         }
       });
   }
 
-  private getNamespaceNameAndVersion(viewName: string): [string, string, string] {
+  private getNamespaceNameAndVersion(
+    viewName: string
+  ): [string, string, string] {
+    if (!viewName) {
+      return [null, null, null];
+    }
     const split = viewName.split('/');
     return [split[0], split[1], split[2]];
   }
@@ -510,7 +674,7 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
     };
 
     this.resources.pluginDoi
-      .get(this.catalogueItem.domainType, this.catalogueItem.id, { }, options)
+      .get(this.catalogueItem.domainType, this.catalogueItem.id, {}, options)
       .pipe(
         catchError(() => {
           this.doiState = 'not submitted';
@@ -525,24 +689,37 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   private submitCatalogueItemForDoi(state: DoiSubmissionState) {
     const doiProfileSummary = this.usedProfiles
       .concat(this.unusedProfiles)
-      .find(item => item.namespace === doiProfileNamespace);
+      .find((item) => item.namespace === doiProfileNamespace);
 
     if (!doiProfileSummary) {
-      this.messageHandler.showWarning('Unable to find the Digital Object Identifier profile. Please check with your administrator if it is enabled.');
+      this.messageHandler.showWarning(
+        'Unable to find the Digital Object Identifier profile. Please check with your administrator if it is enabled.'
+      );
       return;
     }
 
-    const doiProfileInUse = this.usedProfiles.find(item => item.value === doiProfileSummary.value);
+    const doiProfileInUse = this.usedProfiles.find(
+      (item) => item.value === doiProfileSummary.value
+    );
 
     const description = doiProfileInUse
       ? `Before submitting this object to receive a '${state}' Digital Object Identifier (DOI), please check all profile information below to ensure it is correct, then click the 'Submit' button.`
       : `To receive a '${state}' Digital Object Identifier (DOI), please fill in the profile information below, then click the 'Submit' button.`;
 
     this.resources.profile
-      .profile(this.catalogueItem.domainType, this.catalogueItem.id, doiProfileSummary.namespace, doiProfileSummary.name, '')
+      .profile(
+        this.catalogueItem.domainType,
+        this.catalogueItem.id,
+        doiProfileSummary.namespace,
+        doiProfileSummary.name,
+        ''
+      )
       .pipe(
-        catchError(error => {
-          this.messageHandler.showError('There was a problem getting the selected profile.', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem getting the selected profile.',
+            error
+          );
           return EMPTY;
         }),
         switchMap((response: ProfileResponse) => {
@@ -552,34 +729,42 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
           profile.name = doiProfileSummary.name;
 
           return this.editing
-            .openDialog<EditProfileModalComponent, EditProfileModalConfiguration, EditProfileModalResult>(
+            .openDialog<
               EditProfileModalComponent,
-              {
-                data: {
-                  profile: response.body,
-                  profileName: doiProfileSummary.display,
-                  catalogueItem: this.catalogueItem,
-                  isNew: !doiProfileInUse,
-                  description,
-                  okBtn: 'Submit'
-                },
-                disableClose: true,
-                panelClass: 'full-width-dialog'
-              })
+              EditProfileModalConfiguration,
+              EditProfileModalResult
+            >(EditProfileModalComponent, {
+              data: {
+                profile: response.body,
+                profileName: doiProfileSummary.display,
+                catalogueItem: this.catalogueItem,
+                isNew: !doiProfileInUse,
+                description,
+                okBtn: 'Submit'
+              },
+              disableClose: true,
+              panelClass: 'full-width-dialog'
+            })
             .afterClosed();
         }),
-        filter((result: EditProfileModalResult) => result.status === ModalDialogStatus.Ok),
+        filter(
+          (result: EditProfileModalResult) =>
+            result.status === ModalDialogStatus.Ok
+        ),
         switchMap((result: EditProfileModalResult) => {
-          return this.resources.profile
-            .saveProfile(
-              this.catalogueItem.domainType,
-              this.catalogueItem.id,
-              doiProfileSummary.namespace,
-              doiProfileSummary.name,
-              result.profile);
+          return this.resources.profile.saveProfile(
+            this.catalogueItem.domainType,
+            this.catalogueItem.id,
+            doiProfileSummary.namespace,
+            doiProfileSummary.name,
+            result.profile
+          );
         }),
-        catchError(error => {
-          this.messageHandler.showError('There was a problem saving the profile.', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem saving the profile.',
+            error
+          );
           return EMPTY;
         }),
         switchMap(() => {
@@ -588,18 +773,30 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
             this.catalogueItem.id,
             {
               submissionType: state
-            });
+            }
+          );
         }),
-        catchError(error => {
-          this.messageHandler.showError('There was a problem submitting the profile to generate a Digital Object Identifier (DOI).', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem submitting the profile to generate a Digital Object Identifier (DOI).',
+            error
+          );
           return EMPTY;
-        }),
+        })
       )
       .subscribe(() => {
-        this.messageHandler.showSuccess('A Digital Object Identifier (DOI) was successfully stored in this profile.');
+        this.messageHandler.showSuccess(
+          'A Digital Object Identifier (DOI) was successfully stored in this profile.'
+        );
         this.getDoiStatus();
-        this.loadUsedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
-        this.loadUnusedProfiles(this.catalogueItem.domainType, this.catalogueItem.id);
+        this.loadUsedProfiles(
+          this.catalogueItem.domainType,
+          this.catalogueItem.id
+        );
+        this.loadUnusedProfiles(
+          this.catalogueItem.domainType,
+          this.catalogueItem.id
+        );
         if (this.isDoiProfile) {
           // If the DOI profile is currently visible, refresh the view
           this.selectCustomProfile();
@@ -612,7 +809,8 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
       .openConfirmationAsync({
         data: {
           title: 'Confirm',
-          message: 'Are you sure you want to retire the Digital Object Identifier (DOI) for this catalogue item? Once retired, this cannot be undone.',
+          message:
+            'Are you sure you want to retire the Digital Object Identifier (DOI) for this catalogue item? Once retired, this cannot be undone.',
           okBtnTitle: 'Yes, retire',
           cancelBtnTitle: 'No',
           btnType: 'warn'
@@ -625,15 +823,21 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
             this.catalogueItem.id,
             {
               submissionType: 'retire'
-            });
+            }
+          );
         }),
-        catchError(error => {
-          this.messageHandler.showError('There was a problem retiring the Digital Object Identifier (DOI).', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem retiring the Digital Object Identifier (DOI).',
+            error
+          );
           return EMPTY;
         })
       )
       .subscribe(() => {
-        this.messageHandler.showSuccess('The Digital Object Identifier (DOI) was successfully retired.');
+        this.messageHandler.showSuccess(
+          'The Digital Object Identifier (DOI) was successfully retired.'
+        );
         this.getDoiStatus();
         if (this.isDoiProfile) {
           // If the DOI profile is currently visible, refresh the view
@@ -643,108 +847,137 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   }
 
   private loadDefaultCustomProfile(properties: ApiProperty[]) {
-    this.defaultProfileMetadataNamespace = this.getContentProperty(properties, this.defaultProfileNamespacePropertyKey);
-    this.useDefaultProfileSimplifiedEntry = (this.getContentProperty(properties, this.useDefaultProfileSimplifiedEntryPropertyKey) === 'true');
+    this.defaultProfileMetadataNamespace = this.getContentProperty(
+      properties,
+      this.defaultProfileNamespacePropertyKey
+    );
+    this.useDefaultProfileSimplifiedEntry =
+      this.getContentProperty(
+        properties,
+        this.useDefaultProfileSimplifiedEntryPropertyKey
+      ) === 'true';
   }
 
   private getContentProperty(properties: ApiProperty[], key: string): string {
-    return properties?.find(p => p.key === key)?.value;
+    return properties?.find((p) => p.key === key)?.value;
   }
 
   private getCatalogueItemHierarchy() {
     let catalogueHierarchy = [];
-    catalogueHierarchy.push({id: this.catalogueItem.id,
-      domainType: this.catalogueItem.domainType});
+    catalogueHierarchy.push({
+      id: this.catalogueItem.id,
+      domainType: this.catalogueItem.domainType
+    });
     if (this.catalogueItem.hasOwnProperty('breadcrumbs')) {
-      catalogueHierarchy = catalogueHierarchy.concat(this.catalogueItem.breadcrumbs.map(breadcrumb => {
-          return {id: breadcrumb.id, domainType: breadcrumb.domainType};
-      }));
+      catalogueHierarchy = catalogueHierarchy.concat(
+        this.catalogueItem.breadcrumbs.map((breadcrumb) => {
+          return { id: breadcrumb.id, domainType: breadcrumb.domainType };
+        })
+      );
     }
 
     return catalogueHierarchy;
   }
 
   private loadDefaultProfilePropertyValue(
-       domainType: CatalogueItemDomainType,
-       id: any) {
+    domainType: CatalogueItemDomainType,
+    id: any
+  ) {
+    const catalogueHierarchy = this.getCatalogueItemHierarchy();
 
-      const catalogueHierarchy = this.getCatalogueItemHierarchy();
+    // Get metadata for each catalogueItem in the hierarchy
+    const options = this.gridService.constructOptions(20, 0, null, null, null);
+    // const request: Observable<any> =
+    this.resources.profile.otherMetadata(domainType, id, options);
 
-      // Get metadata for each catalogueItem in the hierarchy
-      const options = this.gridService.constructOptions(20, 0, null, null, null);
-      // const request: Observable<any> =
-      this.resources.profile.otherMetadata(
-        domainType,
-        id,
-        options);
+    const properties = from(catalogueHierarchy).pipe(
+      catchError((error) => {
+        this.messageHandler.showError(
+          'There was a problem getting the list of other properties.',
+          error
+        );
+        return EMPTY;
+      }),
+      mergeMap((param) => this.getPropertiesFromCatalogueItem(param))
+    );
 
-      const properties = from(catalogueHierarchy).pipe(
-        catchError(error => {
-          this.messageHandler.showError('There was a problem getting the list of other properties.', error);
-          return EMPTY;
-        }),
-        mergeMap(param => this.getPropertiesFromCatalogueItem(param))
-      );
+    const observable = zip(properties);
 
-
-      const observable = zip(
-        properties
-      );
-
-      let responses = [];
-      const subject = new Subject<any>();
-      observable.subscribe({
-        next: defaultProfileProperties => {
-          const namespace = defaultProfileProperties[0].find(property => property.key === 'namespace');
-          const name = defaultProfileProperties[0].find(property => property.key === 'name');
-          const version = defaultProfileProperties[0].find(property => property.key === 'version');
-          if (!this.useDefaultProfileSimplifiedEntry &&
-              namespace !== undefined && name !== undefined && version !== undefined) {
-            responses = this.usedProfiles.filter(usedProfile =>
-              usedProfile.namespace === namespace.value && usedProfile.name === name.value && usedProfile.version === version.value
-            ).concat(responses);
-
-          } else {
-            for (const property_item of defaultProfileProperties[0]) {
-              if (property_item !== undefined ) {//
-                responses = this.usedProfiles.filter(usedProfile =>
-                  ((decodeURIComponent(usedProfile.name) + '/' + usedProfile.version) === property_item.value)
-                ).concat(responses);
-              }
+    let responses = [];
+    const subject = new Subject<any>();
+    observable.subscribe({
+      next: (defaultProfileProperties) => {
+        const namespace = defaultProfileProperties[0].find(
+          (property) => property.key === 'namespace'
+        );
+        const name = defaultProfileProperties[0].find(
+          (property) => property.key === 'name'
+        );
+        const version = defaultProfileProperties[0].find(
+          (property) => property.key === 'version'
+        );
+        if (
+          !this.useDefaultProfileSimplifiedEntry &&
+          namespace !== undefined &&
+          name !== undefined &&
+          version !== undefined
+        ) {
+          responses = this.usedProfiles
+            .filter(
+              (usedProfile) =>
+                usedProfile.namespace === namespace.value &&
+                usedProfile.name === name.value &&
+                usedProfile.version === version.value
+            )
+            .concat(responses);
+        } else {
+          for (const property_item of defaultProfileProperties[0]) {
+            if (property_item !== undefined) {
+              //
+              responses = this.usedProfiles
+                .filter(
+                  (usedProfile) =>
+                    decodeURIComponent(usedProfile.name) +
+                      '/' +
+                      usedProfile.version ===
+                    property_item.value
+                )
+                .concat(responses);
             }
           }
-        },
-        complete: () => {
-          subject.next(responses);
-        },
-      });
+        }
+      },
+      complete: () => {
+        subject.next(responses);
+      }
+    });
 
-      return subject.asObservable();
-    }
+    return subject.asObservable();
+  }
 
-    private getPropertiesFromCatalogueItem(param) {
-      const options = this.gridService.constructOptions(20, 0, null, null, null);
-      const request: Observable<any> =
-        this.resources.profile.otherMetadata(
-            param.domainType,
-            param.id,
-            options);
+  private getPropertiesFromCatalogueItem(param) {
+    const options = this.gridService.constructOptions(20, 0, null, null, null);
+    const request: Observable<any> = this.resources.profile.otherMetadata(
+      param.domainType,
+      param.id,
+      options
+    );
 
-      return request.pipe(
-        catchError(error => {
-           this.messageHandler.showError('There was a problem getting the list of other properties.', error);
-           return EMPTY;
-        }),
-        map((data: any) => {
-           const tempItems = data.body.items;
-           const items = tempItems.filter( o => (
-             o.namespace === this.defaultProfileMetadataNamespace)
-             );
-           return items;
-        })
-      );
-    }
-
+    return request.pipe(
+      catchError((error) => {
+        this.messageHandler.showError(
+          'There was a problem getting the list of other properties.',
+          error
+        );
+        return EMPTY;
+      }),
+      map((data: any) => {
+        const tempItems = data.body.items;
+        const items = tempItems.filter(
+          (o) => o.namespace === this.defaultProfileMetadataNamespace
+        );
+        return items;
+      })
+    );
+  }
 }
-
-

--- a/src/app/shared/profile-data-view/profile-data-view.model.ts
+++ b/src/app/shared/profile-data-view/profile-data-view.model.ts
@@ -17,12 +17,23 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import {Container, DataTypeReference, Modelable, ModelableDetail, Version} from '@maurodatamapper/mdm-resources';
-import { DefaultProfileControls, DefaultProfileItem, ProfileControlTypes } from '@mdm/model/defaultProfileModel';
+import {
+  Container,
+  DataTypeReference,
+  Modelable,
+  ModelableDetail,
+  Version
+} from '@maurodatamapper/mdm-resources';
+import {
+  DefaultProfileControls,
+  DefaultProfileItem,
+  ProfileControlTypes
+} from '@mdm/model/defaultProfileModel';
 
 export type ProfileDataViewType = 'default' | 'other' | 'addnew';
 
-export const doiProfileNamespace = 'uk.ac.ox.softeng.maurodatamapper.plugins.digitalobjectidentifiers.profile';
+export const doiProfileNamespace =
+  'uk.ac.ox.softeng.maurodatamapper.plugins.digitalobjectidentifiers.profile';
 
 export interface ProfileSummaryListItem {
   display: string;
@@ -30,9 +41,13 @@ export interface ProfileSummaryListItem {
   namespace: string;
   name: string;
   version: Version;
+  editableAfterFinalisation?: boolean;
 }
 
-export const showControl = (controls: string[], controlName: string): boolean => {
+export const showControl = (
+  controls: string[],
+  controlName: string
+): boolean => {
   return controls.findIndex((x) => x === controlName) !== -1;
 };
 
@@ -40,7 +55,8 @@ export const createDefaultProfileItem = (
   value: string | Container[] | string[] | DataTypeReference,
   displayName: string,
   controlType: ProfileControlTypes,
-  propertyName: string): DefaultProfileItem => {
+  propertyName: string
+): DefaultProfileItem => {
   return {
     controlType,
     displayName,
@@ -51,9 +67,12 @@ export const createDefaultProfileItem = (
 
 export const getDefaultProfileData = (
   catalogueItem: Modelable & ModelableDetail & { [key: string]: any },
-  descriptionOnly: boolean): DefaultProfileItem[] => {
+  descriptionOnly: boolean
+): DefaultProfileItem[] => {
   const items: DefaultProfileItem[] = [];
-  const controls = DefaultProfileControls.renderControls(catalogueItem.domainType);
+  const controls = DefaultProfileControls.renderControls(
+    catalogueItem.domainType
+  );
 
   if (showControl(controls, 'code')) {
     items.push(
@@ -100,7 +119,10 @@ export const getDefaultProfileData = (
     );
   }
 
-  if ('organisation' in catalogueItem && showControl(controls, 'organisation')) {
+  if (
+    'organisation' in catalogueItem &&
+    showControl(controls, 'organisation')
+  ) {
     items.push(
       createDefaultProfileItem(
         catalogueItem.organisation,


### PR DESCRIPTION
* Show edit profile button for profiles that are editable after finalisation
* Make individual profile fields readonly under conditions: if profile field is uneditable, or if item is finalised but profile field is editable after finalisation it overrides the readonly state
* Display info messages when item is finalised to make it clear to users
* Allow certain profiles to be added after finalisation. Only profiles with the editableAfterFinalisation flag can still be added

# Screenshots

Item is finalised but can still edit parts of this profile:

![image](https://user-images.githubusercontent.com/3219480/188167030-dde34c01-5060-487f-82f6-8ba11ed8929b.png)

![image](https://user-images.githubusercontent.com/3219480/188167055-6335c343-7b05-4129-9744-5fbc75651dbf.png)

Add further profiles to a finalised item, but only suitable profiles:

![image](https://user-images.githubusercontent.com/3219480/188167195-eeea05af-0cfa-47ab-9929-89f68e15f1a1.png)
