### PR TITLE
gh-742 Code updates to support Angular 14 typed forms

### DIFF
--- a/src/app/admin/api-property/api-property.component.ts
+++ b/src/app/admin/api-property/api-property.component.ts
@@ -20,10 +20,23 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSelectChange } from '@angular/material/select';
 import { Title } from '@angular/platform-browser';
-import { ApiProperty, ApiPropertyIndexResponse, ApiPropertyResponse } from '@maurodatamapper/mdm-resources';
-import { ApiPropertyEditableState, ApiPropertyEditType, ApiPropertyMetadata, propertyMetadata } from '@mdm/model/api-properties';
+import {
+  ApiProperty,
+  ApiPropertyIndexResponse,
+  ApiPropertyResponse
+} from '@maurodatamapper/mdm-resources';
+import {
+  ApiPropertyEditableState,
+  ApiPropertyEditType,
+  ApiPropertyMetadata,
+  propertyMetadata
+} from '@mdm/model/api-properties';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { BroadcastService, MessageHandlerService, StateHandlerService } from '@mdm/services';
+import {
+  BroadcastService,
+  MessageHandlerService,
+  StateHandlerService
+} from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
 import { UIRouterGlobals } from '@uirouter/core';
 import { catchError, map } from 'rxjs/operators';
@@ -34,7 +47,6 @@ import { catchError, map } from 'rxjs/operators';
   styleUrls: ['./api-property.component.scss']
 })
 export class ApiPropertyComponent implements OnInit {
-
   id: string;
   isNew: boolean;
   editExisting = false;
@@ -42,22 +54,27 @@ export class ApiPropertyComponent implements OnInit {
   systemProperties: ApiPropertyMetadata[];
   selectedSystemProperty: ApiPropertyMetadata;
 
-  formGroup: FormGroup;
+  formGroup = new FormGroup({
+    key: new FormControl('', [Validators.required]), // eslint-disable-line @typescript-eslint/unbound-method
+    category: new FormControl('', [Validators.required]), // eslint-disable-line @typescript-eslint/unbound-method
+    publiclyVisible: new FormControl({ value: false, disabled: false }),
+    value: new FormControl('', [Validators.required]) // eslint-disable-line @typescript-eslint/unbound-method
+  });
 
   get key() {
-    return this.formGroup.get('key');
+    return this.formGroup.controls.key;
   }
 
   get category() {
-    return this.formGroup.get('category');
+    return this.formGroup.controls.category;
   }
 
   get publiclyVisible() {
-    return this.formGroup.get('publiclyVisible');
+    return this.formGroup.controls.publiclyVisible;
   }
 
   get value() {
-    return this.formGroup.get('value');
+    return this.formGroup.controls.value;
   }
 
   EditTypes = ApiPropertyEditType;
@@ -69,7 +86,8 @@ export class ApiPropertyComponent implements OnInit {
     private stateHandler: StateHandlerService,
     private broadcast: BroadcastService,
     private editing: EditingService,
-    private title: Title) { }
+    private title: Title
+  ) {}
 
   ngOnInit(): void {
     this.editing.start();
@@ -80,8 +98,7 @@ export class ApiPropertyComponent implements OnInit {
     if (this.editExisting) {
       this.title.setTitle('Configuration - Edit Property');
       this.loadExistingProperty();
-    }
-    else {
+    } else {
       this.title.setTitle('Configuration - Add Property');
       this.loadAvailableSystemProperties();
     }
@@ -89,9 +106,10 @@ export class ApiPropertyComponent implements OnInit {
 
   systemPropertyChanged(change: MatSelectChange) {
     if (change.value) {
-      this.property.metadata = propertyMetadata.find(m => m.key === change.value);
-    }
-    else {
+      this.property.metadata = propertyMetadata.find(
+        (m) => m.key === change.value
+      );
+    } else {
       this.property.metadata = this.getBlankMetadata();
     }
 
@@ -101,8 +119,7 @@ export class ApiPropertyComponent implements OnInit {
 
     if (this.property.metadata.isSystem) {
       this.publiclyVisible.disable();
-    }
-    else {
+    } else {
       this.publiclyVisible.enable();
     }
   }
@@ -112,7 +129,7 @@ export class ApiPropertyComponent implements OnInit {
   }
 
   cancel() {
-    this.editing.confirmCancelAsync().subscribe(confirm => {
+    this.editing.confirmCancelAsync().subscribe((confirm) => {
       if (confirm) {
         this.navigateToParent();
       }
@@ -134,8 +151,11 @@ export class ApiPropertyComponent implements OnInit {
       this.resources.apiProperties
         .update(this.property.original.id, updated)
         .pipe(
-          catchError(errors => {
-            this.messageHandler.showError('There was a problem updating the property.', errors);
+          catchError((errors) => {
+            this.messageHandler.showError(
+              'There was a problem updating the property.',
+              errors
+            );
             return [];
           })
         )
@@ -143,11 +163,11 @@ export class ApiPropertyComponent implements OnInit {
           this.messageHandler.showSuccess('Property was updated successfully.');
           this.broadcast.apiPropertyUpdated({
             key: this.key.value,
-            value: this.value.value });
+            value: this.value.value
+          });
           this.navigateToParent();
         });
-    }
-    else {
+    } else {
       const data: ApiProperty = {
         key: this.key?.value,
         value: this.value?.value,
@@ -158,8 +178,11 @@ export class ApiPropertyComponent implements OnInit {
       this.resources.apiProperties
         .save(data)
         .pipe(
-          catchError(errors => {
-            this.messageHandler.showError('There was a problem saving the property.', errors);
+          catchError((errors) => {
+            this.messageHandler.showError(
+              'There was a problem saving the property.',
+              errors
+            );
             return [];
           })
         )
@@ -167,19 +190,24 @@ export class ApiPropertyComponent implements OnInit {
           this.messageHandler.showSuccess('Property was saved successfully.');
           this.broadcast.apiPropertyUpdated({
             key: this.key.value,
-            value: this.value.value });
+            value: this.value.value
+          });
           this.navigateToParent();
         });
     }
   }
 
-  private createFormGroup() {
-    this.formGroup = new FormGroup({
-      key: new FormControl(this.property.metadata.key, [Validators.required]),  // eslint-disable-line @typescript-eslint/unbound-method
-      category: new FormControl(this.property.metadata.category, [Validators.required]),  // eslint-disable-line @typescript-eslint/unbound-method
-      publiclyVisible: new FormControl({ value: this.property.metadata.publiclyVisible, disabled: this.property.metadata.isSystem }),
-      value: new FormControl(this.property.original?.value, [Validators.required])  // eslint-disable-line @typescript-eslint/unbound-method
-    });
+  private setFormValues() {
+    this.key.setValue(this.property.metadata.key);
+    this.category.setValue(this.property.metadata.category);
+    this.publiclyVisible.setValue(this.property.metadata.publiclyVisible);
+    this.value.setValue(this.property.original?.value);
+
+    if (this.property.metadata.isSystem) {
+      this.publiclyVisible.disable();
+    } else {
+      this.publiclyVisible.enable();
+    }
   }
 
   private getBlankMetadata() {
@@ -196,29 +224,36 @@ export class ApiPropertyComponent implements OnInit {
     this.resources.apiProperties
       .get(this.id)
       .pipe(
-        map((response: ApiPropertyResponse): ApiPropertyEditableState => {
-          const original = response.body;
-          const metadata = propertyMetadata.find(p => p.key === original.key) ?? {
-            key: original.key,
-            category: original.category,
-            isSystem: false,
-            publiclyVisible: original.publiclyVisible,
-            editType: ApiPropertyEditType.Value
-          };
+        map(
+          (response: ApiPropertyResponse): ApiPropertyEditableState => {
+            const original = response.body;
+            const metadata = propertyMetadata.find(
+              (p) => p.key === original.key
+            ) ?? {
+              key: original.key,
+              category: original.category,
+              isSystem: false,
+              publiclyVisible: original.publiclyVisible,
+              editType: ApiPropertyEditType.Value
+            };
 
-          return {
-            metadata,
-            original
-          };
-        }),
-        catchError(errors => {
-          this.messageHandler.showError('There was a problem getting the property.', errors);
+            return {
+              metadata,
+              original
+            };
+          }
+        ),
+        catchError((errors) => {
+          this.messageHandler.showError(
+            'There was a problem getting the property.',
+            errors
+          );
           return [];
         })
       )
       .subscribe((data: ApiPropertyEditableState) => {
         this.property = data;
-        this.createFormGroup();
+        this.setFormValues();
       });
   }
 
@@ -229,17 +264,22 @@ export class ApiPropertyComponent implements OnInit {
         map((response: ApiPropertyIndexResponse) => {
           return response.body.items;
         }),
-        catchError(errors => {
-          this.messageHandler.showError('There was a problem getting the properties.', errors);
+        catchError((errors) => {
+          this.messageHandler.showError(
+            'There was a problem getting the properties.',
+            errors
+          );
           return [];
         })
       )
       .subscribe((data: ApiProperty[]) => {
-        this.systemProperties = propertyMetadata.filter(m => data.every(p => p.key !== m.key));
+        this.systemProperties = propertyMetadata.filter((m) =>
+          data.every((p) => p.key !== m.key)
+        );
         this.property = {
           metadata: this.getBlankMetadata()
         };
-        this.createFormGroup();
+        this.setFormValues();
       });
   }
 
@@ -253,6 +293,7 @@ export class ApiPropertyComponent implements OnInit {
       {
         reload: this.property.metadata.requiresReload,
         inherit: false
-      });
+      }
+    );
   }
 }

--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
@@ -43,61 +43,84 @@ SPDX-License-Identifier: Apache-2.0
   </mat-form-field>
   <mat-form-field appearance="outline">
     <mat-label>Connection type</mat-label>
-    <mat-select formControlName="type">
+    <mat-select formControlName="connectionType">
       <mat-option *ngFor="let type of connectionTypes" [value]="type">{{
         type
       }}</mat-option>
     </mat-select>
-    <mat-error *ngIf="type?.errors?.required"
+    <mat-error *ngIf="connectionType?.errors?.required"
       >Connection type is required</mat-error
     >
   </mat-form-field>
   <mat-form-field appearance="outline">
     <mat-label>Authentication type</mat-label>
     <mat-select formControlName="authenticationType">
-      <mat-option *ngFor="let authenticationType of authenticationTypes" [value]="authenticationType">{{
-        authenticationType
-        }}</mat-option>
+      <mat-option
+        *ngFor="let authenticationType of authenticationTypes"
+        [value]="authenticationType"
+        >{{ authenticationType }}</mat-option
+      >
     </mat-select>
     <mat-error *ngIf="authenticationType?.errors?.required"
-    >Authentication type is required</mat-error
+      >Authentication type is required</mat-error
     >
   </mat-form-field>
   <mat-form-field
+    *ngIf="useApiKeyAuthentication"
     appearance="outline"
     hintLabel="An API key is required to view non-public models in the subscribed catalogue"
-    [hidden]="authenticationType.value !== apiKeyAuthenticationType"
     style="padding-bottom: 20px"
   >
     <mat-label>API Key</mat-label>
-    <input matInput name="apiKey" formControlName="apiKey" [required]="authenticationType.value === apiKeyAuthenticationType" />
+    <input matInput name="apiKey" formControlName="apiKey" required />
+    <mat-error *ngIf="apiKey?.errors?.required"
+      >An API key is required for this authentication type</mat-error
+    >
   </mat-form-field>
   <mat-form-field
+    *ngIf="useOauthAuthentication"
     appearance="outline"
     hintLabel="OAuth Access Token Endpoint URL"
-    [hidden]="authenticationType.value !== oAuthClientCredentialsAuthenticationType"
     style="padding-bottom: 20px"
   >
     <mat-label>Token Endpoint URL</mat-label>
-    <input matInput name="tokenUrl" formControlName="tokenUrl" [required]="authenticationType.value === oAuthClientCredentialsAuthenticationType" />
+    <input matInput name="tokenUrl" formControlName="tokenUrl" required />
+    <mat-error *ngIf="tokenUrl?.errors?.required"
+      >A token URL is required for this authentication type</mat-error
+    >
+    <mat-error *ngIf="tokenUrl?.errors?.url">
+      Please provide a valid URL
+    </mat-error>
   </mat-form-field>
   <mat-form-field
+    *ngIf="useOauthAuthentication"
     appearance="outline"
     hintLabel="OAuth Client ID"
-    [hidden]="authenticationType.value !== oAuthClientCredentialsAuthenticationType"
     style="padding-bottom: 20px"
   >
     <mat-label>Client ID</mat-label>
-    <input matInput name="clientId" formControlName="clientId" [required]="authenticationType.value === oAuthClientCredentialsAuthenticationType" />
+    <input matInput name="clientId" formControlName="clientId" required />
+    <mat-error *ngIf="clientId?.errors?.required"
+      >A client ID is required for this authentication type</mat-error
+    >
   </mat-form-field>
   <mat-form-field
+    *ngIf="useOauthAuthentication"
     appearance="outline"
     hintLabel="OAuth Client Secret"
-    [hidden]="authenticationType.value !== oAuthClientCredentialsAuthenticationType"
     style="padding-bottom: 20px"
   >
     <mat-label>Client Secret</mat-label>
-    <input matInput name="clientSecret" formControlName="clientSecret" [required]="authenticationType.value === oAuthClientCredentialsAuthenticationType" />
+    <input
+      matInput
+      type="password"
+      name="clientSecret"
+      formControlName="clientSecret"
+      required
+    />
+    <mat-error *ngIf="clientSecret?.errors?.required"
+      >A client secret is required for this authentication type</mat-error
+    >
   </mat-form-field>
   <mat-form-field appearance="outline" style="max-width: 200px">
     <mat-label>Refresh period (days)</mat-label>

--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.html
@@ -127,9 +127,17 @@ SPDX-License-Identifier: Apache-2.0
     <input
       type="number"
       matInput
+      min="1"
+      max="365"
       name="refreshPeriod"
       formControlName="refreshPeriod"
     />
+    <mat-error *ngIf="refreshPeriod?.errors?.min">
+      The minimum value is {{ refreshPeriod.errors.min.min }}
+    </mat-error>
+    <mat-error *ngIf="refreshPeriod?.errors?.max">
+      The maximum value is {{ refreshPeriod.errors.max.max }}
+    </mat-error>
   </mat-form-field>
   <div>
     <button

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -34,43 +34,46 @@ import { MdmResourcesService } from './modules/resources';
 import { MatDialogModule } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FeaturesService } from './services/features.service';
-import { LoadingIndicatorComponent } from '@mdm/utility/loading-indicator/loading-indicator.component';
+import { MockComponent } from 'ng-mocks';
+import { LoadingIndicatorComponent } from './utility/loading-indicator/loading-indicator.component';
 
 describe('AppComponent', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        NgxSkeletonLoaderModule,
-        MatTooltipModule,
-        MatMenuModule,
-        MatDialogModule,
-        MatBadgeModule,
-        MatToolbarModule,
-        NoopAnimationsModule,
-        MatSidenavModule,
-        UIRouterModule.forRoot({ useHash: true }),
-        ToastrModule.forRoot()
-      ],
-      providers: [
-        {
-          provide: MdmResourcesService,
-          useValue: {},
-        },
-        {
-          provide: FeaturesService,
-          useValue: jest.fn()
-        }
-      ],
-      declarations: [
-        ProfilePictureComponent,
-        ByteArrayToBase64Pipe,
-        NavbarComponent,
-        FooterComponent,
-        AppComponent,
-        LoadingIndicatorComponent,
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          NgxSkeletonLoaderModule,
+          MatTooltipModule,
+          MatMenuModule,
+          MatDialogModule,
+          MatBadgeModule,
+          MatToolbarModule,
+          NoopAnimationsModule,
+          MatSidenavModule,
+          UIRouterModule.forRoot({ useHash: true }),
+          ToastrModule.forRoot()
+        ],
+        providers: [
+          {
+            provide: MdmResourcesService,
+            useValue: {}
+          },
+          {
+            provide: FeaturesService,
+            useValue: jest.fn()
+          }
+        ],
+        declarations: [
+          ProfilePictureComponent,
+          ByteArrayToBase64Pipe,
+          NavbarComponent,
+          FooterComponent,
+          AppComponent,
+          MockComponent(LoadingIndicatorComponent)
+        ]
+      }).compileComponents();
+    })
+  );
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
@@ -78,10 +81,9 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should have as title \'mdm-ui\'', () => {
+  it("should have as title 'mdm-ui'", () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('mdm-ui');
   });
-
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -81,7 +81,7 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it("should have as title 'mdm-ui'", () => {
+  it('should have as title \'mdm-ui\'', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('mdm-ui');

--- a/src/app/bulk-edit/bulk-edit-select/bulk-edit-select.component.ts
+++ b/src/app/bulk-edit/bulk-edit-select/bulk-edit-select.component.ts
@@ -79,28 +79,31 @@ export class BulkEditSelectComponent implements OnInit, OnDestroy {
   childItemSelections = new SelectionModel<MauroItem>(true);
 
   setupForm = new FormGroup({
-    childDomainType: new FormControl(null, Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-    childItems: new FormControl([], Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-    profiles: new FormControl([], Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-    filter: new FormControl(null)
+    childDomainType: new FormControl<CatalogueItemDomainType>(
+      null,
+      Validators.required // eslint-disable-line @typescript-eslint/unbound-method
+    ),
+    childItems: new FormControl<MauroItem[]>([], Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    profiles: new FormControl<ProfileSummary[]>([], Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    filter: new FormControl('')
   });
 
   private unsubscribe$ = new Subject<void>();
 
   get childDomainType() {
-    return this.setupForm.get('childDomainType');
+    return this.setupForm.controls.childDomainType;
   }
 
   get childItems() {
-    return this.setupForm.get('childItems');
+    return this.setupForm.controls.childItems;
   }
 
   get profiles() {
-    return this.setupForm.get('profiles');
+    return this.setupForm.controls.profiles;
   }
 
   get filter() {
-    return this.setupForm.get('filter');
+    return this.setupForm.controls.filter;
   }
 
   get showBreadcrumbs() {
@@ -122,7 +125,7 @@ export class BulkEditSelectComponent implements OnInit, OnDestroy {
     this.childDomainType.valueChanges
       .pipe(
         takeUntil(this.unsubscribe$),
-        switchMap((value: CatalogueItemDomainType) => {
+        switchMap((value) => {
           this.context.childDomainType = value;
           this.contextChanged.emit(this.context);
 
@@ -161,7 +164,7 @@ export class BulkEditSelectComponent implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
         debounceTime(500),
         distinctUntilChanged(),
-        map((value: string) =>
+        map((value) =>
           this.availableChildItems.filter((item) =>
             item.label.toLowerCase().includes(value.toLowerCase())
           )

--- a/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.spec.ts
@@ -16,11 +16,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { FormControl, FormGroup } from '@angular/forms';
 import {
   CatalogueItemDomainType,
   Classifier,
-  MdmTreeItem
+  MdmTreeItem,
+  ModelDomainType
 } from '@maurodatamapper/mdm-resources';
 import {
   ComponentHarness,
@@ -45,17 +45,24 @@ describe('CatalogueSearchFormAdvancedComponent', () => {
   it('it should reset', () => {
     const value: MdmTreeItem[] = [];
 
-    harness.component.formGroup = new FormGroup({
-      context: new FormControl(value),
-      domainTypes: new FormControl(['DomainTypes']),
-      labelOnly: new FormControl(true),
-      exactMatch: new FormControl(true),
-      classifiers: new FormControl(['classifiers']),
-      createdAfter: new FormControl(new Date('July 21, 1983 01:15:00')),
-      createdBefore: new FormControl(new Date('July 22, 1983 01:15:00')),
-      lastUpdatedAfter: new FormControl(new Date('July 23, 1983 01:15:00')),
-      lastUpdatedBefore: new FormControl(new Date('July 24, 1983 01:15:00'))
-    });
+    harness.component.context.setValue(value);
+    harness.component.domainTypes.setValue([
+      ModelDomainType.DataModels,
+      ModelDomainType.Classifiers
+    ]);
+    harness.component.labelOnly.setValue(true);
+    harness.component.exactMatch.setValue(true);
+    harness.component.classifiers.setValue(['classifiers']);
+    harness.component.createdAfter.setValue(new Date('July 21, 1983 01:15:00'));
+    harness.component.createdBefore.setValue(
+      new Date('July 22, 1983 01:15:00')
+    );
+    harness.component.lastUpdatedAfter.setValue(
+      new Date('July 23, 1983 01:15:00')
+    );
+    harness.component.lastUpdatedBefore.setValue(
+      new Date('July 24, 1983 01:15:00')
+    );
 
     harness.component.reset();
     expect(harness.component.context.value).toBe(null);
@@ -70,9 +77,6 @@ describe('CatalogueSearchFormAdvancedComponent', () => {
   });
 
   it('it should format dates correctly', () => {
-    harness.component.formGroup = new FormGroup({
-      createdAfter: new FormControl(null)
-    });
     harness.component.createdAfter.setValue(new Date('July 21, 1983 01:15:00'));
     expect(
       harness.component.formatDate(harness.component.createdAfter.value)
@@ -80,9 +84,6 @@ describe('CatalogueSearchFormAdvancedComponent', () => {
   });
 
   it('it should return classifer lables in an array', () => {
-    harness.component.formGroup = new FormGroup({
-      classifiers: new FormControl('')
-    });
     const testClassifier: Classifier = {
       domainType: CatalogueItemDomainType.Classifier,
       label: 'testLabel1'

--- a/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.ts
+++ b/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.ts
@@ -16,16 +16,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import {
-  Component,
-  EventEmitter,
-  OnInit,
-  Output} from '@angular/core';
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import {
   Classifier,
   ClassifierIndexResponse,
-  MdmTreeItem
+  MdmTreeItem,
+  ModelDomainType
 } from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
 
@@ -36,12 +33,23 @@ import { MdmResourcesService } from '@mdm/modules/resources';
 })
 export class CatalogueSearchAdvancedFormComponent implements OnInit {
   advancedSearch: boolean;
-  formGroup: FormGroup;
   classifications: Classifier[];
   @Output() searchEvent = new EventEmitter<string>();
 
+  formGroup = new FormGroup({
+    context: new FormControl<MdmTreeItem[]>(null),
+    domainTypes: new FormControl<ModelDomainType[]>([]),
+    labelOnly: new FormControl(true),
+    exactMatch: new FormControl(false),
+    classifiers: new FormControl<any[]>([]),
+    createdAfter: new FormControl<Date>(null),
+    createdBefore: new FormControl<Date>(null),
+    lastUpdatedAfter: new FormControl<Date>(null),
+    lastUpdatedBefore: new FormControl<Date>(null)
+  });
+
   get context() {
-    return this.formGroup.get('context');
+    return this.formGroup.controls.context;
   }
 
   set contextValue(value: MdmTreeItem[]) {
@@ -49,7 +57,7 @@ export class CatalogueSearchAdvancedFormComponent implements OnInit {
   }
 
   get classifiers() {
-    return this.formGroup.get('classifiers');
+    return this.formGroup.controls.classifiers;
   }
 
   get classifierNames() {
@@ -65,46 +73,34 @@ export class CatalogueSearchAdvancedFormComponent implements OnInit {
   }
 
   get domainTypes() {
-    return this.formGroup.get('domainTypes');
+    return this.formGroup.controls.domainTypes;
   }
 
   get labelOnly() {
-    return this.formGroup.get('labelOnly');
+    return this.formGroup.controls.labelOnly;
   }
 
   get exactMatch() {
-    return this.formGroup.get('exactMatch');
+    return this.formGroup.controls.exactMatch;
   }
 
   get lastUpdatedAfter() {
-    return this.formGroup.get('lastUpdatedAfter');
+    return this.formGroup.controls.lastUpdatedAfter;
   }
 
   get lastUpdatedBefore() {
-    return this.formGroup.get('lastUpdatedBefore');
+    return this.formGroup.controls.lastUpdatedBefore;
   }
 
   get createdAfter() {
-    return this.formGroup.get('createdAfter');
+    return this.formGroup.controls.createdAfter;
   }
 
   get createdBefore() {
-    return this.formGroup.get('createdBefore');
+    return this.formGroup.controls.createdBefore;
   }
 
   ngOnInit(): void {
-    this.formGroup = new FormGroup({
-      context: new FormControl(null),
-      domainTypes: new FormControl(''),
-      labelOnly: new FormControl(true),
-      exactMatch: new FormControl(false),
-      classifiers: new FormControl(''),
-      createdAfter: new FormControl(null),
-      createdBefore: new FormControl(null),
-      lastUpdatedAfter: new FormControl(null),
-      lastUpdatedBefore: new FormControl(null)
-    });
-
     this.resources.classifier
       .list({ all: true })
       .subscribe((result: ClassifierIndexResponse) => {

--- a/src/app/catalogue-search/catalogue-search-form/catalogue-search-form.component.ts
+++ b/src/app/catalogue-search/catalogue-search-form/catalogue-search-form.component.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { FormControl, FormGroup, UntypedFormGroup} from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
 
 /**
@@ -34,17 +34,19 @@ import { MatFormFieldAppearance } from '@angular/material/form-field';
 export class CatalogueSearchFormComponent implements OnInit {
   @Input() appearance: MatFormFieldAppearance = 'outline';
   @Input() routeSearchTerm?: string = '';
-  formGroup: UntypedFormGroup = new UntypedFormGroup({});
+
   @Output() searchEvent = new EventEmitter<string>();
+
+  formGroup = new FormGroup({
+    searchTerms: new FormControl(this.routeSearchTerm)
+  });
 
   get searchTerms() {
     return this.formGroup.controls.searchTerms;
   }
 
   ngOnInit(): void {
-    this.formGroup = new FormGroup({
-      searchTerms: new FormControl(this.routeSearchTerm)
-    });
+    this.searchTerms.setValue(this.routeSearchTerm);
   }
 
   reset() {

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.spec.ts
@@ -113,21 +113,32 @@ describe('CatalogueSearchComponent', () => {
     };
     const classifiers: Classifier[] = [testClassifier, testClassifier2];
 
-    harness.component.catalogueSearchAdvancedFormComponent.formGroup = new FormGroup(
-      {
-        context: new FormControl(contextTest),
-        domainTypes: new FormControl([
-          ModelDomainType.DataModels,
-          ModelDomainType.Classifiers
-        ]),
-        labelOnly: new FormControl(true),
-        exactMatch: new FormControl(true),
-        classifiers: new FormControl(classifiers),
-        createdAfter: new FormControl(new Date('July 21, 1983 01:15:00')),
-        createdBefore: new FormControl(new Date('July 22, 1983 01:15:00')),
-        lastUpdatedAfter: new FormControl(new Date('July 23, 1983 01:15:00')),
-        lastUpdatedBefore: new FormControl(new Date('July 24, 1983 01:15:00'))
-      }
+    harness.component.catalogueSearchAdvancedFormComponent.context.setValue(
+      contextTest
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.domainTypes.setValue(
+      [ModelDomainType.DataModels, ModelDomainType.Classifiers]
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.labelOnly.setValue(
+      true
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.exactMatch.setValue(
+      true
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.classifiers.setValue(
+      classifiers
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.createdAfter.setValue(
+      new Date('July 21, 1983 01:15:00')
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.createdBefore.setValue(
+      new Date('July 22, 1983 01:15:00')
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.lastUpdatedAfter.setValue(
+      new Date('July 23, 1983 01:15:00')
+    );
+    harness.component.catalogueSearchAdvancedFormComponent.lastUpdatedBefore.setValue(
+      new Date('July 24, 1983 01:15:00')
     );
 
     harness.component.search();

--- a/src/app/modals/add-rule-modal/add-rule-modal.component.ts
+++ b/src/app/modals/add-rule-modal/add-rule-modal.component.ts
@@ -57,11 +57,11 @@ export class AddRuleModalComponent implements OnInit {
   });
 
   get name() {
-    return this.formGroup.get('name');
+    return this.formGroup.controls.name;
   }
 
   get description() {
-    return this.formGroup.get('description');
+    return this.formGroup.controls.description;
   }
 
   constructor(

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
@@ -136,19 +136,19 @@ export class AddRuleRepresentationModalComponent implements OnInit {
   formGroup = new FormGroup({
     language: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
     representation: new FormControl(''),
-    importFileName: new FormControl()
+    importFileName: new FormControl('')
   });
 
   get language() {
-    return this.formGroup.get('language');
+    return this.formGroup.controls.language;
   }
 
   get representation() {
-    return this.formGroup.get('representation');
+    return this.formGroup.controls.representation;
   }
 
   get importFileName() {
-    return this.formGroup.get('importFileName');
+    return this.formGroup.controls.importFileName;
   }
 
   constructor(

--- a/src/app/modals/change-branch-name-modal/change-branch-name-modal.component.ts
+++ b/src/app/modals/change-branch-name-modal/change-branch-name-modal.component.ts
@@ -17,7 +17,14 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, Inject, OnInit } from '@angular/core';
-import { AbstractControl, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ValidationErrors,
+  ValidatorFn,
+  Validators
+} from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Branchable, Modelable } from '@maurodatamapper/mdm-resources';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
@@ -26,7 +33,9 @@ export const defaultBranchName = 'main';
 
 const defaultBranchNameValidator = (): ValidatorFn => {
   return (control: AbstractControl): ValidationErrors | null => {
-    return defaultBranchName.localeCompare(control.value as string, undefined, { sensitivity: 'accent' }) === 0
+    return defaultBranchName.localeCompare(control.value as string, undefined, {
+      sensitivity: 'accent'
+    }) === 0
       ? { invalidBranchName: { value: control.value } }
       : null;
   };
@@ -49,22 +58,23 @@ export interface ChangeBranchNameModalResult {
 export class ChangeBranchNameModalComponent implements OnInit {
   model: Modelable & Branchable;
   newBranchName: string;
-  formGroup: FormGroup;
+  formGroup = new FormGroup({
+    branchName: new FormControl('', [
+      Validators.required, // eslint-disable-line @typescript-eslint/unbound-method
+      defaultBranchNameValidator()
+    ])
+  });
 
   constructor(
-    private dialogRef: MatDialogRef<ChangeBranchNameModalComponent, ChangeBranchNameModalResult>,
+    private dialogRef: MatDialogRef<
+      ChangeBranchNameModalComponent,
+      ChangeBranchNameModalResult
+    >,
     @Inject(MAT_DIALOG_DATA) public data: ChangeBranchNameModalData
-  ) {
-    this.formGroup = new FormGroup({
-      branchName: new FormControl('', [
-        Validators.required, // eslint-disable-line @typescript-eslint/unbound-method
-        defaultBranchNameValidator()
-      ])
-    });
-  }
+  ) {}
 
   get branchName() {
-    return this.formGroup.get('branchName');
+    return this.formGroup.controls.branchName;
   }
 
   ngOnInit(): void {
@@ -85,5 +95,4 @@ export class ChangeBranchNameModalComponent implements OnInit {
       branchName: this.branchName.value
     });
   }
-
 }

--- a/src/app/modals/change-label-modal/change-label-modal.component.ts
+++ b/src/app/modals/change-label-modal/change-label-modal.component.ts
@@ -38,7 +38,11 @@ export interface ChangeLabelModalResult {
 })
 export class ChangeLabelModalComponent implements OnInit {
   item: CatalogueItemDetail;
-  formGroup: FormGroup;
+  formGroup = new FormGroup({
+    label: new FormControl('', [
+      Validators.required // eslint-disable-line @typescript-eslint/unbound-method
+    ])
+  });
 
   constructor(
     private dialogRef: MatDialogRef<
@@ -46,16 +50,10 @@ export class ChangeLabelModalComponent implements OnInit {
       ChangeLabelModalResult
     >,
     @Inject(MAT_DIALOG_DATA) public data: ChangeLabelModalData
-  ) {
-    this.formGroup = new FormGroup({
-      label: new FormControl('', [
-        Validators.required // eslint-disable-line @typescript-eslint/unbound-method
-      ])
-    });
-  }
+  ) {}
 
   get label() {
-    return this.formGroup.get('label');
+    return this.formGroup.controls.label;
   }
 
   ngOnInit(): void {

--- a/src/app/modals/export-model-dialog/export-model-dialog.component.ts
+++ b/src/app/modals/export-model-dialog/export-model-dialog.component.ts
@@ -48,7 +48,10 @@ export interface ExportModelDialogResponse {
 })
 export class ExportModelDialogComponent implements OnInit {
   exporters: Exporter[];
-  formGroup: FormGroup;
+  formGroup = new FormGroup({
+    exporter: new FormControl<Exporter>(null, Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    asynchronous: new FormControl(false)
+  });
 
   constructor(
     private dialogRef: MatDialogRef<
@@ -61,19 +64,14 @@ export class ExportModelDialogComponent implements OnInit {
   ) {}
 
   get exporter() {
-    return this.formGroup.get('exporter');
+    return this.formGroup.controls.exporter;
   }
 
   get asynchronous() {
-    return this.formGroup.get('asynchronous');
+    return this.formGroup.controls.asynchronous;
   }
 
   ngOnInit(): void {
-    this.formGroup = new FormGroup({
-      exporter: new FormControl(null, Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-      asynchronous: new FormControl(false)
-    });
-
     this.resources
       .getExportableResource(this.data.domain)
       .exporters()

--- a/src/app/modals/login-modal/login-modal.component.spec.ts
+++ b/src/app/modals/login-modal/login-modal.component.spec.ts
@@ -30,6 +30,7 @@ import { of } from 'rxjs';
 import { UserDetails } from '@mdm/services/handlers/security-handler.model';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { FeaturesService } from '@mdm/services/features.service';
+import { MockDirective } from 'ng-mocks';
 
 interface SecurityHandlerServiceStub {
   signIn: jest.Mock;
@@ -96,10 +97,7 @@ describe('LoginModalComponent', () => {
           useValue: features
         }
       ],
-      declarations: [
-        LoginModalComponent,
-        MatDialogContent
-      ]
+      declarations: [LoginModalComponent, MockDirective(MatDialogContent)]
     }).compileComponents();
   });
 
@@ -120,30 +118,37 @@ describe('LoginModalComponent', () => {
   });
 
   describe('Test: Login form', () => {
-
     it.each([
       ['', ''],
       ['test', ''],
       ['test@test.com', ''],
       ['', 'password'],
       ['test', 'password']
-    ])('should not submit invalid data - username: "%s", password: "%s"', (userName, password) => {
-      const spy = jest.spyOn(securityHandler, 'signIn');
-      component.signInForm.setValue({ userName, password });
-      component.login();
-      expect(spy).not.toHaveBeenCalled();
-    });
+    ])(
+      'should not submit invalid data - username: "%s", password: "%s"',
+      (userName, password) => {
+        const spy = jest.spyOn(securityHandler, 'signIn');
+        component.signInForm.setValue({ userName, password });
+        component.login();
+        expect(spy).not.toHaveBeenCalled();
+      }
+    );
 
     it('should submit valid data', () => {
-      securityHandler.signIn.mockImplementationOnce(() => of<UserDetails>({
-        id: '123',
-        firstName: 'test',
-        lastName: 'test',
-        userName: 'test@test.com',
-        email: 'test@test.com'
-      }));
+      securityHandler.signIn.mockImplementationOnce(() =>
+        of<UserDetails>({
+          id: '123',
+          firstName: 'test',
+          lastName: 'test',
+          userName: 'test@test.com',
+          email: 'test@test.com'
+        })
+      );
       const spy = jest.spyOn(securityHandler, 'signIn');
-      component.signInForm.setValue({ userName: 'test@test.com', password: 'password' });
+      component.signInForm.setValue({
+        userName: 'test@test.com',
+        password: 'password'
+      });
       component.login();
       expect(spy).toHaveBeenCalled();
     });

--- a/src/app/modals/login-modal/login-modal.component.ts
+++ b/src/app/modals/login-modal/login-modal.component.ts
@@ -24,22 +24,39 @@ import { MessageService } from '@mdm/services/message.service';
 import { ValidatorService } from '@mdm/services/validator.service';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { catchError, finalize } from 'rxjs/operators';
-import { SignInError, SignInErrorType } from '@mdm/services/handlers/security-handler.model';
+import {
+  SignInError,
+  SignInErrorType
+} from '@mdm/services/handlers/security-handler.model';
 import { EMPTY } from 'rxjs';
-import { MdmHttpHandlerOptions, MdmResourcesService } from '@mdm/modules/resources';
-import { PublicOpenIdConnectProvider, PublicOpenIdConnectProvidersIndexResponse } from '@maurodatamapper/mdm-resources';
+import {
+  MdmHttpHandlerOptions,
+  MdmResourcesService
+} from '@mdm/modules/resources';
+import {
+  PublicOpenIdConnectProvider,
+  PublicOpenIdConnectProvidersIndexResponse
+} from '@maurodatamapper/mdm-resources';
 import { MessageHandlerService, SharedService } from '@mdm/services';
 
 @Component({
   selector: 'mdm-login-modal',
   templateUrl: './login-modal.component.html',
-  styleUrls: ['./login-modal.component.scss'],
+  styleUrls: ['./login-modal.component.scss']
 })
 export class LoginModalComponent implements OnInit {
   message = '';
   authenticating = false;
 
-  signInForm!: FormGroup;
+  signInForm = new FormGroup({
+    userName: new FormControl('', [
+      Validators.required, // eslint-disable-line @typescript-eslint/unbound-method
+      Validators.pattern(this.validator.emailPattern)
+    ]),
+    password: new FormControl('', [
+      Validators.required // eslint-disable-line @typescript-eslint/unbound-method
+    ])
+  });
 
   openIdConnectProviders?: PublicOpenIdConnectProvider[];
 
@@ -51,28 +68,18 @@ export class LoginModalComponent implements OnInit {
     private validator: ValidatorService,
     private resources: MdmResourcesService,
     private shared: SharedService,
-    private messageHandler: MessageHandlerService) { }
+    private messageHandler: MessageHandlerService
+  ) {}
 
   get userName() {
-    return this.signInForm.get('userName');
+    return this.signInForm.controls.userName;
   }
 
   get password() {
-    return this.signInForm.get('password');
+    return this.signInForm.controls.password;
   }
 
-
   ngOnInit() {
-    this.signInForm = new FormGroup({
-      userName: new FormControl('', [
-        Validators.required,  // eslint-disable-line @typescript-eslint/unbound-method
-        Validators.pattern(this.validator.emailPattern)
-      ]),
-      password: new FormControl('', [
-        Validators.required // eslint-disable-line @typescript-eslint/unbound-method
-      ])
-    });
-
     if (this.shared.features.useOpenIdConnect) {
       // If unable to get OpenID Connect providers, silently fail and ignore
       const requestOptions: MdmHttpHandlerOptions = {
@@ -81,9 +88,7 @@ export class LoginModalComponent implements OnInit {
 
       this.resources.pluginOpenIdConnect
         .listPublic({}, requestOptions)
-        .pipe(
-          catchError(() => EMPTY)
-        )
+        .pipe(catchError(() => EMPTY))
         .subscribe((response: PublicOpenIdConnectProvidersIndexResponse) => {
           this.openIdConnectProviders = response.body;
         });
@@ -112,7 +117,8 @@ export class LoginModalComponent implements OnInit {
               this.message = 'Invalid username or password!';
               break;
             case SignInErrorType.AlreadySignedIn:
-              this.message = 'A user is already signed in, please sign out first.';
+              this.message =
+                'A user is already signed in, please sign out first.';
               break;
             default:
               this.message = 'Unable to sign in. Please try again later.';
@@ -126,7 +132,7 @@ export class LoginModalComponent implements OnInit {
           this.signInForm.enable();
         })
       )
-      .subscribe(user => {
+      .subscribe((user) => {
         this.dialogRef.close(user);
         this.securityHandler.loginModalDisplayed = false;
         this.messageService.loggedInChanged(true);
@@ -150,7 +156,9 @@ export class LoginModalComponent implements OnInit {
 
   authenticateWithOpenIdConnect(provider: PublicOpenIdConnectProvider) {
     if (!provider.authorizationEndpoint) {
-      this.messageHandler.showError(`Unable to authenticate with ${provider.label} because of a missing endpoint. Please contact your administrator for further support.`);
+      this.messageHandler.showError(
+        `Unable to authenticate with ${provider.label} because of a missing endpoint. Please contact your administrator for further support.`
+      );
       return;
     }
 

--- a/src/app/modals/new-folder-modal/new-folder-modal.component.ts
+++ b/src/app/modals/new-folder-modal/new-folder-modal.component.ts
@@ -21,11 +21,13 @@ import { Component, OnInit, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { EditingService } from '@mdm/services/editing.service';
 import { SharedService } from '@mdm/services';
-import { NewFolderModalConfiguration, NewFolderModalResponse } from './new-folder-modal.model';
+import {
+  NewFolderModalConfiguration,
+  NewFolderModalResponse
+} from './new-folder-modal.model';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ThemePalette } from '@angular/material/core';
-
 
 @Component({
   selector: 'mdm-new-folder-modal',
@@ -33,7 +35,6 @@ import { ThemePalette } from '@angular/material/core';
   styleUrls: ['./new-folder-modal.component.scss']
 })
 export class NewFolderModalComponent implements OnInit {
-
   okBtn: string;
   cancelBtn: string;
   btnType: ThemePalette;
@@ -44,22 +45,26 @@ export class NewFolderModalComponent implements OnInit {
   useVersionedFolders = false;
 
   folderForm = new FormGroup({
-    label: new FormControl('', Validators.required),  // eslint-disable-line @typescript-eslint/unbound-method
+    label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
     isVersioned: new FormControl(false)
   });
 
   constructor(
-    private dialogRef: MatDialogRef<NewFolderModalComponent, NewFolderModalResponse>,
+    private dialogRef: MatDialogRef<
+      NewFolderModalComponent,
+      NewFolderModalResponse
+    >,
     @Inject(MAT_DIALOG_DATA) public data: NewFolderModalConfiguration,
     private editing: EditingService,
-    private shared: SharedService) { }
+    private shared: SharedService
+  ) {}
 
   get label() {
-    return this.folderForm.get('label');
+    return this.folderForm.controls.label;
   }
 
   get isVersioned() {
-    return this.folderForm.get('isVersioned');
+    return this.folderForm.controls.isVersioned;
   }
 
   ngOnInit(): void {
@@ -70,17 +75,16 @@ export class NewFolderModalComponent implements OnInit {
     this.modalTitle = this.data.modalTitle ? this.data.modalTitle : '';
     this.message = this.data.message;
     this.createRootFolder = this.data.createRootFolder;
-    this.useVersionedFolders = this.data.canVersion && this.shared.features.useVersionedFolders;
+    this.useVersionedFolders =
+      this.data.canVersion && this.shared.features.useVersionedFolders;
   }
 
   cancel() {
-    this.editing
-      .confirmCancelAsync()
-      .subscribe(confirm => {
-        if (confirm) {
-          this.dialogRef.close({ status: ModalDialogStatus.Cancel });
-        }
-      });
+    this.editing.confirmCancelAsync().subscribe((confirm) => {
+      if (confirm) {
+        this.dialogRef.close({ status: ModalDialogStatus.Cancel });
+      }
+    });
   }
 
   confirm() {

--- a/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.ts
+++ b/src/app/subscribed-catalogues/new-federated-subscription-modal/new-federated-subscription-modal.component.ts
@@ -22,6 +22,7 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import {
   FolderDetail,
   Importer,
+  MdmTreeItem,
   PublishedDataModelLink
 } from '@maurodatamapper/mdm-resources';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
@@ -47,22 +48,22 @@ export class NewFederatedSubscriptionModalComponent implements OnInit {
   contentLinks: PublishedDataModelLink[];
   importers: Importer[];
 
-  formGroup: FormGroup = new FormGroup({
-    folder: new FormControl(null, [Validators.required]), // eslint-disable-line @typescript-eslint/unbound-method
-    format: new FormControl(null),
-    importer: new FormControl(null)
+  formGroup = new FormGroup({
+    folder: new FormControl<MdmTreeItem[]>(null, [Validators.required]), // eslint-disable-line @typescript-eslint/unbound-method
+    format: new FormControl<PublishedDataModelLink>(null),
+    importer: new FormControl<Importer>(null)
   });
 
   get format() {
-    return this.formGroup.get('format');
+    return this.formGroup.controls.format;
   }
 
   get folder() {
-    return this.formGroup.get('folder');
+    return this.formGroup.controls.folder;
   }
 
   get importer() {
-    return this.formGroup.get('importer');
+    return this.formGroup.controls.importer;
   }
 
   constructor(

--- a/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
+++ b/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
@@ -34,29 +34,32 @@ describe('SubscribedCatalogueDetailComponent', () => {
   let component: SubscribedCatalogueDetailComponent;
   let fixture: ComponentFixture<SubscribedCatalogueDetailComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        MatDialogModule,
-        FormsModule,
-        UIRouterModule.forRoot({ useHash: true }),
-        ToastrModule.forRoot()
-      ],
-      providers: [
-        {
-          provide: MdmResourcesService, useValue: {}
-        },
-      ],
-      declarations: [
-        SubscribedCatalogueDetailComponent,
-        NgxSkeletonLoaderComponent,
-        ContentEditorComponent,
-        MarkdownTextAreaComponent,
-        MarkdownDirective,
-        InlineTextEditComponent
-      ]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          MatDialogModule,
+          FormsModule,
+          UIRouterModule.forRoot({ useHash: true }),
+          ToastrModule.forRoot()
+        ],
+        providers: [
+          {
+            provide: MdmResourcesService,
+            useValue: {}
+          }
+        ],
+        declarations: [
+          SubscribedCatalogueDetailComponent,
+          NgxSkeletonLoaderComponent,
+          ContentEditorComponent,
+          MarkdownTextAreaComponent,
+          MarkdownDirective,
+          InlineTextEditComponent
+        ]
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SubscribedCatalogueDetailComponent);

--- a/src/app/terminology/term-relationship-type-list/create-term-relationship-type-dialog/create-term-relationship-type-dialog.component.ts
+++ b/src/app/terminology/term-relationship-type-list/create-term-relationship-type-dialog/create-term-relationship-type-dialog.component.ts
@@ -17,14 +17,41 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, Inject, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { TermRelationshipTypeDetail } from '@maurodatamapper/mdm-resources';
+import {
+  TerminologyDetail,
+  TermRelationshipType,
+  TermRelationshipTypeDetail,
+  Uuid
+} from '@maurodatamapper/mdm-resources';
 import { MessageHandlerService } from '@mdm/services';
 import { HttpResponse } from '@angular/common/http';
 import { catchError, finalize } from 'rxjs/operators';
 import { EMPTY } from 'rxjs';
+
+export class CreateTermRelationshipTypeForm {
+  id?: Uuid;
+  label: string;
+  displayLabel: string;
+  parentalRelationship = false;
+  childRelationship = false;
+
+  constructor(
+    readonly terminology: TerminologyDetail,
+    relationshipType?: TermRelationshipType
+  ) {
+    if (relationshipType) {
+      this.id = relationshipType.id || null;
+      this.label = relationshipType.label;
+      this.displayLabel = relationshipType.displayLabel;
+      this.parentalRelationship =
+        relationshipType.parentalRelationship || false;
+      this.childRelationship = relationshipType.childRelationship || false;
+    }
+  }
+}
 
 @Component({
   selector: 'mdm-create-term-relationship-type-dialog',
@@ -32,25 +59,29 @@ import { EMPTY } from 'rxjs';
   styleUrls: ['create-term-relationship-type-dialog.component.scss']
 })
 export class CreateTermRelationshipTypeDialogComponent implements OnInit {
-
-  form: UntypedFormGroup;
+  form = new FormGroup({
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    label: new FormControl('', Validators.required),
+    displayLabel: new FormControl(''),
+    parentalRelationship: new FormControl(false),
+    childRelationship: new FormControl(false)
+  });
 
   submitting = false;
 
   constructor(
     private resources: MdmResourcesService,
     private messageHandler: MessageHandlerService,
-    private formBuilder: UntypedFormBuilder,
     private dialogRef: MatDialogRef<CreateTermRelationshipTypeDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any) { }
+    @Inject(MAT_DIALOG_DATA) public data: CreateTermRelationshipTypeForm
+  ) {}
 
   ngOnInit() {
-    this.form = this.formBuilder.group({
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      label: [this.data.label, Validators.required],
-      displayLabel: [this.data.displayLabel],
-      parentalRelationship: [this.data.parentalRelationship],
-      childRelationship: [this.data.childRelationship]
+    this.form.setValue({
+      label: this.data.label,
+      displayLabel: this.data.displayLabel,
+      parentalRelationship: this.data.parentalRelationship,
+      childRelationship: this.data.childRelationship
     });
   }
 
@@ -61,45 +92,55 @@ export class CreateTermRelationshipTypeDialogComponent implements OnInit {
 
     this.submitting = true;
     if (this.data.id) {
-      this.resources.termRelationshipTypes.update(this.data.terminology.id, this.data.id, {
-        label: this.form.value.label,
-        displayLabel: this.form.value.displayLabel,
-        parentalRelationship: this.form.value.parentalRelationship || false,
-        childRelationship: this.form.value.childRelationship || false
-      }).pipe(
-        catchError(error => {
-          this.messageHandler.showError('Unable to create update relationship type');
-          console.error(error);
-          return EMPTY;
-        }),
-        finalize(() => this.submitting = false)
-      ).subscribe((response: HttpResponse<TermRelationshipTypeDetail>) => {
-        if (response.ok) {
-          this.dialogRef.close(response.body);
-        } else {
-          this.messageHandler.showWarning(response.body);
-        }
-      });
+      this.resources.termRelationshipTypes
+        .update(this.data.terminology.id, this.data.id, {
+          label: this.form.value.label,
+          displayLabel: this.form.value.displayLabel,
+          parentalRelationship: this.form.value.parentalRelationship || false,
+          childRelationship: this.form.value.childRelationship || false
+        })
+        .pipe(
+          catchError((error) => {
+            this.messageHandler.showError(
+              'Unable to create update relationship type'
+            );
+            console.error(error);
+            return EMPTY;
+          }),
+          finalize(() => (this.submitting = false))
+        )
+        .subscribe((response: HttpResponse<TermRelationshipTypeDetail>) => {
+          if (response.ok) {
+            this.dialogRef.close(response.body);
+          } else {
+            this.messageHandler.showWarning(response.body);
+          }
+        });
     } else {
-      this.resources.termRelationshipTypes.save(this.data.terminology.id, {
-        label: this.form.value.label,
-        displayLabel: this.form.value.displayLabel,
-        parentalRelationship: this.form.value.parentalRelationship || false,
-        childRelationship: this.form.value.childRelationship || false
-      }).pipe(
-        catchError(error => {
-          this.messageHandler.showError('Unable to create new relationship type');
-          console.error(error);
-          return EMPTY;
-        }),
-        finalize(() => this.submitting = false)
-      ).subscribe((response: HttpResponse<TermRelationshipTypeDetail>) => {
-        if (response.ok) {
-          this.dialogRef.close(response.body);
-        } else {
-          this.messageHandler.showWarning(response.body);
-        }
-      });
+      this.resources.termRelationshipTypes
+        .save(this.data.terminology.id, {
+          label: this.form.value.label,
+          displayLabel: this.form.value.displayLabel,
+          parentalRelationship: this.form.value.parentalRelationship || false,
+          childRelationship: this.form.value.childRelationship || false
+        })
+        .pipe(
+          catchError((error) => {
+            this.messageHandler.showError(
+              'Unable to create new relationship type'
+            );
+            console.error(error);
+            return EMPTY;
+          }),
+          finalize(() => (this.submitting = false))
+        )
+        .subscribe((response: HttpResponse<TermRelationshipTypeDetail>) => {
+          if (response.ok) {
+            this.dialogRef.close(response.body);
+          } else {
+            this.messageHandler.showWarning(response.body);
+          }
+        });
     }
   }
 

--- a/src/app/terminology/term-relationship-type-list/term-relationship-type-list.component.ts
+++ b/src/app/terminology/term-relationship-type-list/term-relationship-type-list.component.ts
@@ -33,37 +33,17 @@ import {
   FilterQueryParameters,
   TerminologyDetail,
   TermRelationshipType,
-  TermRelationshipTypeDetailResponse,
-  Uuid
+  TermRelationshipTypeDetailResponse
 } from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { merge } from 'rxjs';
 import { MdmTableDataSource } from '@mdm/utility/table-data-source';
-import { CreateTermRelationshipTypeDialogComponent } from './create-term-relationship-type-dialog/create-term-relationship-type-dialog.component';
+import {
+  CreateTermRelationshipTypeDialogComponent,
+  CreateTermRelationshipTypeForm
+} from './create-term-relationship-type-dialog/create-term-relationship-type-dialog.component';
 import { MdmPaginatorComponent } from '@mdm/shared/mdm-paginator/mdm-paginator';
 import { EditingService } from '@mdm/services/editing.service';
-
-class CreateTermRelationshipTypeForm {
-  id?: Uuid;
-  label: string;
-  displayLabel: string;
-  parentalRelationship = false;
-  childRelationship = false;
-
-  constructor(
-    readonly terminology: TerminologyDetail,
-    relationshipType?: TermRelationshipType
-  ) {
-    if (relationshipType) {
-      this.id = relationshipType.id || null;
-      this.label = relationshipType.label;
-      this.displayLabel = relationshipType.displayLabel;
-      this.parentalRelationship =
-        relationshipType.parentalRelationship || false;
-      this.childRelationship = relationshipType.childRelationship || false;
-    }
-  }
-}
 
 @Component({
   selector: 'mdm-term-relationship-type-list',

--- a/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
+++ b/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
@@ -44,26 +44,33 @@ export class CodeSetMainComponent implements OnInit {
   parentDomainType: CatalogueItemDomainType;
   parentFolder: Container;
   savingInProgress = false;
-  setupForm: FormGroup;
+  setupForm = new FormGroup({
+    label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    author: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
+    organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
+    description: new FormControl(''),
+    classifiers: new FormControl([]),
+    terms: new FormControl([]) // eslint-disable-line @typescript-eslint/unbound-method
+  });
 
   get label() {
-    return this.setupForm.get('label');
+    return this.setupForm.controls.label;
   }
 
   get author() {
-    return this.setupForm.get('author');
+    return this.setupForm.controls.author;
   }
 
   get organisation() {
-    return this.setupForm.get('organisation');
+    return this.setupForm.controls.organisation;
   }
 
   get description() {
-    return this.setupForm.get('description');
+    return this.setupForm.controls.description;
   }
 
   get classifiers() {
-    return this.setupForm.get('classifiers');
+    return this.setupForm.controls.classifiers;
   }
 
   set classifiersValue(value: any[]) {
@@ -71,7 +78,7 @@ export class CodeSetMainComponent implements OnInit {
   }
 
   get terms() {
-    return this.setupForm.get('terms');
+    return this.setupForm.controls.terms;
   }
 
   set termsValue(value: any[]) {
@@ -89,15 +96,6 @@ export class CodeSetMainComponent implements OnInit {
 
   ngOnInit() {
     this.title.setTitle('New Code Set');
-
-    this.setupForm = new FormGroup({
-      label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-      author: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
-      organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
-      description: new FormControl(''),
-      classifiers: new FormControl([]),
-      terms: new FormControl([]) // eslint-disable-line @typescript-eslint/unbound-method
-    });
 
     this.parentFolderId = this.uiRouterGlobals.params.parentFolderId;
     this.parentDomainType = this.uiRouterGlobals.params.parentDomainType;

--- a/src/app/wizards/dataModel/data-model-step1/data-model-step1.component.ts
+++ b/src/app/wizards/dataModel/data-model-step1/data-model-step1.component.ts
@@ -19,11 +19,18 @@ SPDX-License-Identifier: Apache-2.0
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { HelpDialogueHandlerService } from '@mdm/services/helpDialogue.service';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { ControlContainer, FormControl, FormGroup, NgForm, Validators } from '@angular/forms';
+import {
+  ControlContainer,
+  FormControl,
+  FormGroup,
+  NgForm,
+  Validators
+} from '@angular/forms';
 import { Subject } from 'rxjs';
 import { WizardStep } from '@mdm/wizards/wizards.model';
 import { DataModelMainComponent } from '../data-model-main/data-model-main.component';
 import { takeUntil } from 'rxjs/operators';
+import { DataModelType } from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-data-model-step1',
@@ -32,10 +39,16 @@ import { takeUntil } from 'rxjs/operators';
   viewProviders: [{ provide: ControlContainer, useExisting: NgForm }]
 })
 export class DataModelStep1Component implements OnInit, OnDestroy {
-
   allDataModelTypes: any;
   step: WizardStep<DataModelMainComponent>;
-  setupForm: FormGroup;
+  setupForm = new FormGroup({
+    label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    author: new FormControl(''),
+    organisation: new FormControl(''),
+    description: new FormControl(''),
+    dataModelType: new FormControl<DataModelType>(null, Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    classifiers: new FormControl([])
+  });
 
   private unsubscribe$ = new Subject<void>();
 
@@ -45,27 +58,27 @@ export class DataModelStep1Component implements OnInit, OnDestroy {
   ) {}
 
   get label() {
-    return this.setupForm.get('label');
+    return this.setupForm.controls.label;
   }
 
   get author() {
-    return this.setupForm.get('author');
+    return this.setupForm.controls.author;
   }
 
   get organisation() {
-    return this.setupForm.get('organisation');
+    return this.setupForm.controls.organisation;
   }
 
   get description() {
-    return this.setupForm.get('description');
+    return this.setupForm.controls.description;
   }
 
   get dataModelType() {
-    return this.setupForm.get('dataModelType');
+    return this.setupForm.controls.dataModelType;
   }
 
   get classifiers() {
-    return this.setupForm.get('classifiers');
+    return this.setupForm.controls.classifiers;
   }
 
   set classifiersValue(value: any[]) {
@@ -73,24 +86,18 @@ export class DataModelStep1Component implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.setupForm = new FormGroup({
-      label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-      author: new FormControl(''),
-      organisation: new FormControl(''),
-      description: new FormControl(''),
-      dataModelType: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-      classifiers: new FormControl([])
-    });
-
     this.setupForm.valueChanges
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(() => {
         this.step.invalid = this.setupForm.invalid;
       });
 
-    this.resources.dataModel.types().toPromise().then(dataTypes => {
-      this.allDataModelTypes = dataTypes.body;
-    });
+    this.resources.dataModel
+      .types()
+      .toPromise()
+      .then((dataTypes) => {
+        this.allDataModelTypes = dataTypes.body;
+      });
   }
 
   ngOnDestroy() {

--- a/src/app/wizards/referenceDataModel/reference-data-model-main/reference-data-model-main.component.ts
+++ b/src/app/wizards/referenceDataModel/reference-data-model-main/reference-data-model-main.component.ts
@@ -44,26 +44,32 @@ export class ReferenceDataModelMainComponent implements OnInit {
   parentDomainType: CatalogueItemDomainType;
   parentFolder: Container;
   savingInProgress = false;
-  setupForm: FormGroup;
+  setupForm = new FormGroup({
+    label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    author: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
+    organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
+    description: new FormControl(''),
+    classifiers: new FormControl([])
+  });
 
   get label() {
-    return this.setupForm.get('label');
+    return this.setupForm.controls.label;
   }
 
   get author() {
-    return this.setupForm.get('author');
+    return this.setupForm.controls.author;
   }
 
   get organisation() {
-    return this.setupForm.get('organisation');
+    return this.setupForm.controls.organisation;
   }
 
   get description() {
-    return this.setupForm.get('description');
+    return this.setupForm.controls.description;
   }
 
   get classifiers() {
-    return this.setupForm.get('classifiers');
+    return this.setupForm.controls.classifiers;
   }
 
   set classifiersValue(value: any[]) {
@@ -81,14 +87,6 @@ export class ReferenceDataModelMainComponent implements OnInit {
 
   ngOnInit(): void {
     this.title.setTitle('New Reference Data Model');
-
-    this.setupForm = new FormGroup({
-      label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-      author: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
-      organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
-      description: new FormControl(''),
-      classifiers: new FormControl([])
-    });
 
     this.parentFolderId = this.uiRouterGlobals.params.parentFolderId;
     this.parentDomainType = this.uiRouterGlobals.params.parentDomainType;

--- a/src/app/wizards/referenceDataType/new-reference-data-type-form/new-reference-data-type-form.component.ts
+++ b/src/app/wizards/referenceDataType/new-reference-data-type-form/new-reference-data-type-form.component.ts
@@ -78,31 +78,33 @@ export class NewReferenceDataTypeFormComponent implements OnInit, OnDestroy {
   @Output() formChange = new EventEmitter<NewReferenceDataTypeState>();
 
   formGroup = new FormGroup({
-    type: new FormControl(null, Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-    label: new FormControl(null, Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-    description: new FormControl(null),
-    enumerationValues: new FormControl(
-      null,
-      referenceDataEnumerationValuesListValidator()
-    )
+    type: new FormControl<
+      | CatalogueItemDomainType.ReferencePrimitiveType
+      | CatalogueItemDomainType.ReferenceEnumerationType
+    >(null, Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    description: new FormControl(''),
+    enumerationValues: new FormControl<
+      ReferenceDataEnumerationValueCreatePayload[]
+    >(null, referenceDataEnumerationValuesListValidator())
   });
 
   private unsubscribe$ = new Subject<void>();
 
   get type() {
-    return this.formGroup.get('type');
+    return this.formGroup.controls.type;
   }
 
   get label() {
-    return this.formGroup.get('label');
+    return this.formGroup.controls.label;
   }
 
   get description() {
-    return this.formGroup.get('description');
+    return this.formGroup.controls.description;
   }
 
   get enumerationValues() {
-    return this.formGroup.get('enumerationValues');
+    return this.formGroup.controls.enumerationValues;
   }
 
   ngOnInit(): void {

--- a/src/app/wizards/terminology/terminology-main/terminology-main.component.ts
+++ b/src/app/wizards/terminology/terminology-main/terminology-main.component.ts
@@ -43,26 +43,32 @@ export class TerminologyMainComponent implements OnInit {
   parentDomainType: CatalogueItemDomainType;
   parentFolder: Container;
   savingInProgress = false;
-  setupForm: FormGroup;
+  setupForm = new FormGroup({
+    label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
+    author: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
+    organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
+    description: new FormControl(''),
+    classifiers: new FormControl([])
+  });
 
   get label() {
-    return this.setupForm.get('label');
+    return this.setupForm.controls.label;
   }
 
   get author() {
-    return this.setupForm.get('author');
+    return this.setupForm.controls.author;
   }
 
   get organisation() {
-    return this.setupForm.get('organisation');
+    return this.setupForm.controls.organisation;
   }
 
   get description() {
-    return this.setupForm.get('description');
+    return this.setupForm.controls.description;
   }
 
   get classifiers() {
-    return this.setupForm.get('classifiers');
+    return this.setupForm.controls.classifiers;
   }
 
   set classifiersValue(value: any[]) {
@@ -80,14 +86,6 @@ export class TerminologyMainComponent implements OnInit {
 
   ngOnInit(): void {
     this.title.setTitle('New Terminology');
-
-    this.setupForm = new FormGroup({
-      label: new FormControl('', Validators.required), // eslint-disable-line @typescript-eslint/unbound-method
-      author: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
-      organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
-      description: new FormControl(''),
-      classifiers: new FormControl([])
-    });
 
     this.parentFolderId = this.uiRouterGlobals.params.parentFolderId;
     this.parentDomainType = this.uiRouterGlobals.params.parentDomainType;


### PR DESCRIPTION
Resolves #742 

Note that some existing forms have _not_ been updated as they seem more complex, these are:

- `mdm-new-version`
- `mdm-openid-connect-provider`
- `mdm-create-term-relationship-dialog`

All other uses of `FormGroup` have been updated to be strongly typed.