### PR TITLE
Rename outputs to match future lint rules

### DIFF
--- a/src/app/bulk-edit/bulk-edit-container/bulk-edit-container.component.html
+++ b/src/app/bulk-edit/bulk-edit-container/bulk-edit-container.component.html
@@ -28,12 +28,12 @@ SPDX-License-Identifier: Apache-2.0
 <mdm-bulk-edit-select
   *ngIf="currentStep === Steps.Selection"
   [(context)]="context"
-  (onNext)="next()"
-  (onCancel)="cancel()"
+  (next)="next()"
+  (cancel)="cancel()"
 ></mdm-bulk-edit-select>
 <mdm-bulk-edit-editor-group
   *ngIf="currentStep === Steps.Editor"
   [(context)]="context"
-  (onCancel)="cancel()"
-  (onPrevious)="previous()"
+  (cancel)="cancel()"
+  (previous)="previous()"
 ></mdm-bulk-edit-editor-group>

--- a/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.html
+++ b/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.html
@@ -17,11 +17,11 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="mdm-bulk-edit__container-controls">
-  <button mat-stroked-button color="primary" type="button" (click)="previous()">
+  <button mat-stroked-button color="primary" type="button" (click)="onPrevious()">
     <span class="fas fa-tasks"></span>
     Select items
   </button>
-  <button mat-stroked-button color="warn" type="button" (click)="cancel()">
+  <button mat-stroked-button color="warn" type="button" (click)="onCancel()">
     <span class="fas fa-door-open"></span>
     Close
   </button>

--- a/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.ts
+++ b/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.ts
@@ -26,8 +26,8 @@ import { BulkEditContext, BulkEditProfileContext } from '../bulk-edit.types';
   styleUrls: ['./bulk-edit-editor-group.component.scss']
 })
 export class BulkEditEditorGroupComponent implements OnInit {
-  @Output() onCancel = new EventEmitter<void>();
-  @Output() onPrevious = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+  @Output() previous = new EventEmitter<void>();
 
   /** Two way binding */
   @Input() context: BulkEditContext;
@@ -46,11 +46,11 @@ export class BulkEditEditorGroupComponent implements OnInit {
     });
   }
 
-  cancel() {
-    this.onCancel.emit();
+  onCancel() {
+    this.cancel.emit();
   }
 
-  previous() {
-    this.onPrevious.emit();
+  onPrevious() {
+    this.previous.emit();
   }
 }

--- a/src/app/bulk-edit/bulk-edit-select/bulk-edit-select.component.html
+++ b/src/app/bulk-edit/bulk-edit-select/bulk-edit-select.component.html
@@ -148,7 +148,7 @@ SPDX-License-Identifier: Apache-2.0
       color="warn"
       type="button"
       class="mr-1"
-      (click)="cancel()"
+      (click)="onCancel()"
     >
       Cancel
     </button>
@@ -160,7 +160,7 @@ SPDX-License-Identifier: Apache-2.0
       color="primary"
       type="button"
       class="mr-1"
-      (click)="next()"
+      (click)="onNext()"
     >
       Next
     </button>

--- a/src/app/bulk-edit/bulk-edit-select/bulk-edit-select.component.ts
+++ b/src/app/bulk-edit/bulk-edit-select/bulk-edit-select.component.ts
@@ -61,8 +61,8 @@ interface CatalogueItemDomainTypeOption {
   styleUrls: ['./bulk-edit-select.component.scss']
 })
 export class BulkEditSelectComponent implements OnInit, OnDestroy {
-  @Output() onCancel = new EventEmitter<void>();
-  @Output() onNext = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+  @Output() next = new EventEmitter<void>();
 
   /** Two way binding */
   @Input() context: BulkEditContext;
@@ -187,12 +187,12 @@ export class BulkEditSelectComponent implements OnInit, OnDestroy {
     return option.name === value.name && option.namespace === value.namespace;
   }
 
-  cancel() {
-    this.onCancel.emit();
+  onCancel() {
+    this.cancel.emit();
   }
 
-  next() {
-    this.onNext.emit();
+  onNext() {
+    this.next.emit();
   }
 
   childItemSelected(selection: MatSelectionListChange) {

--- a/src/app/shared/element-label/element-label.component.ts
+++ b/src/app/shared/element-label/element-label.component.ts
@@ -28,9 +28,9 @@ import { MauroItem } from '@mdm/mauro/mauro-item.types';
 export class ElementLabelComponent {
   @Input() item: MauroItem & Branchable & Versionable;
 
-  @Output() click = new EventEmitter<void>();
+  @Output() labelClick = new EventEmitter<void>();
 
   labelClicked() {
-    this.click.emit();
+    this.labelClick.emit();
   }
 }


### PR DESCRIPTION
Fixes #731 - renaming of output / events to fix future lint issues in Angular 14