### PR TITLE
gh-371 Add filtering for classifier elements screen

### DIFF
--- a/src/app/services/element-types.service.ts
+++ b/src/app/services/element-types.service.ts
@@ -153,8 +153,8 @@ export class ElementTypesService {
       title: 'DataType (Reference)',
       baseTitle: 'DataType',
       markdown: 'dt',
-      classifiable: true,
       displayLabel: 'Reference',
+      classifiable: true,
       domainName: 'referenceTypes'
     },
     {
@@ -163,8 +163,8 @@ export class ElementTypesService {
       title: 'DataType (ModelDataType)',
       baseTitle: 'DataType',
       markdown: 'mdt',
-      classifiable: true,
       displayLabel: 'ModelDataType',
+      classifiable: true,
       domainName: 'modelDataTypes'
     },
     {

--- a/src/app/services/element-types.service.ts
+++ b/src/app/services/element-types.service.ts
@@ -154,6 +154,7 @@ export class ElementTypesService {
       baseTitle: 'DataType',
       markdown: 'dt',
       classifiable: true,
+      displayLabel: 'Reference',
       domainName: 'referenceTypes'
     },
     {
@@ -163,6 +164,7 @@ export class ElementTypesService {
       baseTitle: 'DataType',
       markdown: 'mdt',
       classifiable: true,
+      displayLabel: 'ModelDataType',
       domainName: 'modelDataTypes'
     },
     {

--- a/src/app/services/element-types.service.ts
+++ b/src/app/services/element-types.service.ts
@@ -153,7 +153,6 @@ export class ElementTypesService {
       title: 'DataType (Reference)',
       baseTitle: 'DataType',
       markdown: 'dt',
-      displayLabel: 'Reference',
       classifiable: true,
       domainName: 'referenceTypes'
     },
@@ -163,7 +162,6 @@ export class ElementTypesService {
       title: 'DataType (ModelDataType)',
       baseTitle: 'DataType',
       markdown: 'mdt',
-      displayLabel: 'ModelDataType',
       classifiable: true,
       domainName: 'modelDataTypes'
     },
@@ -291,7 +289,24 @@ export class ElementTypesService {
       markdown: 'dt',
       classifiable: true
     },
-
+    PrimitiveType: {
+      id: 'PrimitiveType',
+      link: 'dataType',
+      title: 'PrimitiveType',
+      resourceName: 'dataType',
+      domainName: 'dataTypes',
+      markdown: 'dt',
+      classifiable: true
+    },
+    EnumerationType: {
+      id: 'EnumerationType',
+      link: 'dataType',
+      title: 'EnumerationType',
+      resourceName: 'dataType',
+      domainName: 'dataTypes',
+      markdown: 'dt',
+      classifiable: true
+    },
     Classifier: {
       id: 'Classifier',
       link: 'classifier',

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.html
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.html
@@ -4,6 +4,7 @@ and Health and Social Care Information Centre, also known as NHS Digital
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
@@ -64,20 +65,45 @@ SPDX-License-Identifier: Apache-2.0
                 </div>
             </td>
         </ng-container>
-        <ng-container matColumnDef="type">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header="domainType" [disabled]="!hideFilters" style="cursor:pointer;max-width: 15%;width: 15%; text-align: center;" columnName="type" scope="col">
+        <ng-container matColumnDef="domainType">
+            <th mat-header-cell
+                *matHeaderCellDef
+                mat-sort-header
+                [disabled]="!hideFilters"
+                style="cursor:pointer;max-width: 15%;width: 15%; text-align: center;"
+                columnName="domainType"
+                sortable="true"
+                filterable="true"
+                scope="col">
                 <span [hidden]="!hideFilters">Type</span>
                 <div [hidden]="hideFilters">
-                  <mat-form-field class="filter" floatLabel="never">
-                    <mat-label>Type</mat-label>
-                    <input #filters matInput name="domainType" (keyup)="applyFilter()">
-                  </mat-form-field>
+                  <mat-label>Type</mat-label>
+                  <mat-select
+                    [(value)]="domainType"
+                    name="domainType"
+                    [(ngModel)]="domainType"
+                    (ngModelChange)="applyMatSelectFilter()"
+                  >
+                    <mat-option [value]="dt" *ngFor="let dt of allDataTypes">{{
+                      dt.title
+                      }}</mat-option>
+                  </mat-select>
                 </div>
             </th>
-            <td mat-cell *matCellDef="let record" style="max-width: 15%;width: 15%;text-align: left;word-wrap: break-word;" >
-                <mdm-element-link [element]="record" [showLink]="false" [showTypeTitle]="true" [showTypeId]="true"></mdm-element-link>
+            <td mat-cell *matCellDef="let record">
+              <div *ngIf="allDataTypesMap[record?.domainType]?.title">
+                {{ allDataTypesMap[record?.domainType]['title'] }}
+              </div>
+              <div class="full-width">
+                <mdm-element-data-type
+                  [elementDataType]="record"
+                  [hideName]="true"
+                  [onlyShowRefDataClass]="true"
+                  [hideEnumList]="false"
+                ></mdm-element-data-type>
+              </div>
             </td>
-        </ng-container>
+          </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.html
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.html
@@ -102,7 +102,7 @@ SPDX-License-Identifier: Apache-2.0
                 ></mdm-element-data-type>
               </div>
             </td>
-          </ng-container>
+        </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.html
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.html
@@ -67,19 +67,15 @@ SPDX-License-Identifier: Apache-2.0
         <ng-container matColumnDef="type">
             <th mat-header-cell *matHeaderCellDef mat-sort-header="domainType" [disabled]="!hideFilters" style="cursor:pointer;max-width: 15%;width: 15%; text-align: center;" columnName="type" scope="col">
                 <span [hidden]="!hideFilters">Type</span>
-                <!-- <div [hidden]="hideFilters">
+                <div [hidden]="hideFilters">
+                  <mat-form-field class="filter" floatLabel="never">
                     <mat-label>Type</mat-label>
-                    <mat-select [(value)]="domainType"
-                                name="domainType"
-                                [(ngModel)]="domainType"
-                                (ngModelChange)="applyMatSelectFilter($event, 'domainType')">
-                        <mat-option></mat-option>
-                        <mat-option [value]="baseType.id" *ngFor="let baseType of classifiableBaseTypes">{{baseType.title}}</mat-option>
-                    </mat-select>
-                </div> -->
+                    <input #filters matInput name="domainType" (keyup)="applyFilter()">
+                  </mat-form-field>
+                </div>
             </th>
             <td mat-cell *matCellDef="let record" style="max-width: 15%;width: 15%;text-align: left;word-wrap: break-word;" >
-                <mdm-element-link [element]="record" [showLink]="false" [showTypeTitle]="true"></mdm-element-link>
+                <mdm-element-link [element]="record" [showLink]="false" [showTypeTitle]="true" [showTypeId]="true"></mdm-element-link>
             </td>
         </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.html
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.html
@@ -4,7 +4,6 @@ and Health and Social Care Information Centre, also known as NHS Digital
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.ts
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.ts
@@ -62,8 +62,8 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
   loading: boolean;
   totalItemCount = 0;
   isLoadingResults = true;
-  filterEvent = new EventEmitter<string>();
-  filter: string;
+  filterEvent = new EventEmitter<any>();
+  filter: {};
   deleteInProgress: boolean;
   domainType;
 
@@ -136,14 +136,11 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
       const value = x.nativeElement.value;
 
       if (value !== '') {
-        filter += `${name}=${value}&`;
+        filter[name] = value;
       }
     });
 
-    if (this.filterValue !== null && this.filterValue !== undefined && this.filterName !== null && this.filterName !== undefined) {
-      filter += `${this.filterName}=${this.filterValue}&`;
-    }
-    this.filter = filter.substring(0, filter.length - 1);
+    this.filter = filter;;
     this.filterEvent.emit(filter);
   };
 

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.ts
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.ts
@@ -135,7 +135,6 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
   }
 
   applyFilter = () => {
-    debugger;
     const filter = {};
     this.filters.forEach((x: any) => {
       const name = x.nativeElement.name;

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.ts
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.ts
@@ -130,7 +130,7 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
   }
 
   applyFilter = () => {
-    const filter: any = '';
+    const filter = {}
     this.filters.forEach((x: any) => {
       const name = x.nativeElement.name;
       const value = x.nativeElement.value;

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.ts
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.ts
@@ -52,6 +52,8 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
   @ViewChild(MatSort, { static: false }) sort: MatSort;
   @ViewChild(MdmPaginatorComponent, { static: true }) paginator: MdmPaginatorComponent;
 
+  allDataTypes: any;
+  allDataTypesMap: any;
   checkAllCheckbox = false;
   processing: boolean;
   failCount: number;
@@ -79,7 +81,7 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
     private gridService: GridService
   ) { }
   ngOnInit(): void {
-    this.displayedColumns = ['label', 'description', 'type'];
+    this.displayedColumns = ['label', 'description', 'domainType'];
     this.isLoadingResults = false;
   }
 
@@ -91,6 +93,9 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
 
     this.classifiableBaseTypes = this.baseTypes.filter(f => f.classifiable === true);
     this.classifiableBaseTypes = [{ id: '', title: '' }].concat(this.classifiableBaseTypes);
+
+    this.allDataTypes = this.classifiableBaseTypes;
+    this.allDataTypesMap = this.getClassifiableBaseTypesMap();
 
     merge(this.sort.sortChange, this.paginator.page, this.filterEvent).pipe(startWith({}), switchMap(() => {
       this.isLoadingResults = true;
@@ -130,27 +135,40 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
   }
 
   applyFilter = () => {
-    const filter = {}
+    debugger;
+    const filter = {};
     this.filters.forEach((x: any) => {
       const name = x.nativeElement.name;
       const value = x.nativeElement.value;
-
       if (value !== '') {
         filter[name] = value;
       }
     });
 
+    if (this.domainType) {
+      if (this.domainType.id !== 'DataType') {
+        filter['domainType'] = this.domainType.id;
+      }
+    }
+
     this.filter = filter;
     this.filterEvent.emit(filter);
   };
 
-  applyMatSelectFilter(filterValue: any, filterName) {
-    this.filterValue = filterValue;
-    if (this.filterValue !== '') { this.filterName = filterName; } else { this.filterName = ''; }
+  applyMatSelectFilter() {
     this.applyFilter();
   }
 
   filterClick = () => {
     this.hideFilters = !this.hideFilters;
   };
+
+  getClassifiableBaseTypesMap() {
+    const dataTypes = this.allDataTypes;
+    const dtMap = {};
+    dataTypes.forEach((dt) => {
+      dtMap[dt.id] = dt;
+    });
+    return dtMap;
+  }
 }

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.ts
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.ts
@@ -130,7 +130,7 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
   }
 
   applyFilter = () => {
-    let filter: any = '';
+    const filter: any = '';
     this.filters.forEach((x: any) => {
       const name = x.nativeElement.name;
       const value = x.nativeElement.value;
@@ -140,7 +140,7 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
       }
     });
 
-    this.filter = filter;;
+    this.filter = filter;
     this.filterEvent.emit(filter);
   };
 

--- a/src/app/utility/element-link/element-link.component.ts
+++ b/src/app/utility/element-link/element-link.component.ts
@@ -38,6 +38,7 @@ export class ElementLinkComponent implements OnInit {
   @Input() showHref = true;
   @Input() showParentDataModelName: boolean;
   @Input() showLink = true;
+  @Input() showTypeId = false;
   @Output() selectedElementsChange = new EventEmitter<any[]>();
   elementVal: any;
 
@@ -119,9 +120,13 @@ export class ElementLinkComponent implements OnInit {
       this.element.domainType &&
       this.types.filter((x) => x.id === this.element.domainType)
     ) {
-      this.elementTypeTitle = this.types.filter(
-        (x) => x.id === this.element.domainType
-      )[0].title;
+      let allElementTypes = this.types.filter(
+                              x => x.id === this.element.domainType
+                            );
+      this.elementTypeTitle = allElementTypes[0].title;
+      if (allElementTypes[0].baseTitle == 'DataType' && this.showTypeId) {
+        this.elementTypeTitle = allElementTypes[0].id;
+      }
     }
   }
 

--- a/src/app/utility/element-link/element-link.component.ts
+++ b/src/app/utility/element-link/element-link.component.ts
@@ -38,7 +38,6 @@ export class ElementLinkComponent implements OnInit {
   @Input() showHref = true;
   @Input() showParentDataModelName: boolean;
   @Input() showLink = true;
-  @Input() showTypeId = false;
   @Output() selectedElementsChange = new EventEmitter<any[]>();
   elementVal: any;
 
@@ -120,13 +119,9 @@ export class ElementLinkComponent implements OnInit {
       this.element.domainType &&
       this.types.filter((x) => x.id === this.element.domainType)
     ) {
-      const allElementTypes = this.types.filter(
-                              x => x.id === this.element.domainType
-                            );
-      this.elementTypeTitle = allElementTypes[0].title;
-      if (allElementTypes[0].baseTitle === 'DataType' && this.showTypeId) {
-        this.elementTypeTitle = allElementTypes[0].id;
-      }
+      this.elementTypeTitle = this.types.filter(
+        (x) => x.id === this.element.domainType
+      )[0].title;
     }
   }
 

--- a/src/app/utility/element-link/element-link.component.ts
+++ b/src/app/utility/element-link/element-link.component.ts
@@ -120,11 +120,11 @@ export class ElementLinkComponent implements OnInit {
       this.element.domainType &&
       this.types.filter((x) => x.id === this.element.domainType)
     ) {
-      let allElementTypes = this.types.filter(
+      const allElementTypes = this.types.filter(
                               x => x.id === this.element.domainType
                             );
       this.elementTypeTitle = allElementTypes[0].title;
-      if (allElementTypes[0].baseTitle == 'DataType' && this.showTypeId) {
+      if (allElementTypes[0].baseTitle === 'DataType' && this.showTypeId) {
         this.elementTypeTitle = allElementTypes[0].id;
       }
     }


### PR DESCRIPTION
gh-371 Updated the classifier elements screen to show a filter text box for the Type column. Updated the element-link component with a new config property to show a domain type without the DataType prefix as users would use DataType as a filter value when filtering the results, and the elements' type value is not prefixed with DataType.