### PR TITLE
Subscribed Catalogue changes to support multiple Authentication Types

### DIFF
--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
@@ -35,6 +35,7 @@ SPDX-License-Identifier: Apache-2.0
   <mat-form-field
     appearance="outline"
     hintLabel="The Syndication feed URL to connect to"
+    style="padding-bottom: 20px"
   >
     <mat-label>URL</mat-label>
     <input matInput name="url" formControlName="url" required />
@@ -65,34 +66,38 @@ SPDX-License-Identifier: Apache-2.0
   <mat-form-field
     appearance="outline"
     hintLabel="An API key is required to view non-public models in the subscribed catalogue"
-    *ngIf="authenticationType.value === apiKeyAuthenticationType"
+    [hidden]="authenticationType.value !== apiKeyAuthenticationType"
+    style="padding-bottom: 20px"
   >
     <mat-label>API Key</mat-label>
-    <input matInput name="apiKey" formControlName="apiKey" required />
+    <input matInput name="apiKey" formControlName="apiKey" [required]="authenticationType.value === apiKeyAuthenticationType" />
   </mat-form-field>
   <mat-form-field
     appearance="outline"
     hintLabel="OAuth Access Token Endpoint URL"
-    *ngIf="authenticationType.value === oAuthClientCredentialsAuthenticationType"
+    [hidden]="authenticationType.value !== oAuthClientCredentialsAuthenticationType"
+    style="padding-bottom: 20px"
   >
     <mat-label>Token Endpoint URL</mat-label>
-    <input matInput name="tokenUrl" formControlName="tokenUrl" required />
+    <input matInput name="tokenUrl" formControlName="tokenUrl" [required]="authenticationType.value === oAuthClientCredentialsAuthenticationType" />
   </mat-form-field>
   <mat-form-field
     appearance="outline"
     hintLabel="OAuth Client ID"
-    *ngIf="authenticationType.value === oAuthClientCredentialsAuthenticationType"
+    [hidden]="authenticationType.value !== oAuthClientCredentialsAuthenticationType"
+    style="padding-bottom: 20px"
   >
     <mat-label>Client ID</mat-label>
-    <input matInput name="clientId" formControlName="clientId" required />
+    <input matInput name="clientId" formControlName="clientId" [required]="authenticationType.value === oAuthClientCredentialsAuthenticationType" />
   </mat-form-field>
   <mat-form-field
     appearance="outline"
     hintLabel="OAuth Client Secret"
-    *ngIf="authenticationType.value === oAuthClientCredentialsAuthenticationType"
+    [hidden]="authenticationType.value !== oAuthClientCredentialsAuthenticationType"
+    style="padding-bottom: 20px"
   >
     <mat-label>Client Secret</mat-label>
-    <input matInput name="clientSecret" formControlName="clientSecret" required />
+    <input matInput name="clientSecret" formControlName="clientSecret" [required]="authenticationType.value === oAuthClientCredentialsAuthenticationType" />
   </mat-form-field>
   <mat-form-field appearance="outline" style="max-width: 200px">
     <mat-label>Refresh period (days)</mat-label>

--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
@@ -34,14 +34,14 @@ SPDX-License-Identifier: Apache-2.0
   </mat-form-field>
   <mat-form-field
     appearance="outline"
-    hintLabel="Provide the domain URL to the Mauro system to connect to"
+    hintLabel="The Syndication feed URL to connect to"
   >
     <mat-label>URL</mat-label>
     <input matInput name="url" formControlName="url" required />
     <mat-error *ngIf="url?.errors?.required">URL is required</mat-error>
   </mat-form-field>
   <mat-form-field appearance="outline">
-    <mat-label>Type</mat-label>
+    <mat-label>Connection type</mat-label>
     <mat-select formControlName="type">
       <mat-option *ngFor="let type of connectionTypes" [value]="type">{{
         type
@@ -51,12 +51,48 @@ SPDX-License-Identifier: Apache-2.0
       >Connection type is required</mat-error
     >
   </mat-form-field>
+  <mat-form-field appearance="outline">
+    <mat-label>Authentication type</mat-label>
+    <mat-select formControlName="authenticationType">
+      <mat-option *ngFor="let authenticationType of authenticationTypes" [value]="authenticationType">{{
+        authenticationType
+        }}</mat-option>
+    </mat-select>
+    <mat-error *ngIf="authenticationType?.errors?.required"
+    >Authentication type is required</mat-error
+    >
+  </mat-form-field>
   <mat-form-field
     appearance="outline"
     hintLabel="An API key is required to view non-public models in the subscribed catalogue"
+    *ngIf="authenticationType.value === apiKeyAuthenticationType"
   >
     <mat-label>API Key</mat-label>
-    <input matInput name="apiKey" formControlName="apiKey" />
+    <input matInput name="apiKey" formControlName="apiKey" required />
+  </mat-form-field>
+  <mat-form-field
+    appearance="outline"
+    hintLabel="OAuth Access Token Endpoint URL"
+    *ngIf="authenticationType.value === oAuthClientCredentialsAuthenticationType"
+  >
+    <mat-label>Token Endpoint URL</mat-label>
+    <input matInput name="tokenUrl" formControlName="tokenUrl" required />
+  </mat-form-field>
+  <mat-form-field
+    appearance="outline"
+    hintLabel="OAuth Client ID"
+    *ngIf="authenticationType.value === oAuthClientCredentialsAuthenticationType"
+  >
+    <mat-label>Client ID</mat-label>
+    <input matInput name="clientId" formControlName="clientId" required />
+  </mat-form-field>
+  <mat-form-field
+    appearance="outline"
+    hintLabel="OAuth Client Secret"
+    *ngIf="authenticationType.value === oAuthClientCredentialsAuthenticationType"
+  >
+    <mat-label>Client Secret</mat-label>
+    <input matInput name="clientSecret" formControlName="clientSecret" required />
   </mat-form-field>
   <mat-form-field appearance="outline" style="max-width: 200px">
     <mat-label>Refresh period (days)</mat-label>

--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.ts
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.ts
@@ -21,9 +21,8 @@ import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {Title} from '@angular/platform-browser';
 import {
   SubscribedCatalogue,
-  SubscribedCatalogueTypeResponse,
   SubscribedCatalogueResponse,
-  Uuid, SubscribedCatalogueAuthenticationTypeResponse
+  Uuid
 } from '@maurodatamapper/mdm-resources';
 import {MdmResourcesService} from '@mdm/modules/resources';
 import {
@@ -35,6 +34,7 @@ import {EditingService} from '@mdm/services/editing.service';
 import {UIRouterGlobals} from '@uirouter/core';
 import {EMPTY, forkJoin, Observable, of} from 'rxjs';
 import {catchError, map, switchMap} from 'rxjs/operators';
+import {MdmResponse} from '../../../../../mdm-resources/src';
 
 @Component({
   selector: 'mdm-subscribed-catalogue',
@@ -116,11 +116,11 @@ export class SubscribedCatalogueComponent implements OnInit {
       subscribedCatalogueType: this.type.value,
       subscribedCatalogueAuthenticationType: this.authenticationType.value,
       refreshPeriod: this.refreshPeriod.value
-    }
+    };
     if (this.authenticationType.value === this.noAuthAuthenticationType) {
-      return baseRequest
+      return baseRequest;
     } else if (this.authenticationType.value === this.apiKeyAuthenticationType) {
-      return {...baseRequest, ...{apiKey: this.apiKey.value}}
+      return {...baseRequest, ...{apiKey: this.apiKey.value}};
     } else if (this.authenticationType.value === this.oAuthClientCredentialsAuthenticationType) {
       return {
         ...baseRequest, ...{
@@ -128,7 +128,7 @@ export class SubscribedCatalogueComponent implements OnInit {
           clientId: this.clientId.value,
           clientSecret: this.clientSecret.value,
         }
-      }
+      };
     }
   }
 
@@ -146,7 +146,7 @@ export class SubscribedCatalogueComponent implements OnInit {
       this.resources.subscribedCatalogues.authenticationTypes()
     ])
       .pipe(
-        switchMap(([typesResponse, authenticationTypesResponse]: [SubscribedCatalogueTypeResponse, SubscribedCatalogueAuthenticationTypeResponse]) => {
+        switchMap(([typesResponse, authenticationTypesResponse]: MdmResponse<string[]>[]) => {
           this.connectionTypes = typesResponse.body;
           this.authenticationTypes = this.supportedAuthenticationTypes.filter(authType => authenticationTypesResponse.body.includes(authType));
 
@@ -236,7 +236,7 @@ export class SubscribedCatalogueComponent implements OnInit {
         Validators.required // eslint-disable-line @typescript-eslint/unbound-method
       ]),
       authenticationType: new FormControl(catalogue?.subscribedCatalogueAuthenticationType, [
-        Validators.required
+        Validators.required // eslint-disable-line @typescript-eslint/unbound-method
       ]),
       apiKey: new FormControl(catalogue?.apiKey),
       tokenUrl: new FormControl(catalogue?.tokenUrl),

--- a/src/app/admin/subscribed-catalogues/subscribed-catalogues.component.html
+++ b/src/app/admin/subscribed-catalogues/subscribed-catalogues.component.html
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
           Catalogues
           <span class="mdm--badge mdm--element-count">{{
             totalItemCount
-          }}</span>
+            }}</span>
         </h4>
       </div>
       <div
@@ -123,8 +123,20 @@ SPDX-License-Identifier: Apache-2.0
           style="text-align: left; word-wrap: break-word"
         >
           <p><strong>URL:</strong> {{ record.url }}</p>
-          <p><strong>Type:</strong> {{ record.subscribedCatalogueType }}</p>
-          <p *ngIf="record.apiKey"><strong>Key:</strong> {{ record.apiKey }}</p>
+          <div class="detail-icons">
+            <div class="text-muted">
+              <small>
+                <span class="fas fa-rss" matTooltip="Connection Type"></span>
+                <strong>Type: </strong><span class="item-type">{{ record.subscribedCatalogueType }}</span>
+              </small>
+            </div>
+            <div class="text-muted">
+              <small>
+                <span class="fas fa-lock" matTooltip="Authentication Type"></span>
+                <strong>Authentication: </strong><span class="item-type">{{ record.subscribedCatalogueAuthenticationType }}</span>
+              </small>
+            </div>
+          </div>
         </td>
       </ng-container>
       <ng-container matColumnDef="refreshPeriod">

--- a/src/app/model/federated-data-model.ts
+++ b/src/app/model/federated-data-model.ts
@@ -37,6 +37,7 @@ export class FederatedDataModel {
   folderId?: string;
   folderLabel?: string;
   version?: string;
+  modelVersionTag?: string;
 
   constructor(
     catalogueId: string,
@@ -48,6 +49,7 @@ export class FederatedDataModel {
     this.label = published?.label;
     this.description = published?.description;
     this.version = published?.version;
+    this.modelVersionTag = published?.modelVersionTag;
     this.modelType = published?.modelType;
     this.dateCreated = published?.dateCreated;
     this.datePublished = published?.datePublished;

--- a/src/app/services/model-tree.service.ts
+++ b/src/app/services/model-tree.service.ts
@@ -231,7 +231,7 @@ export class ModelTreeService implements OnDestroy {
               domainType: CatalogueItemDomainType.FederatedDataModel,
               hasChildren: false,
               label: item.label,
-              modelVersion: item.version,
+              modelVersion: item.version ?? item.modelVersionTag,
               parentId: item.catalogueId,
               availableActions: []
             }

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.html
@@ -64,7 +64,7 @@ SPDX-License-Identifier: Apache-2.0
         Version
       </th>
       <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
-        {{ record.version }}
+        {{ record.version ?? record.modelVersionTag }}
       </td>
     </ng-container>
     <ng-container matColumnDef="navigate">

--- a/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
+++ b/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
@@ -65,7 +65,7 @@ describe('SubscribedCatalogueDetailComponent', () => {
       url: '',
       label: '',
       subscribedCatalogueType: 'test',
-      subscribedCatalogueAuthenticationType: ''
+      subscribedCatalogueAuthenticationType: 'test'
     };
     fixture.detectChanges();
   });


### PR DESCRIPTION
- Display versions (or model version tags) for Published Models in the tree entry for a Subscribed Catalogue.
- In the Subscribed Catalogue admin settings page, add fields to choose Authentication Type and required authentication fields for each type (No Authentication, API Key or OAuth (Client Credentials)).

Depends on https://github.com/MauroDataMapper/mdm-resources/pull/84.