### PR TITLE
gh-680 Make footer stick to bottom of page

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -22,13 +22,13 @@ SPDX-License-Identifier: Apache-2.0
 
     <main ui-view></main>
 
-    <mdm-footer
-      class="app-footer"
-      [version]="appVersion"
-      [copyright]="copyright"
-      [links]="footerLinks"
-    ></mdm-footer>
-
     <mdm-loading-indicator></mdm-loading-indicator>
   </div>
+
+  <mdm-footer
+    class="app-footer"
+    [version]="appVersion"
+    [copyright]="copyright"
+    [links]="footerLinks"
+  ></mdm-footer>
 </div>

--- a/src/app/shared/models/models.component.html
+++ b/src/app/shared/models/models.component.html
@@ -208,14 +208,7 @@ SPDX-License-Identifier: Apache-2.0
             </div>
           </div>
         </div>
-        <div
-          style="
-            width: 100%;
-            clear: left;
-            height: calc(100vh - 168px);
-            overflow-y: auto;
-          "
-        >
+        <div style="width: 100%; clear: left; overflow-y: auto">
           <div
             style="margin: 3px 0px 0px 0px"
             *ngIf="

--- a/src/index.html
+++ b/src/index.html
@@ -18,30 +18,60 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta contentType="text/html; charset=UTF-8" />
-        <meta charset="utf-8" />
-        <title>Mauro Data Mapper</title>
-        <!-- Chrome, Firefox OS and Opera -->
-        <meta name="theme-color" content="#002147">
-        <!-- Windows Phone -->
-        <meta name="msapplication-navbutton-color" content="#002147">
-        <!-- iOS Safari -->
-        <meta name="apple-mobile-web-app-status-bar-style" content="#002147">
-        <meta name="description" content="Use the Mauro Data Mapper platform to create shared documentation for your data, and to collaborate on the definition of new data models.  Developed by the University of Oxford in collaboration with NIHR and NHS Digital.">
-        <meta name="viewport" content="width=device-width">
-        <link rel="shortcut icon" type="image/png" href="assets/favicon.png" />
-        <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,600;0,700;1,400&display=block" rel="stylesheet">
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-        <link rel="stylesheet" href="https://unpkg.com/dmn-js@9.4.0/dist/assets/diagram-js.css">
-        <link rel="stylesheet" href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-shared.css">
-        <link rel="stylesheet" href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-drd.css">
-        <link rel="stylesheet" href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-decision-table.css">
-        <link rel="stylesheet" href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-decision-table-controls.css">
-        <link rel="stylesheet" href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-literal-expression.css">
-        <link rel="stylesheet" href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-font/css/dmn.css">
-    </head>
-    <body>
-        <mdm-ui-view></mdm-ui-view>
-    </body>
+  <head>
+    <meta contentType="text/html; charset=UTF-8" />
+    <meta charset="utf-8" />
+    <title>Mauro Data Mapper</title>
+    <!-- Chrome, Firefox OS and Opera -->
+    <meta name="theme-color" content="#002147" />
+    <!-- Windows Phone -->
+    <meta name="msapplication-navbutton-color" content="#002147" />
+    <!-- iOS Safari -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="#002147" />
+    <meta
+      name="description"
+      content="Use the Mauro Data Mapper platform to create shared documentation for your data, and to collaborate on the definition of new data models.  Developed by the University of Oxford in collaboration with NIHR and NHS Digital."
+    />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="shortcut icon" type="image/png" href="assets/favicon.png" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,wght@0,400;0,600;0,700;1,400&display=block"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/dmn-js@9.4.0/dist/assets/diagram-js.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-shared.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-drd.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-decision-table.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-decision-table-controls.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-js-literal-expression.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/dmn-js@9.4.0/dist/assets/dmn-font/css/dmn.css"
+    />
+  </head>
+  <body>
+    <mdm-ui-view class="page-content"></mdm-ui-view>
+  </body>
 </html>

--- a/src/style/_default.scss
+++ b/src/style/_default.scss
@@ -16,20 +16,42 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-html,
-body,
 .mdm-root,
 #mdm-ui,
 .mdm-ui-view {
   height: 100%;
 }
-body,
+
+/* use viewport-relative units to cover page fully */
+body {
+  height: 100vh;
+  width: 100vw;
+}
+
+/* include border and padding in element width and height */
+* {
+  box-sizing: border-box;
+}
+
+/* full-sized container that fills up the page */
+.page-content,
+.mdm-root {
+  height: 100%;
+  width: 100%;
+}
+
 .mdm-root {
   display: flex;
   flex-direction: column;
 }
-main {
+
+main,
+.mdm-app-component {
   flex: 1 0 auto;
+}
+
+.app-footer {
+  flex-shrink: 0;
 }
 
 strong {

--- a/src/style/_main.scss
+++ b/src/style/_main.scss
@@ -20,10 +20,10 @@ SPDX-License-Identifier: Apache-2.0
 /* Large Devices, Wide Screens */
 @media only screen and (max-width: 2400px) {
   .resizableLeft {
-    min-height: 800px;
+    //min-height: 800px;
   }
   .resizableRight {
-    min-height: 800px;
+    //min-height: 800px;
   }
   div.scrollPanel {
     max-height: 800px !important;
@@ -33,10 +33,10 @@ SPDX-License-Identifier: Apache-2.0
 /* Large Devices, Wide Screens */
 @media only screen and (max-width: 1200px) {
   .resizableLeft {
-    min-height: 800px;
+    //min-height: 800px;
   }
   .resizableRight {
-    min-height: 800px;
+    //min-height: 800px;
   }
   div.scrollPanel {
     max-height: 800px !important;
@@ -46,10 +46,10 @@ SPDX-License-Identifier: Apache-2.0
 /* Medium Devices, Desktops */
 @media only screen and (max-width: 992px) {
   .resizableLeft {
-    min-height: 400px;
+    //min-height: 400px;
   }
   .resizableRight {
-    min-height: 400px;
+    //min-height: 400px;
   }
   div.scrollPanel {
     max-height: 800px !important;
@@ -79,10 +79,10 @@ SPDX-License-Identifier: Apache-2.0
 /* Small Devices, Tablets */
 @media only screen and (max-width: 768px) {
   .resizableLeft {
-    min-height: 400px;
+    //min-height: 400px;
   }
   .resizableRight {
-    min-height: 400px;
+    //min-height: 400px;
   }
   div.scrollPanel {
     max-height: 800px !important;
@@ -92,10 +92,10 @@ SPDX-License-Identifier: Apache-2.0
 @media only screen and (max-width: 480px) {
   /* CSS goes here */
   .resizableLeft {
-    min-height: 400px;
+    //min-height: 400px;
   }
   .resizableRight {
-    min-height: 400px;
+    //min-height: 400px;
   }
   div.scrollPanel {
     max-height: 800px !important;
@@ -106,10 +106,10 @@ SPDX-License-Identifier: Apache-2.0
 @media only screen and (max-width: 320px) {
   /* CSS goes here */
   .resizableLeft {
-    min-height: 400px;
+    //min-height: 400px;
   }
   .resizableRight {
-    min-height: 400px;
+    //min-height: 400px;
   }
   div.scrollPanel {
     max-height: 800px !important;


### PR DESCRIPTION
- When page contains additional space in content, footer will also attach to the bottom of the screen
- If the page height requires vertical scrolling, footer will always be at the end of the page
- Remove model tree forced height

Resolves #680 

![image](https://user-images.githubusercontent.com/3219480/204306185-b4830ba4-a048-417f-b093-a7183b4766ee.png)
