### PR TITLE
Tidy test spec files

### DIFF
--- a/src/app/access/share-with/share-with.component.spec.ts
+++ b/src/app/access/share-with/share-with.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MdmResourcesService } from '@mdm/modules/resources';
@@ -28,7 +28,7 @@ describe('ShareWithComponent', () => {
   let component: ShareWithComponent;
   let fixture: ComponentFixture<ShareWithComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatCheckboxModule,

--- a/src/app/admin/api-property-table/api-property-table.component.spec.ts
+++ b/src/app/admin/api-property-table/api-property-table.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from '@mdm/modules/material/material.module';
@@ -31,7 +31,7 @@ describe('ApiPropertyTableComponent', () => {
   let component: ApiPropertyTableComponent;
   let fixture: ComponentFixture<ApiPropertyTableComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MaterialModule,

--- a/src/app/admin/api-property-table/api-property-table.component.spec.ts
+++ b/src/app/admin/api-property-table/api-property-table.component.spec.ts
@@ -25,6 +25,7 @@ import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
 
 import { ApiPropertyTableComponent } from './api-property-table.component';
+import { DataTypeListButtonsComponent } from '@mdm/shared/data-type-list-buttons/data-type-list-buttons.component';
 
 describe('ApiPropertyTableComponent', () => {
   let component: ApiPropertyTableComponent;
@@ -48,7 +49,9 @@ describe('ApiPropertyTableComponent', () => {
           }
         }
       ],
-      declarations: [ ApiPropertyTableComponent ]
+      declarations: [
+        ApiPropertyTableComponent,
+        DataTypeListButtonsComponent]
     })
     .compileComponents();
   }));

--- a/src/app/admin/api-property/api-property.component.spec.ts
+++ b/src/app/admin/api-property/api-property.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from '@mdm/modules/material/material.module';
@@ -32,7 +32,7 @@ describe('ApiPropertyComponent', () => {
   let component: ApiPropertyComponent;
   let fixture: ComponentFixture<ApiPropertyComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MaterialModule,

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { ProfilePictureComponent } from './shared/profile-picture/profile-picture.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -37,7 +37,7 @@ import { FeaturesService } from './services/features.service';
 import { LoadingIndicatorComponent } from '@mdm/utility/loading-indicator/loading-indicator.component';
 
 describe('AppComponent', () => {
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         NgxSkeletonLoaderModule,

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -34,6 +34,7 @@ import { MdmResourcesService } from './modules/resources';
 import { MatDialogModule } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FeaturesService } from './services/features.service';
+import { LoadingIndicatorComponent } from '@mdm/utility/loading-indicator/loading-indicator.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -65,7 +66,8 @@ describe('AppComponent', () => {
         ByteArrayToBase64Pipe,
         NavbarComponent,
         FooterComponent,
-        AppComponent
+        AppComponent,
+        LoadingIndicatorComponent,
       ],
     }).compileComponents();
   }));

--- a/src/app/enumerationValues/enumeration-values-details/enumeration-values-details.component.spec.ts
+++ b/src/app/enumerationValues/enumeration-values-details/enumeration-values-details.component.spec.ts
@@ -17,17 +17,35 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { EnumerationValuesDetailsComponent } from './enumeration-values-details.component';
-import { ComponentHarness, setupTestModuleForComponent } from '@mdm/testing/testing.helpers';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { SubscribedCatalogueDetailComponent } from '@mdm/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component';
+import { ModelPathComponent } from '@mdm/utility/model-path/model-path.component';
 
 describe('EnumerationValuesDetailsComponent', () => {
-  let harness: ComponentHarness<EnumerationValuesDetailsComponent>;
+  let component: SubscribedCatalogueDetailComponent;
+  let fixture: ComponentFixture<SubscribedCatalogueDetailComponent>;
 
-  beforeEach(async () => {
-    harness = await setupTestModuleForComponent(EnumerationValuesDetailsComponent);
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        ModelPathComponent
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SubscribedCatalogueDetailComponent);
+    component = fixture.componentInstance;
+    component.subscribedCatalogue = {
+      url: '',
+      label: '',
+      subscribedCatalogueType: 'test',
+      subscribedCatalogueAuthenticationType: ''
+    };
+    fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(harness.isComponentCreated).toBeTruthy();
+    expect(component).toBeTruthy();
   });
 });

--- a/src/app/enumerationValues/enumeration-values/enumeration-values.component.spec.ts
+++ b/src/app/enumerationValues/enumeration-values/enumeration-values.component.spec.ts
@@ -17,11 +17,11 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { EnumerationValuesComponent } from './enumeration-values.component';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { empty } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
 import { MatTabsModule } from '@angular/material/tabs';
@@ -31,7 +31,7 @@ describe('EnumerationValuesComponent', () => {
   let component: EnumerationValuesComponent;
   let fixture: ComponentFixture<EnumerationValuesComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
          MatTabsModule,
@@ -43,9 +43,9 @@ describe('EnumerationValuesComponent', () => {
          {
            provide: MdmResourcesService,
            // tslint:disable-next-line: deprecation
-           useValue: { dataType: { get: () => empty() },
+           useValue: { dataType: { get: () => EMPTY },
            // tslint:disable-next-line: deprecation
-           enumerationValues: { getFromDataType: () => empty() }
+           enumerationValues: { getFromDataType: () => EMPTY }
          },
         },
        ],

--- a/src/app/modals/api-keys-modal/api-keys-modal.component.spec.ts
+++ b/src/app/modals/api-keys-modal/api-keys-modal.component.spec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ApiKeysModalComponent } from './api-keys-modal.component';
 import { MatRadioModule } from '@angular/material/radio';
@@ -32,7 +32,7 @@ describe('ApiKeysModalComponent', () => {
   let component: ApiKeysModalComponent;
   let fixture: ComponentFixture<ApiKeysModalComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
          MatRadioModule,

--- a/src/app/modals/finalise-modal/finalise-modal.component.spec.ts
+++ b/src/app/modals/finalise-modal/finalise-modal.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { FinaliseModalComponent } from './finalise-modal.component';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
@@ -31,7 +31,7 @@ describe('FinaliseModalComponent', () => {
   let component: FinaliseModalComponent;
   let fixture: ComponentFixture<FinaliseModalComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatRadioModule,

--- a/src/app/modals/input-modal/input-modal.component.spec.ts
+++ b/src/app/modals/input-modal/input-modal.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { InputModalComponent } from './input-modal.component';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { FormsModule } from '@angular/forms';
@@ -29,7 +29,7 @@ describe('InputModalComponent', () => {
   let component: InputModalComponent;
   let fixture: ComponentFixture<InputModalComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatFormFieldModule,

--- a/src/app/modals/login-modal/login-modal.component.spec.ts
+++ b/src/app/modals/login-modal/login-modal.component.spec.ts
@@ -20,7 +20,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { LoginModalComponent } from './login-modal.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogContent, MatDialogRef } from '@angular/material/dialog';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
 import { MatInputModule } from '@angular/material/input';
@@ -97,7 +97,8 @@ describe('LoginModalComponent', () => {
         }
       ],
       declarations: [
-        LoginModalComponent
+        LoginModalComponent,
+        MatDialogContent
       ]
     }).compileComponents();
   });

--- a/src/app/modals/register-modal/register-modal.component.spec.ts
+++ b/src/app/modals/register-modal/register-modal.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { RegisterModalComponent } from './register-modal.component';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -34,7 +34,7 @@ describe('RegisterModalComponent', () => {
   let component: RegisterModalComponent;
   let fixture: ComponentFixture<RegisterModalComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatFormFieldModule,

--- a/src/app/model-selector-tree/model-selector-tree.component.spec.ts
+++ b/src/app/model-selector-tree/model-selector-tree.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ModelSelectorTreeComponent } from './model-selector-tree.component';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
@@ -29,7 +29,7 @@ import { MdmResourcesService } from '@mdm/modules/resources';
 import { ByteArrayToBase64Pipe } from '@mdm/pipes/byte-array-to-base64.pipe';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { SecurityHandlerService } from '@mdm/services';
-import { empty } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { ContainerDomainType } from '@maurodatamapper/mdm-resources';
 
 interface SecurityHandlerServiceStub {
@@ -46,7 +46,7 @@ describe('ModelSelectorTreeComponent', () => {
     isLoggedIn: jest.fn(() => false)
   };
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         NgxSkeletonLoaderModule,
@@ -62,9 +62,9 @@ describe('ModelSelectorTreeComponent', () => {
           useValue: {
             tree: {
               // tslint:disable-next-line: deprecation
-              list: () => empty(),
+              list: () => EMPTY,
               // tslint:disable-next-line: deprecation
-              get: () => empty()
+              get: () => EMPTY
             }
           }
         },

--- a/src/app/referenceData/reference-data-element/reference-data-element.component.spec.ts
+++ b/src/app/referenceData/reference-data-element/reference-data-element.component.spec.ts
@@ -27,6 +27,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { MatTableModule } from '@angular/material/table';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkeletonBadgeComponent } from '@mdm/utility/skeleton-badge/skeleton-badge.component';
 
 describe('ReferenceDataElementComponent', () => {
   let component: ReferenceDataElementComponent;
@@ -39,7 +40,7 @@ describe('ReferenceDataElementComponent', () => {
         MatDialogModule,
         NgxSkeletonLoaderModule,
         MatTableModule,
-        NoopAnimationsModule
+        NoopAnimationsModule,
       ],
       providers: [
         {
@@ -52,7 +53,11 @@ describe('ReferenceDataElementComponent', () => {
           }
         }
       ],
-      declarations: [ReferenceDataElementComponent, MdmPaginatorComponent]
+      declarations: [
+        ReferenceDataElementComponent,
+        MdmPaginatorComponent,
+        SkeletonBadgeComponent
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/referenceData/reference-data-element/reference-data-element.component.spec.ts
+++ b/src/app/referenceData/reference-data-element/reference-data-element.component.spec.ts
@@ -16,11 +16,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ReferenceDataElementComponent } from './reference-data-element.component';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { empty } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MdmPaginatorComponent } from '@mdm/shared/mdm-paginator/mdm-paginator';
 import { MatPaginatorModule } from '@angular/material/paginator';
@@ -33,7 +33,7 @@ describe('ReferenceDataElementComponent', () => {
   let component: ReferenceDataElementComponent;
   let fixture: ComponentFixture<ReferenceDataElementComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatPaginatorModule,
@@ -48,7 +48,7 @@ describe('ReferenceDataElementComponent', () => {
           useValue: {
             referenceDataElement: {
               // tslint:disable-next-line: deprecation
-              list: () => empty()
+              list: () => EMPTY
             }
           }
         }

--- a/src/app/referenceData/reference-data-values/reference-data-values.component.spec.ts
+++ b/src/app/referenceData/reference-data-values/reference-data-values.component.spec.ts
@@ -16,9 +16,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { empty } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatTableModule } from '@angular/material/table';
@@ -32,7 +32,7 @@ describe('ReferenceDataValuesComponent', () => {
   let component: ReferenceDataValuesComponent;
   let fixture: ComponentFixture<ReferenceDataValuesComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatPaginatorModule,
@@ -47,9 +47,9 @@ describe('ReferenceDataValuesComponent', () => {
           useValue: {
             referenceDataValue: {
               // tslint:disable-next-line: deprecation
-              list: () => empty(),
+              list: () => EMPTY,
               // tslint:disable-next-line: deprecation
-              search: () => empty()
+              search: () => EMPTY
             }
           }
         }

--- a/src/app/referenceData/reference-data-values/reference-data-values.component.spec.ts
+++ b/src/app/referenceData/reference-data-values/reference-data-values.component.spec.ts
@@ -26,6 +26,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MdmPaginatorComponent } from '@mdm/shared/mdm-paginator/mdm-paginator';
 import { ReferenceDataValuesComponent } from './reference-data-values.component';
 import { FormsModule } from '@angular/forms';
+import { SkeletonBadgeComponent } from '@mdm/utility/skeleton-badge/skeleton-badge.component';
 
 describe('ReferenceDataValuesComponent', () => {
   let component: ReferenceDataValuesComponent;
@@ -53,7 +54,7 @@ describe('ReferenceDataValuesComponent', () => {
           }
         }
       ],
-      declarations: [ReferenceDataValuesComponent, MdmPaginatorComponent]
+      declarations: [ReferenceDataValuesComponent, MdmPaginatorComponent, SkeletonBadgeComponent]
     }).compileComponents();
   }));
 

--- a/src/app/shared/alert/alert.component.spec.ts
+++ b/src/app/shared/alert/alert.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AlertComponent } from './alert.component';
 import { AlertStyle } from './alert.model';
@@ -25,7 +25,7 @@ describe('AlertComponent', () => {
   let component: AlertComponent;
   let fixture: ComponentFixture<AlertComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ AlertComponent ]
     })

--- a/src/app/shared/classified-elements-list/classified-elements-list.component.spec.ts
+++ b/src/app/shared/classified-elements-list/classified-elements-list.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ClassifiedElementsListComponent } from './classified-elements-list.component';
 import { ToastrModule } from 'ngx-toastr';
@@ -42,7 +42,7 @@ describe('ClassifiedElementsListComponent', () => {
   let component: ClassifiedElementsListComponent;
   let fixture: ComponentFixture<ClassifiedElementsListComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,

--- a/src/app/shared/code-set-terms-table/code-set-terms-table.component.spec.ts
+++ b/src/app/shared/code-set-terms-table/code-set-terms-table.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CodeSetTermsTableComponent } from './code-set-terms-table.component';
 import { MatSortModule } from '@angular/material/sort';
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
@@ -46,7 +46,7 @@ describe('CodeSetTermsTableComponent', () => {
   let component: CodeSetTermsTableComponent;
   let fixture: ComponentFixture<CodeSetTermsTableComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         NgxSkeletonLoaderModule,

--- a/src/app/shared/data-classes-list/data-classes-list.component.spec.ts
+++ b/src/app/shared/data-classes-list/data-classes-list.component.spec.ts
@@ -45,6 +45,7 @@ import { AllLinksInPagedListComponent } from '@mdm/utility/all-links-in-paged-li
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { MultiplicityComponent } from '../multiplicity/multiplicity.component';
 import { ByteArrayToBase64Pipe } from '@mdm/pipes/byte-array-to-base64.pipe';
+import { SkeletonBadgeComponent } from '@mdm/utility/skeleton-badge/skeleton-badge.component';
 
 describe('DataClassesListComponent', () => {
    let component: DataClassesListComponent;
@@ -85,7 +86,8 @@ describe('DataClassesListComponent', () => {
             MdmPaginatorComponent,
             MultiplicityComponent,
             ByteArrayToBase64Pipe,
-            DataClassesListComponent
+            DataClassesListComponent,
+            SkeletonBadgeComponent
          ]
       })
          .compileComponents();

--- a/src/app/shared/data-classes-list/data-classes-list.component.spec.ts
+++ b/src/app/shared/data-classes-list/data-classes-list.component.spec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DataClassesListComponent } from './data-classes-list.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -51,7 +51,7 @@ describe('DataClassesListComponent', () => {
    let component: DataClassesListComponent;
    let fixture: ComponentFixture<DataClassesListComponent>;
 
-   beforeEach(async(() => {
+   beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
          imports: [
             NgxSkeletonLoaderModule,

--- a/src/app/shared/data-elements-list/data-elements-list.component.spec.ts
+++ b/src/app/shared/data-elements-list/data-elements-list.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DataElementsListComponent } from './data-elements-list.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -51,7 +51,7 @@ describe('DataElementsListComponent', () => {
    let component: DataElementsListComponent;
    let fixture: ComponentFixture<DataElementsListComponent>;
 
-   beforeEach(async(() => {
+   beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
          imports: [
             NgxSkeletonLoaderModule,

--- a/src/app/shared/data-elements-list/data-elements-list.component.spec.ts
+++ b/src/app/shared/data-elements-list/data-elements-list.component.spec.ts
@@ -45,6 +45,7 @@ import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { MultiplicityComponent } from '../multiplicity/multiplicity.component';
 import { ByteArrayToBase64Pipe } from '@mdm/pipes/byte-array-to-base64.pipe';
 import '@mdm/utility/extensions/mat-dialog.extensions';
+import { SkeletonBadgeComponent } from '@mdm/utility/skeleton-badge/skeleton-badge.component';
 
 describe('DataElementsListComponent', () => {
    let component: DataElementsListComponent;
@@ -85,7 +86,8 @@ describe('DataElementsListComponent', () => {
             MdmPaginatorComponent,
             MultiplicityComponent,
             ByteArrayToBase64Pipe,
-            DataElementsListComponent
+            DataElementsListComponent,
+            SkeletonBadgeComponent
          ]
       }).compileComponents();
    }));

--- a/src/app/shared/history/history.component.spec.ts
+++ b/src/app/shared/history/history.component.spec.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { HistoryComponent } from './history.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -36,7 +36,7 @@ describe('HistoryComponent', () => {
   let component: HistoryComponent;
   let fixture: ComponentFixture<HistoryComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
    TestBed.configureTestingModule({
      imports: [
        NgxSkeletonLoaderModule,

--- a/src/app/shared/inline-text-edit/inline-text-edit.component.spec.ts
+++ b/src/app/shared/inline-text-edit/inline-text-edit.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { InlineTextEditComponent } from './inline-text-edit.component';
 import { FormsModule } from '@angular/forms';
@@ -26,7 +26,7 @@ describe('InlineTextEditComponent', () => {
   let component: InlineTextEditComponent;
   let fixture: ComponentFixture<InlineTextEditComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         CommonModule,

--- a/src/app/shared/mc-data-set-metadata/mc-data-set-metadata.component.spec.ts
+++ b/src/app/shared/mc-data-set-metadata/mc-data-set-metadata.component.spec.ts
@@ -37,6 +37,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatInputModule } from '@angular/material/input';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { SkeletonBadgeComponent } from '@mdm/utility/skeleton-badge/skeleton-badge.component';
 
 describe('McDataSetMetadataComponent', () => {
   let component: McDataSetMetadataComponent;
@@ -70,7 +71,8 @@ describe('McDataSetMetadataComponent', () => {
         MarkdownTextAreaComponent,
         MarkdownDirective,
         MoreDescriptionComponent,
-        McDataSetMetadataComponent
+        McDataSetMetadataComponent,
+        SkeletonBadgeComponent
       ]
     })
     .compileComponents();

--- a/src/app/shared/mc-data-set-metadata/mc-data-set-metadata.component.spec.ts
+++ b/src/app/shared/mc-data-set-metadata/mc-data-set-metadata.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { McDataSetMetadataComponent } from './mc-data-set-metadata.component';
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { MatPaginatorModule } from '@angular/material/paginator';
@@ -43,7 +43,7 @@ describe('McDataSetMetadataComponent', () => {
   let component: McDataSetMetadataComponent;
   let fixture: ComponentFixture<McDataSetMetadataComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         NgxSkeletonLoaderModule,

--- a/src/app/shared/text-diff/text-diff.component.spec.ts
+++ b/src/app/shared/text-diff/text-diff.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { TextDiffComponent } from './text-diff.component';
 
@@ -24,7 +24,7 @@ describe('TextDiffComponent', () => {
   let component: TextDiffComponent;
   let fixture: ComponentFixture<TextDiffComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ TextDiffComponent ]
     })

--- a/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.spec.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { ToastrModule } from 'ngx-toastr';
@@ -33,7 +33,7 @@ describe('FederatedDataModelDetailComponent', () => {
   let component: FederatedDataModelDetailComponent;
   let fixture: ComponentFixture<FederatedDataModelDetailComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatDialogModule,

--- a/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.spec.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-detail/federated-data-model-detail.component.spec.ts
@@ -22,6 +22,12 @@ import { MdmResourcesService } from '@mdm/modules/resources';
 import { ToastrModule } from 'ngx-toastr';
 
 import { FederatedDataModelDetailComponent } from './federated-data-model-detail.component';
+import { InlineTextEditComponent } from '@mdm/shared/inline-text-edit/inline-text-edit.component';
+import { ContentEditorComponent } from '@mdm/utility/content-editor/content-editor.component';
+import { UIRouterModule } from '@uirouter/angular';
+import { MarkdownTextAreaComponent } from '@mdm/utility/markdown/markdown-text-area/markdown-text-area.component';
+import { MarkdownDirective } from '@mdm/directives/markdown.directive';
+import { FormsModule } from '@angular/forms';
 
 describe('FederatedDataModelDetailComponent', () => {
   let component: FederatedDataModelDetailComponent;
@@ -31,7 +37,11 @@ describe('FederatedDataModelDetailComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         MatDialogModule,
-        ToastrModule.forRoot()
+        FormsModule,
+        ToastrModule.forRoot(),
+
+        // Transitive Dependency
+        UIRouterModule.forRoot({ useHash: true }),
       ],
       providers: [
         {
@@ -43,7 +53,13 @@ describe('FederatedDataModelDetailComponent', () => {
           useValue: {}
         },
       ],
-      declarations: [ FederatedDataModelDetailComponent ]
+      declarations: [
+        FederatedDataModelDetailComponent,
+        InlineTextEditComponent,
+        ContentEditorComponent,
+        MarkdownTextAreaComponent,
+        MarkdownDirective
+      ]
     })
     .compileComponents();
   }));

--- a/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.spec.ts
+++ b/src/app/subscribed-catalogues/federated-data-model-main/federated-data-model-main.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
@@ -29,7 +29,7 @@ describe('FederatedDataModelMainComponent', () => {
   let component: FederatedDataModelMainComponent;
   let fixture: ComponentFixture<FederatedDataModelMainComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         UIRouterModule.forRoot({ useHash: true }),

--- a/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
+++ b/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SubscribedCatalogueDetailComponent } from './subscribed-catalogue-detail.component';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
@@ -28,13 +28,13 @@ import { MarkdownTextAreaComponent } from '@mdm/utility/markdown/markdown-text-a
 import { MatDialogModule } from '@angular/material/dialog';
 import { MarkdownDirective } from '@mdm/directives/markdown.directive';
 import { InlineTextEditComponent } from '@mdm/shared/inline-text-edit/inline-text-edit.component';
-import { FormsModule } from "@angular/forms";
+import { FormsModule } from '@angular/forms';
 
 describe('SubscribedCatalogueDetailComponent', () => {
   let component: SubscribedCatalogueDetailComponent;
   let fixture: ComponentFixture<SubscribedCatalogueDetailComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatDialogModule,

--- a/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
+++ b/src/app/subscribed-catalogues/subscribed-catalogue-detail/subscribed-catalogue-detail.component.spec.ts
@@ -19,6 +19,16 @@ SPDX-License-Identifier: Apache-2.0
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SubscribedCatalogueDetailComponent } from './subscribed-catalogue-detail.component';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
+import { ContentEditorComponent } from '@mdm/utility/content-editor/content-editor.component';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { UIRouterModule } from '@uirouter/angular';
+import { ToastrModule } from 'ngx-toastr';
+import { MarkdownTextAreaComponent } from '@mdm/utility/markdown/markdown-text-area/markdown-text-area.component';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MarkdownDirective } from '@mdm/directives/markdown.directive';
+import { InlineTextEditComponent } from '@mdm/shared/inline-text-edit/inline-text-edit.component';
+import { FormsModule } from "@angular/forms";
 
 describe('SubscribedCatalogueDetailComponent', () => {
   let component: SubscribedCatalogueDetailComponent;
@@ -26,7 +36,25 @@ describe('SubscribedCatalogueDetailComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SubscribedCatalogueDetailComponent]
+      imports: [
+        MatDialogModule,
+        FormsModule,
+        UIRouterModule.forRoot({ useHash: true }),
+        ToastrModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: MdmResourcesService, useValue: {}
+        },
+      ],
+      declarations: [
+        SubscribedCatalogueDetailComponent,
+        NgxSkeletonLoaderComponent,
+        ContentEditorComponent,
+        MarkdownTextAreaComponent,
+        MarkdownDirective,
+        InlineTextEditComponent
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/subscribed-catalogues/subscribed-catalogue-main/subscribed-catalogue-main.component.spec.ts
+++ b/src/app/subscribed-catalogues/subscribed-catalogue-main/subscribed-catalogue-main.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
@@ -27,7 +27,7 @@ describe('SubscribedCatalogueComponent', () => {
   let component: SubscribedCatalogueMainComponent;
   let fixture: ComponentFixture<SubscribedCatalogueMainComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         UIRouterModule.forRoot({ useHash: true }),

--- a/src/app/userArea/api-keys/api-keys.component.spec.ts
+++ b/src/app/userArea/api-keys/api-keys.component.spec.ts
@@ -17,23 +17,22 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ApiKeysComponent } from './api-keys.component';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { empty } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
-import '@mdm/utility/extensions/mat-dialog.extensions';
 import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('ApiKeysComponent', () => {
    let component: ApiKeysComponent;
    let fixture: ComponentFixture<ApiKeysComponent>;
 
-   beforeEach(async(() => {
+   beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
          imports: [
             MatDialogModule,
@@ -47,17 +46,17 @@ describe('ApiKeysComponent', () => {
                useValue: {
                   catalogueUser: {
                      // tslint:disable-next-line: deprecation
-                     listApiKeys: () => empty(),
+                     listApiKeys: () => EMPTY,
                      // tslint:disable-next-line: deprecation
-                     enableApiKey: () => empty(),
+                     enableApiKey: () => EMPTY,
                      // tslint:disable-next-line: deprecation
-                     disableApiKey: () => empty(),
+                     disableApiKey: () => EMPTY,
                      // tslint:disable-next-line: deprecation
-                     refreshApiKey: () => empty(),
+                     refreshApiKey: () => EMPTY,
                      // tslint:disable-next-line: deprecation
-                     saveApiKey: () => empty(),
+                     saveApiKey: () => EMPTY,
                      // tslint:disable-next-line: deprecation
-                     removeApiKey: () => empty(),
+                     removeApiKey: () => EMPTY,
                   }
                }
             }

--- a/src/app/userArea/api-keys/api-keys.component.spec.ts
+++ b/src/app/userArea/api-keys/api-keys.component.spec.ts
@@ -27,6 +27,7 @@ import { ToastrModule } from 'ngx-toastr';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
 import '@mdm/utility/extensions/mat-dialog.extensions';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('ApiKeysComponent', () => {
    let component: ApiKeysComponent;
@@ -61,7 +62,7 @@ describe('ApiKeysComponent', () => {
                }
             }
          ],
-         declarations: [ApiKeysComponent]
+         declarations: [ApiKeysComponent, NgxSkeletonLoaderComponent]
       }).compileComponents();
    }));
 

--- a/src/app/utility/all-links-in-paged-list/all-links-in-paged-list.component.spec.ts
+++ b/src/app/utility/all-links-in-paged-list/all-links-in-paged-list.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { AllLinksInPagedListComponent } from './all-links-in-paged-list.component';
 import { McPagedListComponent } from '../mc-paged-list/mc-paged-list.component';
@@ -28,7 +28,7 @@ describe('AllLinksInPagedListComponent', () => {
   let component: AllLinksInPagedListComponent;
   let fixture: ComponentFixture<AllLinksInPagedListComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatTooltipModule

--- a/src/app/utility/data-model-default.component.spec.ts
+++ b/src/app/utility/data-model-default.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DataModelDefaultComponent } from './data-model-default.component';
 
@@ -24,7 +24,7 @@ describe('DataModelDefaultComponent', () => {
   let component: DataModelDefaultComponent;
   let fixture: ComponentFixture<DataModelDefaultComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ DataModelDefaultComponent ]
     })

--- a/src/app/utility/element-alias/element-alias.component.spec.ts
+++ b/src/app/utility/element-alias/element-alias.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ElementAliasComponent } from './element-alias.component';
 import { MatInputModule } from '@angular/material/input';
@@ -27,7 +27,7 @@ describe('ElementAliasComponent', () => {
   let component: ElementAliasComponent;
   let fixture: ComponentFixture<ElementAliasComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,

--- a/src/app/utility/element-classifications/element-classifications.component.spec.ts
+++ b/src/app/utility/element-classifications/element-classifications.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ElementClassificationsComponent } from './element-classifications.component';
 import { MatSelectModule } from '@angular/material/select';
@@ -25,7 +25,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { empty } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 
@@ -33,7 +33,7 @@ describe('ElementClassificationsComponent', () => {
   let component: ElementClassificationsComponent;
   let fixture: ComponentFixture<ElementClassificationsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
@@ -50,7 +50,7 @@ describe('ElementClassificationsComponent', () => {
           useValue: {
             classifier: {
               // tslint:disable-next-line: deprecation
-              list: () => empty()
+              list: () => EMPTY
             }
           }
         }

--- a/src/app/utility/element-selector.component.spec.ts
+++ b/src/app/utility/element-selector.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ElementSelectorComponent } from './element-selector.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { ProfilePictureComponent } from '@mdm/shared/profile-picture/profile-picture.component';
@@ -38,7 +38,7 @@ describe('ElementSelectorComponent', () => {
   let component: ElementSelectorComponent;
   let fixture: ComponentFixture<ElementSelectorComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         NgxSkeletonLoaderModule,

--- a/src/app/utility/element-status/element-status.component.spec.ts
+++ b/src/app/utility/element-status/element-status.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { ElementStatusComponent } from './element-status.component';
 
@@ -24,7 +24,7 @@ describe('ElementStatusComponent', () => {
   let component: ElementStatusComponent;
   let fixture: ComponentFixture<ElementStatusComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ ElementStatusComponent ]
     })

--- a/src/app/utility/loading-indicator/loading-indicator.component.spec.ts
+++ b/src/app/utility/loading-indicator/loading-indicator.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { LoadingIndicatorComponent } from './loading-indicator.component';
 
@@ -24,7 +24,7 @@ describe('LoadingIndicatorComponent', () => {
   let component: LoadingIndicatorComponent;
   let fixture: ComponentFixture<LoadingIndicatorComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ LoadingIndicatorComponent ]
     })

--- a/src/app/utility/mc-paged-list/mc-paged-list.component.spec.ts
+++ b/src/app/utility/mc-paged-list/mc-paged-list.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { McPagedListComponent } from './mc-paged-list.component';
 
@@ -24,7 +24,7 @@ describe('McPagedListComponent', () => {
   let component: McPagedListComponent;
   let fixture: ComponentFixture<McPagedListComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ McPagedListComponent ]
     })

--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.spec.ts
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { MultipleTermsSelectorComponent } from './multiple-terms-selector.component';
 import { McPagedListComponent } from '../mc-paged-list/mc-paged-list.component';
@@ -29,13 +29,13 @@ import { FormsModule } from '@angular/forms';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
-import { empty } from 'rxjs';
+import { EMPTY } from 'rxjs';
 
 describe('MultipleTermsSelectorComponent', () => {
   let component: MultipleTermsSelectorComponent;
   let fixture: ComponentFixture<MultipleTermsSelectorComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatTableModule,
@@ -51,7 +51,7 @@ describe('MultipleTermsSelectorComponent', () => {
           useValue: {
             terminology: {
               // tslint:disable-next-line: deprecation
-              list: () => empty()
+              list: () => EMPTY
             }
           }
         }

--- a/src/app/utility/new-data-type-inline/new-data-type-inline.component.spec.ts
+++ b/src/app/utility/new-data-type-inline/new-data-type-inline.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { NewDataTypeInlineComponent } from './new-data-type-inline.component';
 import { McEnumerationListWithCategoryComponent } from '../mc-enumeration-list-with-category/mc-enumeration-list-with-category.component';
 import { ModelSelectorTreeComponent } from '@mdm/model-selector-tree/model-selector-tree.component';
@@ -38,14 +38,14 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { UIRouterModule } from '@uirouter/angular';
 import { ToastrModule } from 'ngx-toastr';
-import { empty } from 'rxjs/internal/observable/empty';
+import { EMPTY } from 'rxjs';
 import '@mdm/utility/extensions/mat-dialog.extensions';
 
 describe('NewDataTypeInlineComponent', () => {
   let component: NewDataTypeInlineComponent;
   let fixture: ComponentFixture<NewDataTypeInlineComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatOptionModule,
@@ -66,16 +66,13 @@ describe('NewDataTypeInlineComponent', () => {
           provide: MdmResourcesService,
           useValue: {
             terminology: {
-              // tslint:disable-next-line: deprecation
-              list: () => empty()
+              list: () => EMPTY
             },
             codeSet: {
-               // tslint:disable-next-line: deprecation
-               list: () => empty()
+               list: () => EMPTY
              },
              referenceDataModel: {
-               // tslint:disable-next-line: deprecation
-               list: () => empty()
+               list: () => EMPTY
              }
           }
         }

--- a/src/app/utility/skeleton-badge/skeleton-badge.component.spec.ts
+++ b/src/app/utility/skeleton-badge/skeleton-badge.component.spec.ts
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SkeletonBadgeComponent } from './skeleton-badge.component';
+import { NgxSkeletonLoaderComponent } from 'ngx-skeleton-loader';
 
 describe('SkeletonBadgeComponent', () => {
   let component: SkeletonBadgeComponent;
@@ -26,7 +27,7 @@ describe('SkeletonBadgeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SkeletonBadgeComponent ]
+      declarations: [ SkeletonBadgeComponent, NgxSkeletonLoaderComponent ]
     })
     .compileComponents();
   });

--- a/src/app/utility/term-relationships/term-relationships.component.spec.ts
+++ b/src/app/utility/term-relationships/term-relationships.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { TermRelationshipsComponent } from './term-relationships.component';
 import { McPagedListComponent } from '../mc-paged-list/mc-paged-list.component';
 import { ElementLinkComponent } from '../element-link/element-link.component';
@@ -28,7 +28,7 @@ describe('TermRelationshipsComponent', () => {
   let component: TermRelationshipsComponent;
   let fixture: ComponentFixture<TermRelationshipsComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatDialogModule,

--- a/src/app/wizards/dataElement/data-element-main/data-element-main.component.spec.ts
+++ b/src/app/wizards/dataElement/data-element-main/data-element-main.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DataElementMainComponent } from './data-element-main.component';
 import { ProfilePictureComponent } from '@mdm/shared/profile-picture/profile-picture.component';
@@ -34,7 +34,7 @@ describe('DataElementMainComponent', () => {
   let component: DataElementMainComponent;
   let fixture: ComponentFixture<DataElementMainComponent>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         NgxSkeletonLoaderModule,

--- a/src/app/wizards/dataElement/data-element-step1/data-element-step1.component.spec.ts
+++ b/src/app/wizards/dataElement/data-element-step1/data-element-step1.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DataElementStep1Component } from './data-element-step1.component';
 import { ElementLinkComponent } from '@mdm/utility/element-link/element-link.component';
@@ -30,7 +30,7 @@ describe('DataElementStep1Component', () => {
   let component: DataElementStep1Component;
   let fixture: ComponentFixture<DataElementStep1Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         MatRadioModule,

--- a/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.spec.ts
+++ b/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.spec.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { DataElementStep2Component } from './data-element-step2.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -54,7 +54,7 @@ describe('DataElementStep2Component', () => {
   let component: DataElementStep2Component;
   let fixture: ComponentFixture<DataElementStep2Component>;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,


### PR DESCRIPTION
- Add missing imports and declarations to get rid of warnings during testing
- Replace deprecated methods `async` and `empty` in spec files
Fixes #751 