### PR TITLE
gh-375 Case insensitive Sorting for classifier elements

### DIFF
--- a/src/app/shared/classified-elements-list/classified-elements-list.component.ts
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.ts
@@ -126,6 +126,7 @@ export class ClassifiedElementsListComponent implements OnInit, AfterViewInit {
     filters?
   ): Observable<any> {
     const options = this.gridService.constructOptions(pageSize, pageIndex, sortBy, sortType, filters);
+    options['ignoreCase'] = true;
     return this.resources.classifier.listCatalogueItemsFor(this.parent.id, options);
   }
 


### PR DESCRIPTION
gh-375 Set sorting to be case insensitive for classifier elements as catalogue items of different types may have different naming conventions - ie: all caps, sentence case or all lower case.