### PR TITLE
gh-370 Allow User & Group access icon for finalized models

### DIFF
--- a/src/app/services/handlers/security-handler.service.spec.ts
+++ b/src/app/services/handlers/security-handler.service.spec.ts
@@ -27,7 +27,7 @@ import { MdmResourcesService } from '@mdm/modules/resources';
 import { UserDetails } from './security-handler.model';
 import { cold } from 'jest-marbles';
 import { HttpErrorResponse } from '@angular/common/http';
-import { LoginPayload } from '@maurodatamapper/mdm-resources';
+import { LoginPayload, Securable } from '@maurodatamapper/mdm-resources';
 
 interface MdmSecurityResourceStub {
   login: jest.Mock;
@@ -118,5 +118,15 @@ describe('SecurityHandlerService', () => {
     const expected$ = cold('--#');
     const actual$ = service.signIn({ username: 'fail', password: 'fail' });
     expect(actual$).toBeObservable(expected$);
+  });
+
+  it('should return showPermission when element is editable after finalization', () => {
+    const dataModel: Securable = {
+      availableActions: ['finalisedEditActions']
+    };
+    const actual$ = service.elementAccess(
+      dataModel
+    );
+   expect(actual$.showPermission).toBeTruthy();
   });
 });

--- a/src/app/services/handlers/security-handler.service.ts
+++ b/src/app/services/handlers/security-handler.service.ts
@@ -320,7 +320,7 @@ export class SecurityHandlerService {
       showEdit: element.availableActions?.includes('update'),
       canEditDescription: element.availableActions?.includes('editDescription'),
       showFinalise: element.availableActions?.includes('finalise'),
-      showPermission: element.availableActions?.includes('update'),
+      showPermission: element.availableActions?.includes('update') || element.availableActions?.includes('finalisedEditActions'),
       showSoftDelete: element.availableActions?.includes('softDelete'),
       showPermanentDelete: element.availableActions?.includes('delete'),
       canAddAnnotation: element.availableActions?.includes('comment'),


### PR DESCRIPTION
gh-370 Updated the UI to show the Allow User & Group access icon when an element as the available action of finalisedEditActions. This will show the icon for finalized data models.

https://github.com/MauroDataMapper/mdm-core/issues/370