### PR TITLE
gh-709 Improvements to the Rules and Representations UI

### DIFF
--- a/src/app/constraints-rules/constraints-rules.component.html
+++ b/src/app/constraints-rules/constraints-rules.component.html
@@ -170,12 +170,12 @@ SPDX-License-Identifier: Apache-2.0
               <span
                 *ngIf="(record.ruleRepresentations?.length ?? 0) > 0"
                 [ngClass]="
-                  this.expandedElement === record
+                  this.expandedRuleId === record.id
                     ? 'fas fa-angle-double-up'
                     : 'fas fa-angle-double-down'
                 "
                 [matTooltip]="
-                  this.expandedElement === record ? 'Collapse' : 'Expand'
+                  this.expandedRuleId === record.id ? 'Collapse' : 'Expand'
                 "
               ></span>
             </button>
@@ -266,7 +266,7 @@ SPDX-License-Identifier: Apache-2.0
             <div
               class="example-element-detail"
               [@detailExpand]="
-                row == expandedElement ? 'expanded' : 'collapsed'
+                row.id == expandedRuleId ? 'expanded' : 'collapsed'
               "
             >
               <table

--- a/src/app/constraints-rules/constraints-rules.component.html
+++ b/src/app/constraints-rules/constraints-rules.component.html
@@ -24,59 +24,66 @@ SPDX-License-Identifier: Apache-2.0
         [hideToggle]="true"
         [expanded]="filteredOpen"
         class="prevent-click mat-elevation-z0"
-        (click)="clickButton=false"
+        (click)="clickButton = false"
       >
         <mat-expansion-panel-header>
+          <div
+            fxFlex
+            fxLayout="row"
+            fxLayout.md="row"
+            fxLayout.sm="row"
+            fxLayout.xs="column"
+            fxLayoutAlign="space-around"
+          >
             <div
               fxFlex
               fxLayout="row"
-              fxLayout.md="row"
-              fxLayout.sm="row"
-              fxLayout.xs="column"
-              fxLayoutAlign="space-around"
+              fxFlex="55"
+              fxFlex.md="55"
+              fxFlex.sm="55"
+              fxFlex.xs="100"
+              fxLayoutAlign="flex-start center"
             >
-              <div
-                fxFlex
-                fxLayout="row"
-                fxFlex="55"
-                fxFlex.md="55"
-                fxFlex.sm="55"
-                fxFlex.xs="100"
-                fxLayoutAlign="flex-start center"
-              >
-                <h4 class="marginless">
-                  Rules
-                  <span class="mdm--badge mdm--element-count">{{
-                    totalItemCount
-                  }}</span>
+              <h4 class="marginless">
+                Rules
+                <span class="mdm--badge mdm--element-count">{{
+                  totalItemCount
+                }}</span>
 
                 <span
                   class="fas fa-filter authorize-click"
                   (click)="$event.stopPropagation(); filterClick()"
                   matTooltip="Toggle search"
                 ></span>
-                </h4>
-              </div>
+              </h4>
+            </div>
 
-              <div
-                fxFlex
-                fxLayout="row"
-                fxFlex="45"
-                fxFlex.md="45"
-                fxFlex.sm="45"
-                fxFlex.xs="100"
-                fxLayoutAlign="flex-end center"
-                fxLayoutAlign.xs="flex-start center"
-              >
+            <div
+              fxFlex
+              fxLayout="row"
+              fxFlex="45"
+              fxFlex.md="45"
+              fxFlex.sm="45"
+              fxFlex.xs="100"
+              fxLayoutAlign="flex-end center"
+              fxLayoutAlign.xs="flex-start center"
+            >
               <div class="mt-1">
-               <button mat-flat-button color="primary" class="mr-1 mb-1 authorize-click" class="authorize-click" *ngIf="canAddRules" (click)=" $event.stopPropagation(); add()">
+                <button
+                  mat-flat-button
+                  color="primary"
+                  class="mr-1 mb-1 authorize-click"
+                  class="authorize-click"
+                  *ngIf="canAddRules"
+                  (click)="$event.stopPropagation(); add()"
+                >
                   <span class="fas fa-plus" aria-hidden="true"></span>
                   Add Rule
                 </button>
                 <button
                   mat-flat-button
                   color="primary"
-                  style="margin-left: 5px; z-index: 100;"
+                  style="margin-left: 5px; z-index: 100"
                   type="button"
                   (click)="exportAllRules()"
                   class="authorize-click"
@@ -84,8 +91,8 @@ SPDX-License-Identifier: Apache-2.0
                   <span class="fas fa-download"></span> Export
                 </button>
               </div>
-              </div>
             </div>
+          </div>
         </mat-expansion-panel-header>
         <mat-form-field appearance="outline" class="mb-2 full-width">
           <mat-label>Select Language</mat-label>
@@ -147,28 +154,31 @@ SPDX-License-Identifier: Apache-2.0
             </div>
           </td>
         </ng-container>
-        <ng-container matColumnDef="rule">
+        <ng-container matColumnDef="representations">
           <th
             mat-header-cell
             *matHeaderCellDef
-            style="max-width: 50%; width: 50%"
-            columnName="description"
+            style="max-width: 20%; width: 20%"
+            columnName="representations"
             scope="col"
           >
-            Rules
+            Representations
           </th>
           <td mat-cell *matCellDef="let record">
-            <div style="margin-bottom: 10px">
+            <button mat-button (click)="expandRow(record)">
+              {{ record.ruleRepresentations?.length ?? 0 }}
               <span
-                [ngClass]="(this.expandedElement === record) ? 'fas fa-angle-double-up' : 'fas fa-angle-double-down'"
-                (click)="expandRow(record)"
+                *ngIf="(record.ruleRepresentations?.length ?? 0) > 0"
+                [ngClass]="
+                  this.expandedElement === record
+                    ? 'fas fa-angle-double-up'
+                    : 'fas fa-angle-double-down'
+                "
+                [matTooltip]="
+                  this.expandedElement === record ? 'Collapse' : 'Expand'
+                "
               ></span>
-            </div>
-            <div>
-              <mdm-all-links-in-paged-list
-                [parent]="record"
-              ></mdm-all-links-in-paged-list>
-            </div>
+            </button>
           </td>
         </ng-container>
 
@@ -176,21 +186,42 @@ SPDX-License-Identifier: Apache-2.0
           <th
             mat-header-cell
             *matHeaderCellDef
-            style="cursor: pointer; max-width: 10%; width: 10%"
+            style="cursor: pointer; max-width: 20%; width: 20%"
             scope="col"
           ></th>
           <td
             mat-cell
             *matCellDef="let record"
-            style="max-width: 10%; width: 10%; text-align: center"
+            style="max-width: 20%; width: 20%; text-align: center"
           >
+            <button
+              mat-icon-button
+              color="primary"
+              type="button"
+              matTooltip="Edit"
+              *ngIf="canAddRules"
+              (click)="openEdit(record)"
+            >
+              <span class="fas fa-pencil-alt"></span>
+            </button>
+            <button
+              mat-icon-button
+              color="primary"
+              type="button"
+              matTooltip="Add representation"
+              *ngIf="canAddRules"
+              (click)="addRepresentation(record)"
+            >
+              <span class="fas fa-plus"></span>
+            </button>
             <button
               mat-icon-button
               color="primary"
               [matMenuTriggerFor]="dataTypeRowActions"
               aria-label="Mat menu actions"
             >
-            <span class="fas fa-ellipsis-v"></span> <span style="display: none;">Menu</span>
+              <span class="fas fa-ellipsis-v"></span>
+              <span style="display: none">Menu</span>
             </button>
             <mat-menu
               #dataTypeRowActions="matMenu"
@@ -199,25 +230,10 @@ SPDX-License-Identifier: Apache-2.0
               class="mdm--mat-menu--actions"
             >
               <button
-                mat-menu-item
-                color="accent"
-                type="button"
-                *ngIf="canAddRules"
-                (click)="openEdit(record)"
-              >
-                <span class="fas fa-pencil-alt"></span> Edit
-              </button>
-              <button
-                mat-menu-item
-                color="accent"
-                type="button"
-                *ngIf="canAddRules"
-                (click)="addRepresentation(record)"
-              >
-                <span class="fas fa-plus"></span> Add Representation
-              </button>
-              <mat-divider></mat-divider>
-              <button
+                *ngIf="
+                  record.ruleRepresentations &&
+                  record.ruleRepresentations.length > 0
+                "
                 mat-menu-item
                 color="accent"
                 type="button"
@@ -243,7 +259,7 @@ SPDX-License-Identifier: Apache-2.0
         <ng-container matColumnDef="expandedDetail">
           <td
             mat-cell
-            style="padding-top: 0px; padding-bottom: 0px;"
+            style="padding-top: 0px; padding-bottom: 0px"
             *matCellDef="let row"
             [attr.colspan]="displayedColumns.length"
           >
@@ -257,7 +273,7 @@ SPDX-License-Identifier: Apache-2.0
                 mat-table
                 #innerTable
                 [dataSource]="row.ruleRepresentations"
-                style="padding-top: 7px; padding-bottom: 7px;"
+                style="padding-top: 7px; padding-bottom: 7px"
                 class="mdm--mat-table mat-elevation-z3 table-striped"
               >
                 <ng-container matColumnDef="language">
@@ -300,21 +316,32 @@ SPDX-License-Identifier: Apache-2.0
                   <th
                     mat-header-cell
                     *matHeaderCellDef
-                    style="cursor: pointer; max-width: 10%; width: 10%"
+                    style="cursor: pointer; max-width: 15%; width: 15%"
                     scope="col"
                   ></th>
                   <td
                     mat-cell
                     *matCellDef="let record"
-                    style="max-width: 10%; width: 10%; text-align: center"
+                    style="max-width: 15%; width: 15%; text-align: center"
                   >
+                    <button
+                      mat-icon-button
+                      color="primary"
+                      type="button"
+                      matTooltip="Edit"
+                      *ngIf="canAddRules"
+                      (click)="openEditRepresentation(row, record)"
+                    >
+                      <span class="fas fa-pencil-alt"></span>
+                    </button>
                     <button
                       mat-icon-button
                       color="primary"
                       [matMenuTriggerFor]="dataTypeRowActions"
                       aria-label="Mat menu actions"
                     >
-                    <span class="fas fa-ellipsis-v"></span> <span style="display: none;">Menu</span>
+                      <span class="fas fa-ellipsis-v"></span>
+                      <span style="display: none">Menu</span>
                     </button>
                     <mat-menu
                       #dataTypeRowActions="matMenu"
@@ -326,17 +353,7 @@ SPDX-License-Identifier: Apache-2.0
                         mat-menu-item
                         color="accent"
                         type="button"
-                        *ngIf="canAddRules"
-                        (click)="openEditRepresentation(record)"
-                      >
-                        <span class="fas fa-pencil-alt"></span> Edit
-                      </button>
-                      <mat-divider></mat-divider>
-                      <button
-                        mat-menu-item
-                        color="accent"
-                        type="button"
-                        (click)="exportRuleRepresentation(record)"
+                        (click)="exportRuleRepresentation(row, record)"
                       >
                         <span class="fas fa-download"></span> Export
                       </button>
@@ -345,7 +362,7 @@ SPDX-License-Identifier: Apache-2.0
                         mat-menu-item
                         color="warn"
                         type="button"
-                        (click)="deleteRepresentation(record)"
+                        (click)="deleteRepresentation(row, record)"
                         class="warning"
                         *ngIf="canDeleteRules"
                       >

--- a/src/app/constraints-rules/constraints-rules.component.html
+++ b/src/app/constraints-rules/constraints-rules.component.html
@@ -280,7 +280,7 @@ SPDX-License-Identifier: Apache-2.0
                   <th
                     mat-header-cell
                     *matHeaderCellDef
-                    style="max-width: 35%; width: 35%"
+                    style="max-width: 20%; width: 20%"
                     columnName="language"
                     scope="col"
                   >
@@ -308,7 +308,10 @@ SPDX-License-Identifier: Apache-2.0
                   </th>
                   <td mat-cell class="truncate" *matCellDef="let record">
                     <div style="margin-bottom: 10px">
-                      {{ record.representation }}
+                      <mdm-more-description
+                        [description]="record.representation"
+                        type="preformatted"
+                      ></mdm-more-description>
                     </div>
                   </td>
                 </ng-container>

--- a/src/app/constraints-rules/constraints-rules.component.ts
+++ b/src/app/constraints-rules/constraints-rules.component.ts
@@ -16,38 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-
-export class BaseDataGrid {
-  displayedColumns: string[];
-  records: Array<RuleModel>;
-  totalItemCount: number;
-}
-
-export class RuleRepresentation {
-  id: string;
-  rule: RuleModel;
-  language: string;
-  representation: string;
-}
-
-export class RuleModel {
-  ruleRepresentations: Array<RuleRepresentation>;
-  name: string;
-  description: string;
-  id: string;
-
-  constructor(rule: Array<RuleRepresentation>, name: any, description: any) {
-    this.ruleRepresentations = rule;
-    this.name = name;
-    this.description = description;
-  }
-}
-
-export class RuleLanguage {
-  displayName: any;
-  value: any;
-}
-
 import {
   trigger,
   state,
@@ -57,19 +25,40 @@ import {
 } from '@angular/animations';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { AddRuleModalComponent } from '@mdm/modals/add-rule-modal/add-rule-modal.component';
+import {
+  AddRuleModalComponent,
+  AddRuleModalConfig,
+  AddRuleModalResult
+} from '@mdm/modals/add-rule-modal/add-rule-modal.component';
 import {
   AddRuleRepresentationModalComponent,
-  RuleLanguages
+  AddRuleRepresentationModalConfig,
+  AddRuleRepresentationModalResult,
+  RuleLanguage,
+  supportedLanguages
 } from '@mdm/modals/add-rule-representation-modal/add-rule-representation-modal.component';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { catchError, switchMap } from 'rxjs/operators';
+import { catchError, filter, finalize, switchMap } from 'rxjs/operators';
 import { MessageHandlerService } from '@mdm/services';
 import JSZip from 'jszip';
 import FileSaver from 'file-saver';
-import { Finalisable, Modelable } from '@maurodatamapper/mdm-resources';
+import {
+  FilterQueryParameters,
+  Finalisable,
+  Modelable,
+  Rule,
+  RuleDomainType,
+  RuleIndexResponse,
+  RulePayload,
+  RuleRepresentation,
+  RuleRepresentationIndexResponse,
+  RuleRepresentationPayload,
+  RuleResponse
+} from '@maurodatamapper/mdm-resources';
 import { EditingService } from '@mdm/services/editing.service';
 import { EMPTY } from 'rxjs';
+import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
+import ts from 'typescript';
 
 @Component({
   selector: 'mdm-constraints-rules',
@@ -89,14 +78,18 @@ import { EMPTY } from 'rxjs';
     ])
   ]
 })
-export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
+export class ConstraintsRulesComponent implements OnInit {
   @Input() parent: Modelable & Finalisable;
-  @Input() domainType: string;
+  @Input() domainType: RuleDomainType;
   @Output() totalCount = new EventEmitter<string>();
 
+  displayedColumns = ['name', 'description', 'representations', 'actions'];
+  records: Rule[];
+  totalItemCount: number;
+
   isLoadingResults: boolean;
-  expandedElement: any;
-  languages: Array<RuleLanguage>;
+  expandedElement: Rule;
+  languages: RuleLanguage[];
   selectedLanguage: RuleLanguage;
 
   clickButton = false;
@@ -105,32 +98,16 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
   canAddRules: boolean;
   canDeleteRules: boolean;
 
-  fileExtensions = {
-    'c#': 'cs',
-    dmn: 'dmn',
-    java: 'java',
-    javascript: 'js',
-    typescript: 'ts',
-    text: 'txt',
-    drools: 'drools',
-    sql: 'sql'
-  };
-
   constructor(
     public dialog: MatDialog,
     private editing: EditingService,
     protected resourcesService: MdmResourcesService,
     protected messageHandler: MessageHandlerService
   ) {
-    super();
-
-    this.languages = Object.assign([], RuleLanguages.supportedLanguages);
-    this.languages.sort((a: any, b: any) => {
-      return a - b;
-    });
+    this.languages = Object.assign([], supportedLanguages);
+    this.languages.sort((a, b) => a.displayName.localeCompare(b.displayName));
     this.languages.push({ displayName: 'All', value: 'all' });
     this.isLoadingResults = true;
-    this.displayedColumns = ['name', 'description', 'rule', 'actions'];
     this.selectedLanguage = this.languages.find((x) => x.value === 'all');
   }
 
@@ -140,181 +117,59 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
     this.canDeleteRules = !this.parent.finalised;
   }
 
-  expandRow = (record: RuleModel) => {
-    if (this.expandedElement === record) {
-      this.expandedElement = null;
-    } else {
-      this.expandedElement = record;
-      this.resourcesService.catalogueItem
-        .listRuleRepresentations(this.domainType, this.parent.id, record.id)
-        .subscribe((result) => {
-          const tempList: Array<RuleRepresentation> = [];
-
-          result.body.items.forEach((element: RuleRepresentation) => {
-            element['rule'] = record;
-            if (
-              this.selectedLanguage.value === 'all' ||
-              this.selectedLanguage.value === element.language
-            ) {
-              tempList.push(element);
-            }
-          });
-
-          record.ruleRepresentations = tempList;
-        });
+  expandRow(record: Rule) {
+    if ((record.ruleRepresentations?.length ?? 0) === 0) {
+      return;
     }
-  };
+
+    this.expandedElement = this.expandedElement === record ? null : record;
+  }
 
   add() {
-    this.clickButton = true;
-
-    this.editing
-      .openDialog(AddRuleModalComponent, {
-        data: {
-          name: '',
-          description: '',
-          modalTitle: 'Add New Rule',
-          okBtn: 'Add',
-          btnType: 'primary'
-        },
-        height: '1000px',
-        width: '1000px'
-      })
-      .afterClosed()
-      .subscribe((dialogResult) => {
-        this.clickButton = false;
-        if (dialogResult) {
-          const data = {
-            name: dialogResult.name,
-            description: dialogResult.description
-          };
-          this.resourcesService.catalogueItem
-            .saveRule(this.domainType, this.parent.id, data)
-            .subscribe(
-              (result) => {
-                const temp = Object.assign([], this.records);
-                temp.push(result.body);
-                this.records = temp;
-                this.totalItemCount = this.records.length;
-                this.totalCount.emit(String(this.totalItemCount));
-              },
-              (error) => {
-                this.messageHandler.showError(error);
-              }
-            );
-        } else {
-          return;
-        }
-      });
+    this.showRuleDialog('add');
   }
 
   loadRules() {
     this.resourcesService.catalogueItem
       .listRules(this.domainType, this.parent.id)
-      .subscribe(
-        (result) => {
-          this.records = result.body.items;
-          this.totalItemCount = result.body.count;
-          this.totalCount.emit(String(result.body.count));
-          this.isLoadingResults = false;
-        },
-        (error) => {
+      .pipe(
+        catchError((error) => {
           this.messageHandler.showError(error);
-          this.isLoadingResults = false;
-        }
-      );
-  }
-
-  openEdit(record: RuleModel): void {
-    if (record) {
-      this.editing
-        .openDialog(AddRuleModalComponent, {
-          data: {
-            name: record.name,
-            description: record.description,
-            modalTitle: 'Edit Rule',
-            okBtn: 'Apply',
-            btnType: 'primary'
-          },
-          height: '1000px',
-          width: '1000px'
-        })
-        .afterClosed()
-        .subscribe((dialogResult) => {
-          if (dialogResult) {
-            const data = {
-              name: dialogResult.name,
-              description: dialogResult.description
-            };
-            this.resourcesService.catalogueItem
-              .updateRule(this.domainType, this.parent.id, record.id, data)
-              .subscribe(
-                () => {
-                  this.messageHandler.showSuccess('Successfully Updated');
-                  this.loadRules();
-                },
-                (error) => {
-                  this.messageHandler.showError(error);
-                }
-              );
-          } else {
-            return;
-          }
-        });
-    }
-  }
-
-  openEditRepresentation(rep: RuleRepresentation) {
-    this.editing
-      .openDialog(AddRuleRepresentationModalComponent, {
-        data: {
-          language: rep.language,
-          representation: rep.representation,
-          modalTitle: 'Edit Rule Representation',
-          okBtn: 'Apply',
-          btnType: 'primary'
-        },
-        height: '1000px',
-        width: '1000px'
-      })
-      .afterClosed()
-      .subscribe((dialogResult) => {
-        if (dialogResult) {
-          const data = {
-            language: dialogResult.language,
-            representation: dialogResult.representation
-          };
-          this.resourcesService.catalogueItem
-            .updateRulesRepresentation(
-              this.domainType,
-              this.parent.id,
-              data,
-              rep.rule.id,
-              rep.id
-            )
-            .subscribe(
-              () => {
-                this.messageHandler.showSuccess('Successfully Updated');
-                this.expandRow(rep.rule);
-              },
-              (error) => {
-                this.messageHandler.showError(error);
-              }
-            );
-        } else {
-          return;
-        }
+          return EMPTY;
+        }),
+        finalize(() => (this.isLoadingResults = false))
+      )
+      .subscribe((response: RuleIndexResponse) => {
+        this.records = response.body.items;
+        this.totalItemCount = response.body.count;
+        this.totalCount.emit(String(response.body.count));
       });
   }
 
-  deleteRule(record: RuleModel) {
+  openEdit(rule: Rule) {
+    if (!rule) {
+      return;
+    }
+
+    this.showRuleDialog('edit', rule);
+  }
+
+  openEditRepresentation(rule: Rule, rep: RuleRepresentation) {
+    if (!rep) {
+      return;
+    }
+
+    this.showRepresentationDialog('edit', rule, rep);
+  }
+
+  deleteRule(rule: Rule) {
     this.dialog
       .openConfirmationAsync({
         data: {
-          title: 'Delete permanently',
+          title: 'Delete rule',
           okBtnTitle: 'Yes, delete',
           btnType: 'warn',
-          message: 'Are you sure you wish delete?'
+          message: `Are you sure you wish to delete the rule '${rule.name}'?`
         }
       })
       .pipe(
@@ -322,7 +177,7 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
           this.resourcesService.catalogueItem.removeRule(
             this.domainType,
             this.parent.id,
-            record.id
+            rule.id
           )
         ),
         catchError((error) => {
@@ -331,69 +186,31 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
         })
       )
       .subscribe(() => {
-        this.messageHandler.showSuccess('Successfully Deleted');
+        this.messageHandler.showSuccess('Rule was successfully deleted.');
         this.loadRules();
       });
   }
 
-  addRepresentation(rule: RuleModel): void {
-    this.editing
-      .openDialog(AddRuleRepresentationModalComponent, {
-        data: {
-          language: '',
-          representation: '',
-          modalTitle: 'Add Representation',
-          okBtn: 'Add',
-          btnType: 'primary'
-        },
-        height: '1000px',
-        width: '1000px'
-      })
-      .afterClosed()
-      .subscribe((dialogResult) => {
-        if (dialogResult) {
-          const data = {
-            language: dialogResult.language,
-            representation: dialogResult.representation
-          };
-          this.resourcesService.catalogueItem
-            .saveRulesRepresentation(
-              this.domainType,
-              this.parent.id,
-              data,
-              rule.id
-            )
-            .subscribe(
-              () => {
-                this.messageHandler.showSuccess('Rule Added Successfully');
-                this.expandRow(rule);
-              },
-              (error) => {
-                this.messageHandler.showError(error);
-              }
-            );
-        } else {
-          return;
-        }
-      });
+  addRepresentation(rule: Rule) {
+    this.showRepresentationDialog('add', rule);
   }
 
-  deleteRepresentation(record: RuleRepresentation) {
+  deleteRepresentation(rule: Rule, record: RuleRepresentation) {
     this.dialog
       .openConfirmationAsync({
         data: {
-          title: 'Delete permanently',
+          title: 'Delete rule representation',
           okBtnTitle: 'Yes, delete',
           btnType: 'warn',
-          message: 'Are you sure you wish delete?'
+          message: `Are you sure you wish to delete the rule representation '${record.language}' for the rule '${rule.name}'?`
         }
       })
       .pipe(
         switchMap(() =>
-          this.resourcesService.catalogueItem.removeRulesRepresentation(
+          this.resourcesService.catalogueItem.removeRuleRepresentation(
             this.domainType,
             this.parent.id,
-            record.rule.id,
+            rule.id,
             record.id
           )
         ),
@@ -403,28 +220,28 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
         })
       )
       .subscribe(() => {
-        this.messageHandler.showSuccess('Successfully Deleted');
-        this.expandRow(record.rule);
+        this.messageHandler.showSuccess(
+          'Rule representation was successfully deleted.'
+        );
+        this.loadRules();
       });
   }
 
-  filterClick = () => {
+  filterClick() {
     this.filteredOpen = !this.filteredOpen;
-  };
+  }
 
-  exportRuleRepresentation = (ruleRep: RuleRepresentation) => {
+  exportRuleRepresentation(rule: Rule, rep: RuleRepresentation) {
     try {
-      const myFilename = `${ruleRep.rule.name}.${
-        this.fileExtensions[ruleRep.language]
-      }`;
-      const content = new Blob([ruleRep.representation as BlobPart]);
+      const myFilename = `${rule.name}.${this.getFileExtension(rep.language)}`;
+      const content = new Blob([rep.representation as BlobPart]);
       FileSaver.saveAs(content, myFilename);
     } catch (error) {
       this.messageHandler.showError('Error Exporting', error);
     }
-  };
+  }
 
-  exportRule = (rule: any) => {
+  exportRule(rule: Rule) {
     const zip = new JSZip();
     let count = 0;
     const zipFilename = `${rule.name}.zip`;
@@ -439,14 +256,16 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
 
           let fileCount = 1;
           while (
-            zip.files[`${myFilename}.${this.fileExtensions[ruleRep.language]}`]
+            zip.files[
+              `${myFilename}.${this.getFileExtension(ruleRep.language)}`
+            ]
           ) {
             myFilename = `${myFilename}(${fileCount})`;
             fileCount++;
           }
 
           zip.file(
-            `${myFilename}.${this.fileExtensions[ruleRep.language]}`,
+            `${myFilename}.${this.getFileExtension(ruleRep.language)}`,
             ruleRep.representation
           );
           count++;
@@ -461,9 +280,9 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
     } catch (error) {
       this.messageHandler.showError('Error Exporting', error);
     }
-  };
+  }
 
-  exportAllRules = () => {
+  exportAllRules() {
     this.clickButton = true;
     const zip = new JSZip();
     let count = 0;
@@ -481,9 +300,9 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
               let fileCount = 1;
               while (
                 zip.files[
-                  `${rule.name}/${myFilename}.${
-                    this.fileExtensions[ruleRep.language]
-                  }`
+                  `${rule.name}/${myFilename}.${this.getFileExtension(
+                    ruleRep.language
+                  )}`
                 ]
               ) {
                 myFilename = `${myFilename}(${fileCount})`;
@@ -493,7 +312,7 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
               zip
                 .folder(`${rule.name}`)
                 .file(
-                  `${myFilename}.${this.fileExtensions[ruleRep.language]}`,
+                  `${myFilename}.${this.getFileExtension(ruleRep.language)}`,
                   ruleRep.representation
                 );
             }
@@ -512,30 +331,156 @@ export class ConstraintsRulesComponent extends BaseDataGrid implements OnInit {
     } catch (error) {
       this.messageHandler.showError('Error Exporting', error);
     }
-  };
+  }
 
-  selectedLanguageChange = () => {
+  selectedLanguageChange() {
     if (this.selectedLanguage.value === 'all') {
       this.loadRules();
       return;
     }
 
-    const data = {
+    const query: FilterQueryParameters = {
       language: this.selectedLanguage.value
     };
 
     this.resourcesService.catalogueItem
-      .listRules(this.domainType, this.parent.id, data)
-      .subscribe(
-        (result) => {
-          this.records = result.body.items;
-          this.totalItemCount = result.body.count;
-          this.isLoadingResults = false;
-        },
-        (error) => {
+      .listRules(this.domainType, this.parent.id, query)
+      .pipe(
+        catchError((error) => {
           this.messageHandler.showError(error);
-          this.isLoadingResults = false;
-        }
-      );
-  };
+          return EMPTY;
+        }),
+        finalize(() => (this.isLoadingResults = false))
+      )
+      .subscribe((response: RuleIndexResponse) => {
+        this.records = response.body.items;
+        this.totalItemCount = response.body.count;
+      });
+  }
+
+  private getFileExtension(language: string) {
+    const lang = supportedLanguages.find((lang) => lang.value === language);
+    return lang?.fileExt;
+  }
+
+  private showRuleDialog(mode: 'add' | 'edit', current?: Rule) {
+    this.clickButton = true;
+
+    this.editing
+      .openDialog<
+        AddRuleModalComponent,
+        AddRuleModalConfig,
+        AddRuleModalResult
+      >(AddRuleModalComponent, {
+        data: {
+          ...(current as RulePayload),
+          title: mode === 'edit' ? 'Edit Rule' : 'Add Rule',
+          okBtnTitle: mode === 'edit' ? 'Apply' : 'Create',
+          btnType: 'primary'
+        },
+        width: '1000px'
+      })
+      .afterClosed()
+      .pipe(
+        filter((result) => result.status === ModalDialogStatus.Ok),
+        switchMap((result) => {
+          if (mode === 'edit' && current) {
+            return this.resourcesService.catalogueItem.updateRule(
+              this.domainType,
+              this.parent.id,
+              current.id,
+              { name: result.name, description: result.description }
+            );
+          }
+
+          return this.resourcesService.catalogueItem.saveRule(
+            this.domainType,
+            this.parent.id,
+            { name: result.name, description: result.description }
+          );
+        }),
+        catchError((error) => {
+          this.messageHandler.showError(
+            `There was a problem ${
+              mode === 'edit' ? 'updating' : 'creating'
+            } the rule.`,
+            error
+          );
+          return EMPTY;
+        }),
+        finalize(() => (this.clickButton = false))
+      )
+      .subscribe(() => {
+        this.messageHandler.showSuccess(
+          `Rule was successfully ${mode === 'edit' ? 'updated' : 'created'}.`
+        );
+        this.loadRules();
+      });
+  }
+
+  private showRepresentationDialog(
+    mode: 'add' | 'edit',
+    rule: Rule,
+    current?: RuleRepresentation
+  ) {
+    this.clickButton = true;
+
+    this.editing
+      .openDialog<
+        AddRuleRepresentationModalComponent,
+        AddRuleRepresentationModalConfig,
+        AddRuleRepresentationModalResult
+      >(AddRuleRepresentationModalComponent, {
+        data: {
+          ...(current as RuleRepresentationPayload),
+          title: mode === 'edit' ? 'Edit Representation' : 'Add Representation',
+          okBtnTitle: mode === 'edit' ? 'Apply' : 'Create',
+          btnType: 'primary'
+        },
+        width: '1000px'
+      })
+      .afterClosed()
+      .pipe(
+        filter((result) => result.status === ModalDialogStatus.Ok),
+        switchMap((result) => {
+          if (mode === 'edit' && current) {
+            return this.resourcesService.catalogueItem.updateRuleRepresentation(
+              this.domainType,
+              this.parent.id,
+              rule.id,
+              current.id,
+              {
+                language: result.language,
+                representation: result.representation
+              }
+            );
+          }
+
+          return this.resourcesService.catalogueItem.saveRuleRepresentation(
+            this.domainType,
+            this.parent.id,
+            rule.id,
+            { language: result.language, representation: result.representation }
+          );
+        }),
+        catchError((error) => {
+          this.messageHandler.showError(
+            `There was a problem ${
+              mode === 'edit' ? 'updating' : 'creating'
+            } the rule representation.`,
+            error
+          );
+          return EMPTY;
+        }),
+        finalize(() => (this.clickButton = false))
+      )
+      .subscribe(() => {
+        this.messageHandler.showSuccess(
+          `Rule representation was successfully ${
+            mode === 'edit' ? 'updated' : 'created'
+          }.`
+        );
+        this.loadRules();
+      });
+  }
 }

--- a/src/app/constraints-rules/constraints-rules.component.ts
+++ b/src/app/constraints-rules/constraints-rules.component.ts
@@ -51,14 +51,11 @@ import {
   RuleIndexResponse,
   RulePayload,
   RuleRepresentation,
-  RuleRepresentationIndexResponse,
-  RuleRepresentationPayload,
-  RuleResponse
+  RuleRepresentationPayload
 } from '@maurodatamapper/mdm-resources';
 import { EditingService } from '@mdm/services/editing.service';
 import { EMPTY } from 'rxjs';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
-import ts from 'typescript';
 
 @Component({
   selector: 'mdm-constraints-rules',

--- a/src/app/constraints-rules/constraints-rules.component.ts
+++ b/src/app/constraints-rules/constraints-rules.component.ts
@@ -356,7 +356,7 @@ export class ConstraintsRulesComponent implements OnInit {
   }
 
   private getFileExtension(language: string) {
-    const lang = supportedLanguages.find((lang) => lang.value === language);
+    const lang = supportedLanguages.find((l) => l.value === language);
     return lang?.fileExt;
   }
 

--- a/src/app/constraints-rules/constraints-rules.component.ts
+++ b/src/app/constraints-rules/constraints-rules.component.ts
@@ -51,7 +51,8 @@ import {
   RuleIndexResponse,
   RulePayload,
   RuleRepresentation,
-  RuleRepresentationPayload
+  RuleRepresentationPayload,
+  Uuid
 } from '@maurodatamapper/mdm-resources';
 import { EditingService } from '@mdm/services/editing.service';
 import { EMPTY } from 'rxjs';
@@ -85,7 +86,7 @@ export class ConstraintsRulesComponent implements OnInit {
   totalItemCount: number;
 
   isLoadingResults: boolean;
-  expandedElement: Rule;
+  expandedRuleId: Uuid;
   languages: RuleLanguage[];
   selectedLanguage: RuleLanguage;
 
@@ -119,7 +120,7 @@ export class ConstraintsRulesComponent implements OnInit {
       return;
     }
 
-    this.expandedElement = this.expandedElement === record ? null : record;
+    this.expandedRuleId = this.expandedRuleId === record.id ? null : record.id;
   }
 
   add() {
@@ -479,6 +480,7 @@ export class ConstraintsRulesComponent implements OnInit {
             mode === 'edit' ? 'updated' : 'created'
           }.`
         );
+        this.expandedRuleId = rule.id;
         this.loadRules();
       });
   }

--- a/src/app/constraints-rules/constraints-rules.component.ts
+++ b/src/app/constraints-rules/constraints-rules.component.ts
@@ -434,7 +434,9 @@ export class ConstraintsRulesComponent implements OnInit {
           okBtnTitle: mode === 'edit' ? 'Apply' : 'Create',
           btnType: 'primary'
         },
-        width: '1000px'
+        width: '65%',
+        maxHeight: '98vh',
+        maxWidth: '98vw'
       })
       .afterClosed()
       .pipe(

--- a/src/app/modals/add-rule-modal/add-rule-modal.component.html
+++ b/src/app/modals/add-rule-modal/add-rule-modal.component.html
@@ -17,24 +17,43 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="modal-header pxy-2">
-    <h4 class='modal-title marginless'>{{modalTitle}}</h4>
+  <h4 class="modal-title marginless">{{ modalTitle }}</h4>
 </div>
-<div class="modal-body pxy-2">
-    <p [innerHtml]="message"></p>
+<form [formGroup]="formGroup">
+  <div class="modal-body pxy-2">
+    <p *ngIf="message" [innerHtml]="message"></p>
     <div class="mdm--form-input">
-        <mat-form-field appearance="outline" required  class="full-width paddingless">
-            <mat-label>Name</mat-label>
-            <input matInput [(ngModel)]="data.name">
-        </mat-form-field>
+      <mat-form-field appearance="outline" required class="full-width">
+        <mat-label>Name</mat-label>
+        <input matInput formControlName="name" />
+        <mat-error *ngIf="name.errors?.required"> Name is required </mat-error>
+      </mat-form-field>
     </div>
     <div class="mdm--form-input">
-        <mat-form-field appearance="outline" class="full-width paddingless">
-            <mat-label>Description</mat-label>
-            <input matInput [(ngModel)]="data.description">
-        </mat-form-field>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Description</mat-label>
+        <input matInput formControlName="description" />
+      </mat-form-field>
     </div>
-</div>
-<div class="modal-footer pxy-2">
-    <button mat-button color="warn" class="mr-1" type="button" mat-dialog-close>{{cancelBtn}}</button>
-    <button mat-flat-button color="{{btnType}}" type="button" [disabled]="data.name.length === 0 ||  data.description.length === 0" [mat-dialog-close]="data">{{okBtn}}</button>
-</div>
+  </div>
+  <div class="modal-footer pxy-2">
+    <button
+      mat-button
+      color="warn"
+      class="mr-1"
+      type="button"
+      (click)="cancel()"
+    >
+      {{ cancelBtn }}
+    </button>
+    <button
+      mat-flat-button
+      color="{{ btnType }}"
+      type="button"
+      [disabled]="!formGroup.valid"
+      (click)="confirm()"
+    >
+      {{ okBtn }}
+    </button>
+  </div>
+</form>

--- a/src/app/modals/add-rule-modal/add-rule-modal.component.ts
+++ b/src/app/modals/add-rule-modal/add-rule-modal.component.ts
@@ -18,7 +18,26 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
+
+export interface AddRuleModalConfig {
+  name: string;
+  description?: string;
+  title?: string;
+  message?: string;
+  okBtnTitle?: string;
+  cancelBtnTitle?: string;
+  cancelShown?: boolean;
+  btnType?: string;
+}
+
+export interface AddRuleModalResult {
+  status: ModalDialogStatus;
+  name?: string;
+  description?: string;
+}
 
 @Component({
   selector: 'mdm-add-rule-modal',
@@ -26,32 +45,56 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
   styleUrls: ['./add-rule-modal.component.scss']
 })
 export class AddRuleModalComponent implements OnInit {
-
   okBtn: string;
   cancelBtn: string;
   btnType: string;
-  inputValue: { label: string; groups: any[]};
   modalTitle: string;
   message: string;
-  inputLabel: string;
-  allGroups = [];
-  selectedGroups = [];
 
-  constructor( private dialogRef: MatDialogRef<AddRuleModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any)
- { }
+  formGroup = new FormGroup({
+    name: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    description: new FormControl('')
+  });
 
-  ngOnInit(): void {
-    this.okBtn = this.data.okBtn ? this.data.okBtn : 'Save';
-    this.btnType = this.data.btnType ? this.data.btnType : 'primary';
-    this.cancelBtn = this.data.cancelBtn ? this.data.cancelBtn : 'Cancel';
-    this.inputLabel = this.data.inputLabel ? this.data.inputLabel : '';
-    this.modalTitle = this.data.modalTitle ? this.data.modalTitle : '';
-    this.message = this.data.message;
-    this.inputValue = {
-      label: '',
-      groups: []
-    };
+  get name() {
+    return this.formGroup.get('name');
   }
 
+  get description() {
+    return this.formGroup.get('description');
+  }
+
+  constructor(
+    private dialogRef: MatDialogRef<AddRuleModalComponent, AddRuleModalResult>,
+    @Inject(MAT_DIALOG_DATA) public data: AddRuleModalConfig
+  ) {}
+
+  ngOnInit(): void {
+    this.okBtn = this.data.okBtnTitle ? this.data.okBtnTitle : 'Save';
+    this.btnType = this.data.btnType ? this.data.btnType : 'primary';
+    this.cancelBtn = this.data.cancelBtnTitle
+      ? this.data.cancelBtnTitle
+      : 'Cancel';
+    this.modalTitle = this.data.title ? this.data.title : '';
+    this.message = this.data.message;
+
+    this.name.setValue(this.data.name);
+    this.description.setValue(this.data.description);
+  }
+
+  cancel() {
+    this.dialogRef.close({ status: ModalDialogStatus.Cancel });
+  }
+
+  confirm() {
+    if (!this.formGroup.valid) {
+      return;
+    }
+
+    this.dialogRef.close({
+      status: ModalDialogStatus.Ok,
+      name: this.name.value,
+      description: this.description.value
+    });
+  }
 }

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.html
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.html
@@ -16,12 +16,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
+<!-- <div> -->
 <div class="modal-header pxy-2">
   <h4 class="modal-title marginless">{{ modalTitle }}</h4>
 </div>
-<form [formGroup]="formGroup">
-  <div class="modal-body pxy-2">
-    <p [innerHtml]="message"></p>
+<div class="modal-body pxy-2">
+  <p [innerHtml]="message"></p>
+  <form [formGroup]="formGroup">
     <div class="mdm--form-input">
       <mat-form-field appearance="outline" class="full-width paddingless">
         <mat-label>Language</mat-label>
@@ -83,25 +84,20 @@ SPDX-License-Identifier: Apache-2.0
       <label class="manual-material-label">Representation</label>
       <div id="dmn" #dmn class="dmn-container"></div>
     </div>
-    <div class="modal-footer pxy-2">
-      <button
-        mat-button
-        color="warn"
-        class="mr-1"
-        type="button"
-        (click)="cancel()"
-      >
-        {{ cancelBtn }}
-      </button>
-      <button
-        mat-flat-button
-        color="{{ btnType }}"
-        type="button"
-        [disabled]="!formGroup.valid"
-        (click)="confirm()"
-      >
-        {{ okBtn }}
-      </button>
-    </div>
-  </div>
-</form>
+  </form>
+</div>
+<div class="modal-footer pxy-2">
+  <button mat-button color="warn" class="mr-1" type="button" (click)="cancel()">
+    {{ cancelBtn }}
+  </button>
+  <button
+    mat-flat-button
+    color="{{ btnType }}"
+    type="button"
+    [disabled]="!formGroup.valid"
+    (click)="confirm()"
+  >
+    {{ okBtn }}
+  </button>
+</div>
+<!-- </div> -->

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.html
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.html
@@ -19,76 +19,38 @@ SPDX-License-Identifier: Apache-2.0
 <div class="modal-header pxy-2">
   <h4 class="modal-title marginless">{{ modalTitle }}</h4>
 </div>
-<div class="modal-body pxy-2">
-  <p [innerHtml]="message"></p>
-  <div class="mdm--form-input">
-    <mat-form-field appearance="outline" class="full-width paddingless">
-      <mat-label>Language</mat-label>
-      <mat-select
-        class="authorize-click"
-        aria-label="selectedImporterStr"
-        [(ngModel)]="selectedLanguage"
-      >
-        <mat-option *ngFor="let item of supportedLanguage" [value]="item">{{
-          item.displayName
-        }}</mat-option>
-      </mat-select>
-    </mat-form-field>
-  </div>
-  <mat-form-field
-    *ngIf="showAceEditor()"
-    appearance="outline"
-    class="full-width paddingless"
-  >
-    <div class="myfilebrowser">
-      <mat-toolbar>
-        <!-- Readonly Input to show File names -->
-        <input
-          style="font-size: large"
-          matInput
-          [(ngModel)]="myFilename"
-          readonly
-          name="memberContactNo"
-        />
-
-        <!-- Browse Button -->
-        <button mat-flat-button color="primary">Browse</button>
-      </mat-toolbar>
-
-      <!-- Fetch selected filed on change -->
-      <input
-        type="file"
-        #UploadFileInput
-        id="fileUpload"
-        (change)="otherFileAdded($event)"
-        name="fileUpload"
-      />
+<form [formGroup]="formGroup">
+  <div class="modal-body pxy-2">
+    <p [innerHtml]="message"></p>
+    <div class="mdm--form-input">
+      <mat-form-field appearance="outline" class="full-width paddingless">
+        <mat-label>Language</mat-label>
+        <mat-select formControlName="language">
+          <mat-option
+            *ngFor="let item of supportedLanguages"
+            [value]="item.value"
+            >{{ item.displayName }}</mat-option
+          >
+        </mat-select>
+        <mat-error *ngIf="language.errors?.required">
+          Language is required
+        </mat-error>
+      </mat-form-field>
     </div>
-  </mat-form-field>
-
-  <div *ngIf="showAceEditor()" class="mdm--form-input">
-    <span>Representation</span>
-    <ace
-      [mode]="selectedLanguage.aceValue"
-      style="height: 500px; width: 800px"
-      [theme]="'github'"
-      [(value)]="data.representation"
-      [config]="options"
-   ></ace>
-  </div>
-  <div *ngIf="selectedLanguage.value === 'dmn'">
-    <span>Representation</span>
-
-    <mat-form-field appearance="outline" class="full-width paddingless">
+    <mat-form-field
+      *ngIf="language.value"
+      appearance="outline"
+      class="full-width paddingless"
+    >
       <div class="myfilebrowser">
         <mat-toolbar>
           <!-- Readonly Input to show File names -->
           <input
-            style="font-size: large"
+            class="import-file-name"
             matInput
-            [(ngModel)]="myFilename"
             readonly
-            name="memberContactNo"
+            formControlName="importFileName"
+            placeholder="Import a file..."
           />
 
           <!-- Browse Button -->
@@ -106,19 +68,40 @@ SPDX-License-Identifier: Apache-2.0
       </div>
     </mat-form-field>
 
-    <div id="dmn" #dmn></div>
+    <div *ngIf="showAceEditor" class="mdm--form-input">
+      <label class="manual-material-label">Representation</label>
+      <ace
+        class="ace-editor"
+        [mode]="selectedLanguage.aceValue"
+        [theme]="'github'"
+        [value]="representation.value"
+        (valueChange)="representation.setValue($event)"
+        [config]="aceEditorConfig"
+      ></ace>
+    </div>
+    <div *ngIf="selectedLanguage?.value === 'dmn'" class="mdm--form-input">
+      <label class="manual-material-label">Representation</label>
+      <div id="dmn" #dmn class="dmn-container"></div>
+    </div>
+    <div class="modal-footer pxy-2">
+      <button
+        mat-button
+        color="warn"
+        class="mr-1"
+        type="button"
+        (click)="cancel()"
+      >
+        {{ cancelBtn }}
+      </button>
+      <button
+        mat-flat-button
+        color="{{ btnType }}"
+        type="button"
+        [disabled]="!formGroup.valid"
+        (click)="confirm()"
+      >
+        {{ okBtn }}
+      </button>
+    </div>
   </div>
-  <div class="modal-footer pxy-2">
-    <button mat-button color="warn" class="mr-1" type="button" mat-dialog-close>
-      {{ cancelBtn }}
-    </button>
-    <button
-      mat-flat-button
-      color="{{ btnType }}"
-      type="button"
-      (click)="save()"
-    >
-      {{ okBtn }}
-    </button>
-  </div>
-</div>
+</form>

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.scss
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.scss
@@ -36,7 +36,7 @@ SPDX-License-Identifier: Apache-2.0
 }
 
 .ace-editor {
-  height: 500px;
+  height: 30vh;
   width: 100%;
 }
 

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.scss
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.scss
@@ -18,30 +18,46 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 .myform-wrapper {
-    margin: 10px;
-    width: 350px;
+  margin: 10px;
+  width: 350px;
 
-    .mat-form-field {
-        width: 100%;
+  .mat-form-field {
+    width: 100%;
+  }
+
+  .mat-toolbar-single-row {
+    height: auto !important;
+    background: transparent;
+
+    button {
+      width: 30%;
     }
+  }
+}
 
-    .mat-toolbar-single-row {
-        height: auto !important;
-        background: transparent;
+.ace-editor {
+  height: 500px;
+  width: 100%;
+}
 
-        button {
-            width: 30%;
-        }
-    }
+.myfilebrowser {
+  .import-file-name {
+    font-size: large;
+  }
 }
 
 #fileUpload {
-    position: absolute;
-    z-index: 9;
-    opacity: 0;
-    height: 100%;
-    width: 100%;
-    left: 0px;
-    top: 0px;
-    cursor: pointer;
+  position: absolute;
+  z-index: 9;
+  opacity: 0;
+  height: 100%;
+  width: 100%;
+  left: 0px;
+  top: 0px;
+  cursor: pointer;
+}
+
+.dmn-container {
+  border-radius: 5px;
+  border: 1px solid #dddddd;
 }

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
@@ -16,36 +16,6 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-
-export class RuleLanguages {
-  static supportedLanguages = [
-    { displayName: 'SQL', value: 'sql', aceValue: 'sql', fileExt: 'sql' },
-    { displayName: 'C#', value: 'c#', aceValue: 'csharp', fileExt: 'cs' },
-    {
-      displayName: 'JavaScript',
-      value: 'javascript',
-      aceValue: 'javascript',
-      fileExt: 'js'
-    },
-
-    { displayName: 'Java', value: 'java', aceValue: 'java', fileExt: 'java' },
-    {
-      displayName: 'Typescript',
-      value: 'typescript',
-      aceValue: 'typescript',
-      fileExt: 'ts'
-    },
-    {
-      displayName: 'Drools',
-      value: 'drools',
-      aceValue: 'drools',
-      fileExt: 'drools'
-    },
-    { displayName: 'Text', value: 'text', aceValue: 'text', fileExt: 'txt' },
-    { displayName: 'DMN', value: 'dmn', aceValue: '', fileExt: 'dmn' }
-  ];
-}
-
 import {
   Component,
   ElementRef,
@@ -61,11 +31,67 @@ import 'brace/mode/drools';
 import 'brace/mode/sql';
 import 'brace/mode/java';
 import 'brace/mode/javascript';
+import 'brace/mode/json';
 import 'brace/mode/typescript';
 import 'brace/mode/csharp';
 import 'brace/mode/text';
 import 'brace/theme/github';
 import { MessageHandlerService } from '@mdm/services';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
+import { AceConfigInterface } from 'ngx-ace-wrapper';
+
+export class RuleLanguage {
+  displayName: string;
+  value: string;
+  aceValue?: string;
+  fileExt?: string;
+}
+
+export const supportedLanguages: RuleLanguage[] = [
+  { displayName: 'SQL', value: 'sql', aceValue: 'sql', fileExt: 'sql' },
+  { displayName: 'C#', value: 'c#', aceValue: 'csharp', fileExt: 'cs' },
+  {
+    displayName: 'JavaScript',
+    value: 'javascript',
+    aceValue: 'javascript',
+    fileExt: 'js'
+  },
+
+  { displayName: 'Java', value: 'java', aceValue: 'java', fileExt: 'java' },
+  { displayName: 'JSON', value: 'json', aceValue: 'json', fileExt: 'json' },
+  {
+    displayName: 'Typescript',
+    value: 'typescript',
+    aceValue: 'typescript',
+    fileExt: 'ts'
+  },
+  {
+    displayName: 'Drools',
+    value: 'drools',
+    aceValue: 'drools',
+    fileExt: 'drools'
+  },
+  { displayName: 'Text', value: 'text', aceValue: 'text', fileExt: 'txt' },
+  { displayName: 'DMN', value: 'dmn', fileExt: 'dmn' }
+];
+
+export interface AddRuleRepresentationModalConfig {
+  language: string;
+  representation: string;
+  title?: string;
+  message?: string;
+  okBtnTitle?: string;
+  cancelBtnTitle?: string;
+  cancelShown?: boolean;
+  btnType?: string;
+}
+
+export interface AddRuleRepresentationModalResult {
+  status: ModalDialogStatus;
+  language?: string;
+  representation?: string;
+}
 
 @Component({
   selector: 'mdm-add-rule-representation-modal',
@@ -88,50 +114,74 @@ export class AddRuleRepresentationModalComponent implements OnInit {
   okBtn: string;
   cancelBtn: string;
   btnType: string;
-  inputValue: { label: string; groups: any[] };
   modalTitle: string;
   message: string;
-  inputLabel: string;
   allGroups = [];
   selectedGroups = [];
   modeler: DmnModeler;
-  supportedLanguage = RuleLanguages.supportedLanguages;
-  selectedLanguage = this.supportedLanguage[0];
-  myFilename = 'Import File';
-  options:any = { showPrintMargin  : false};
+  supportedLanguages = supportedLanguages;
+  aceEditorConfig: AceConfigInterface = { showPrintMargin: false };
+
+  formGroup = new FormGroup({
+    language: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    representation: new FormControl(''),
+    importFileName: new FormControl()
+  });
+
+  get language() {
+    return this.formGroup.get('language');
+  }
+
+  get representation() {
+    return this.formGroup.get('representation');
+  }
+
+  get importFileName() {
+    return this.formGroup.get('importFileName');
+  }
 
   constructor(
-    private dialogRef: MatDialogRef<AddRuleRepresentationModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    private dialogRef: MatDialogRef<
+      AddRuleRepresentationModalComponent,
+      AddRuleRepresentationModalResult
+    >,
+    @Inject(MAT_DIALOG_DATA) public data: AddRuleRepresentationModalConfig,
     private messageHandler: MessageHandlerService
   ) {}
 
   ngOnInit(): void {
-    this.okBtn = this.data.okBtn ? this.data.okBtn : 'Save';
+    this.okBtn = this.data.okBtnTitle ? this.data.okBtnTitle : 'Save';
     this.btnType = this.data.btnType ? this.data.btnType : 'primary';
-    this.cancelBtn = this.data.cancelBtn ? this.data.cancelBtn : 'Cancel';
-    this.inputLabel = this.data.inputLabel ? this.data.inputLabel : '';
-    this.modalTitle = this.data.modalTitle ? this.data.modalTitle : '';
+    this.cancelBtn = this.data.cancelBtnTitle
+      ? this.data.cancelBtnTitle
+      : 'Cancel';
+    this.modalTitle = this.data.title ? this.data.title : '';
     this.message = this.data.message;
 
-    this.inputValue = {
-      label: '',
-      groups: []
-    };
+    this.supportedLanguages = this.supportedLanguages.sort((a, b) =>
+      a.displayName.localeCompare(b.displayName)
+    );
 
-    this.supportedLanguage.forEach((x) => {
-      if (x.value === this.data.language) {
-        this.selectedLanguage = x;
-      }
-    });
+    this.language.setValue(this.data.language);
+    this.representation.setValue(this.data.representation);
 
     if (this.data.language === 'dmn') {
       this.createDMNWindow();
     }
   }
 
-  showAceEditor() {
-    return this.selectedLanguage.aceValue.length > 0;
+  get selectedLanguage() {
+    if (!this.language.value) {
+      return undefined;
+    }
+
+    return this.supportedLanguages.find(
+      (lang) => lang.value === this.language.value
+    );
+  }
+
+  get showAceEditor() {
+    return !!this.selectedLanguage?.aceValue;
   }
 
   createDMNWindow(content?: any) {
@@ -139,8 +189,8 @@ export class AddRuleRepresentationModalComponent implements OnInit {
       if (!this.modeler) {
         this.modeler = new DmnModeler({
           container: '#dmn',
-          width: '600px',
-          height: '600px'
+          width: '100%',
+          height: '500px'
         });
       }
 
@@ -168,44 +218,65 @@ export class AddRuleRepresentationModalComponent implements OnInit {
     }, 1000);
   }
 
-  otherFileAdded(fileInput: any) {
-    if (fileInput.target.files && fileInput.target.files[0]) {
-      this.myFilename = fileInput.target.files[0].name;
-      const lang = this.supportedLanguage.find(
-        (x) => x.fileExt === this.myFilename.split('.')[1]
+  otherFileAdded(fileInput: Event) {
+    const target = fileInput.target as HTMLInputElement;
+
+    if (target.files && target.files[0]) {
+      const file = target.files[0];
+
+      this.importFileName.setValue(file.name);
+
+      const lang = this.supportedLanguages.find(
+        (x) => x.fileExt === file.name.split('.')[1]
       );
 
-      if (lang) {
-        this.selectedLanguage = lang;
-        const reader = new FileReader();
-        reader.onload = () => {
-          if(lang.value === 'dmn')
-          {
-            this.createDMNWindow(reader.result);
-          }
-          else{
-          this.data.representation = reader.result;
-          }
-        };
-        reader.readAsText(fileInput.target.files[0]);
+      if (!lang) {
+        this.importFileName.setValue(null);
+        this.messageHandler.showError(
+          'Unable to import file. Please copy and paste instead.'
+        );
+        return;
       }
-      else{
-        this.myFilename = 'Import File';
-        this.messageHandler.showError('Unable in import file please copy and paste');
-      }
+
+      this.language.setValue(lang.value);
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (lang.value === 'dmn') {
+          this.createDMNWindow(reader.result);
+        } else {
+          this.representation.setValue(reader.result.toString());
+        }
+      };
+      reader.readAsText(file);
     }
   }
 
-  save() {
-    this.data.language = this.selectedLanguage.value;
-    if (this.data.language === 'dmn') {
+  cancel() {
+    this.dialogRef.close({ status: ModalDialogStatus.Cancel });
+  }
+
+  confirm() {
+    if (!this.formGroup.valid) {
+      return;
+    }
+
+    let representation: string = this.representation.value;
+
+    if (this.selectedLanguage.value === 'dmn') {
       this.modeler.saveXML({ format: true }, (err, xml) => {
         if (err) {
           return;
         }
-        this.data.representation = xml;
+
+        representation = xml;
       });
     }
-    this.dialogRef.close(this.data);
+
+    this.dialogRef.close({
+      status: ModalDialogStatus.Ok,
+      language: this.language.value,
+      representation: representation ?? ''
+    });
   }
 }

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
@@ -59,7 +59,18 @@ export const supportedLanguages: RuleLanguage[] = [
   },
 
   { displayName: 'Java', value: 'java', aceValue: 'java', fileExt: 'java' },
-  { displayName: 'JSON', value: 'json', aceValue: 'json', fileExt: 'json' },
+  {
+    displayName: 'JSON',
+    value: 'json',
+    aceValue: 'json',
+    fileExt: 'json'
+  },
+  {
+    displayName: 'JSON (MEQL)',
+    value: 'json-meql',
+    aceValue: 'json',
+    fileExt: 'json'
+  },
   {
     displayName: 'Typescript',
     value: 'typescript',
@@ -190,7 +201,7 @@ export class AddRuleRepresentationModalComponent implements OnInit {
         this.modeler = new DmnModeler({
           container: '#dmn',
           width: '100%',
-          height: '500px'
+          height: '30vh'
         });
       }
 

--- a/src/app/shared/more-description/more-description.component.html
+++ b/src/app/shared/more-description/more-description.component.html
@@ -17,16 +17,25 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <span [hidden]="!this.description || this.description.length == 0">
-  <div #descriptionContent [class]="showMore?'content-full':'content-hidden'">
+  <div
+    #descriptionContent
+    [class]="showMore ? 'content-full' : 'content-hidden'"
+  >
     <mdm-content-editor
+      *ngIf="type === 'editable'"
       [(content)]="this.description"
       [inEditMode]="false"
       style="height: 100%"
     ></mdm-content-editor>
+    <pre *ngIf="type === 'preformatted'">{{ description }}</pre>
   </div>
   <div *ngIf="isOverflowing" class="show-more-less">
     <span *ngIf="!showMore">...</span>
-    <a color="primary" class="show-less" (click)="toggle()" [hidden]="!showMore">Show less</a>
-    <a color="primary" class="show-more" (click)="toggle()" [hidden]="showMore">Show more</a>
+    <a color="primary" class="show-less" (click)="toggle()" [hidden]="!showMore"
+      >Show less</a
+    >
+    <a color="primary" class="show-more" (click)="toggle()" [hidden]="showMore"
+      >Show more</a
+    >
   </div>
 </span>

--- a/src/app/shared/more-description/more-description.component.scss
+++ b/src/app/shared/more-description/more-description.component.scss
@@ -1,4 +1,22 @@
 /*
+Copyright 2020-2022 University of Oxford
+and Health and Social Care Information Centre, also known as NHS Digital
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+/*
   Copyright 2020-2022 University of Oxford
   and Health and Social Care Information Centre, also known as NHS Digital
 

--- a/src/app/shared/more-description/more-description.component.scss
+++ b/src/app/shared/more-description/more-description.component.scss
@@ -1,4 +1,4 @@
-//
+/*
   Copyright 2020-2022 University of Oxford
   and Health and Social Care Information Centre, also known as NHS Digital
 
@@ -15,28 +15,34 @@
   limitations under the License.
 
   SPDX-License-Identifier: Apache-2.0
+*/
+.content-hidden {
+  overflow: hidden;
+  line-height: 1.4rem;
+  height: 5.8rem;
+}
 
+.content-full {
+  line-height: 1.4rem;
+  height: auto;
+}
 
-.content-hidden
-  overflow: hidden
-  line-height: 1.4rem
-  height: 5.8rem
+.content-hidden p {
+  margin: 0 !important;
+}
 
-.content-full
-  line-height: 1.4rem
-  height: auto
+.content-full p {
+  margin: 0 !important;
+}
 
-.content-hidden p
-  margin: 0 !important
+div.show-more-less {
+  width: 100%;
+}
 
-.content-full p
-  margin: 0 !important
+a.show-less {
+  float: right;
+}
 
-div.show-more-less
-  width: 100%
-
-a.show-less
-  float: right
-
-a.show-more
-  float: right
+a.show-more {
+  float: right;
+}

--- a/src/app/shared/more-description/more-description.component.ts
+++ b/src/app/shared/more-description/more-description.component.ts
@@ -16,16 +16,24 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, Input, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  Input,
+  ElementRef,
+  ViewChild,
+  AfterViewChecked,
+  ChangeDetectorRef
+} from '@angular/core';
 import { UserSettingsHandlerService } from '@mdm/services/utility/user-settings-handler.service';
 
 @Component({
   selector: 'mdm-more-description',
   templateUrl: './more-description.component.html',
-  styleUrls: ['./more-description.component.sass']
+  styleUrls: ['./more-description.component.scss']
 })
-export class MoreDescriptionComponent implements AfterViewInit {
+export class MoreDescriptionComponent implements AfterViewChecked {
   @Input() description: string;
+  @Input() type: 'editable' | 'preformatted' = 'editable';
 
   showMore = true;
   isOverflowing = false;
@@ -33,21 +41,25 @@ export class MoreDescriptionComponent implements AfterViewInit {
   descriptionContent: ElementRef;
 
   constructor(
-    userSettingsHandler: UserSettingsHandlerService
+    private userSettingsHandler: UserSettingsHandlerService,
+    private changeDetector: ChangeDetectorRef
   ) {
-    this.showMore = userSettingsHandler.get('expandMoreDescription');
+    this.showMore = this.userSettingsHandler.get('expandMoreDescription');
   }
 
-  ngAfterViewInit() {
-    this.isOverflowing = this.checkOverflow(this.descriptionContent.nativeElement);
+  ngAfterViewChecked(): void {
+    this.isOverflowing = this.checkOverflow(
+      this.descriptionContent.nativeElement
+    );
+    // Avoid "ExpressionHasChangedAfterItWasChecked" error because isOverflowing could potentially change
+    this.changeDetector.detectChanges();
   }
 
   toggle() {
     this.showMore = !this.showMore;
   }
 
-  private checkOverflow (element): boolean {
+  private checkOverflow(element): boolean {
     return element.offsetHeight < element.scrollHeight;
   }
-
 }


### PR DESCRIPTION
*Note:* requires MauroDataMapper/mdm-resources#79 to be merged first.

Resolves #709

- Use type definitions for rules from mdm-resources
- Fix sort order of rule languages filter
- Code cleanup
- Improve Add Rule  and Add Rule Representation dialog - use reactive forms, add type definitions
- Add JSON support to rule representations
- Hide export option if rule has no representations
- Improve expand/collapse buttons for representations
- Move common action buttons out of context menu and into the table row
- List the number of representations in the rules table, then shows if there are any

![image](https://user-images.githubusercontent.com/3219480/206521094-d1c5988f-02c2-4c6e-af58-940ac607461f.png)

![image](https://user-images.githubusercontent.com/3219480/206521258-d4ffce9f-5995-47d1-af67-f4aece1a431d.png)
