### PR TITLE
gh-675 Show / Hide edit after finalization alerts

### DIFF
--- a/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
+++ b/src/app/modals/edit-profile-modal/edit-profile-modal.component.html
@@ -29,7 +29,7 @@ SPDX-License-Identifier: Apache-2.0
     enctype="multipart/form-data"
     method="POST"
   >
-    <mdm-alert *ngIf="data.finalised" alertStyle="info" showIcon="true">
+    <mdm-alert *ngIf="data.finalised && showCanEditPropertyAlert" alertStyle="info" showIcon="true">
       Only certain fields can be edited on this profile as the catalogue item is
       finalised.
     </mdm-alert>

--- a/src/app/model/api-properties.ts
+++ b/src/app/model/api-properties.ts
@@ -312,5 +312,13 @@ export const propertyMetadata: ApiPropertyMetadata[] = [
     isSystem: true,
     publiclyVisible: true,
     requiresReload: true
+  },
+  {
+    key: 'ui.show_can_edit_property_alert',
+    category: 'UI',
+    editType: ApiPropertyEditType.Boolean,
+    isSystem: true,
+    publiclyVisible: true,
+    requiresReload: true
   }
 ];

--- a/src/app/shared/profile-data-view/profile-data-view.component.html
+++ b/src/app/shared/profile-data-view/profile-data-view.component.html
@@ -191,7 +191,7 @@ SPDX-License-Identifier: Apache-2.0
   </div>
 
   <mdm-alert
-    *ngIf="catalogueItem.finalised && canEditCustomProfile"
+    *ngIf="catalogueItem.finalised && canEditCustomProfile && showCanEditPropertyAlert"
     alertStyle="info"
     showIcon="true"
   >

--- a/src/app/shared/profile-data-view/profile-data-view.component.ts
+++ b/src/app/shared/profile-data-view/profile-data-view.component.ts
@@ -121,11 +121,15 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
   defaultProfileView: string;
   otherDefaultProfileView: string;
   useDefaultProfileSimplifiedEntry = false;
+  showCanEditPropertyAlert = true;
 
   private readonly defaultProfileNamespacePropertyKey =
     'ui.default.profile.namespace';
   private readonly useDefaultProfileSimplifiedEntryPropertyKey =
     'ui.default.profile.simplified_entry';
+  private readonly showCanEditPropertyAlertKey =
+    'ui.show_can_edit_property_alert';
+
 
   get canEditCustomProfile() {
     if (
@@ -856,6 +860,11 @@ export class ProfileDataViewComponent implements OnInit, OnChanges {
         properties,
         this.useDefaultProfileSimplifiedEntryPropertyKey
       ) === 'true';
+
+    this.showCanEditPropertyAlert =
+      JSON.parse(this.getContentProperty(properties,
+        this.showCanEditPropertyAlertKey));
+
   }
 
   private getContentProperty(properties: ApiProperty[], key: string): string {


### PR DESCRIPTION
gh-675 Added configuration that can hide the edit after finalization alerts found on profile edit and details screens.

config key: ui.show_can_edit_property_alert
default value: true
category: UI