### PR TITLE
Slight improvements to Summary Metadata bar chart presentation

### DIFF
--- a/src/app/shared/summary-metadata/summary-metadata-chart/summary-metadata-chart.component.ts
+++ b/src/app/shared/summary-metadata/summary-metadata-chart/summary-metadata-chart.component.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, Input, OnInit } from '@angular/core';
-import { ChartDataset, ChartOptions, ChartType, Ticks } from "chart.js";
+import { ChartDataset, ChartOptions, ChartType } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 @Component({
@@ -74,7 +74,7 @@ export class SummaryMetadataChartComponent implements OnInit {
     scales: {
       xAxis: {
         ticks: {
-          callback: (value, index, ticks): string => {
+          callback: (value, index): string => {
             let shortLabel = this.barChartLabels[index].toString();
             if(shortLabel == null){
               return '';

--- a/src/app/shared/summary-metadata/summary-metadata-chart/summary-metadata-chart.component.ts
+++ b/src/app/shared/summary-metadata/summary-metadata-chart/summary-metadata-chart.component.ts
@@ -17,7 +17,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, Input, OnInit } from '@angular/core';
-import { ChartDataset, ChartOptions, ChartType } from 'chart.js';
+import { ChartDataset, ChartOptions, ChartType, Ticks } from "chart.js";
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 
 @Component({
@@ -71,7 +71,23 @@ export class SummaryMetadataChartComponent implements OnInit {
   public barChartOptions: ChartOptions = {
     responsive: true,
     // We use these empty structures as placeholders for dynamic theming.
-    scales: { xAxis: {}, yAxis: { min: 0 } },
+    scales: {
+      xAxis: {
+        ticks: {
+          callback: (value, index, ticks): string => {
+            let shortLabel = this.barChartLabels[index].toString();
+            if(shortLabel == null){
+              return '';
+            }
+            if (shortLabel.length > 15) {
+              shortLabel = shortLabel.substring(0, 15);
+              shortLabel += '...';
+            }
+            return shortLabel;
+          }
+        }
+      }, yAxis: { min: 0 } },
+
 
     plugins: {
       datalabels: {

--- a/src/app/shared/summary-metadata/summary-metadata-table/summary-metadata-table.component.html
+++ b/src/app/shared/summary-metadata/summary-metadata-table/summary-metadata-table.component.html
@@ -39,7 +39,7 @@ SPDX-License-Identifier: Apache-2.0
         mat-header-cell
         *matHeaderCellDef
         mat-sort-header
-        style="cursor: pointer; max-width: 40%; width: 40%"
+        style="cursor: pointer; max-width: 30%; width: 20%"
         scope="col"
         [disabled]="!hideFilters"
       >
@@ -51,7 +51,7 @@ SPDX-License-Identifier: Apache-2.0
           </mat-form-field>
         </div>
       </th>
-      <td mat-cell *matCellDef="let record" style="word-wrap: break-word">
+      <td mat-cell *matCellDef="let record" style="word-wrap: break-word; vertical-align: middle;">
         <h4 class="marginless">{{ record.label }}</h4>
         <p>{{ record.description }}</p>
         <button


### PR DESCRIPTION
Shorten the labels on the chart so that the rotation doesn't spoil the appearance.  Also tweak the table column widths and title styling.

Before:
<img width="1677" alt="Screenshot 2023-02-09 at 14 57 13" src="https://user-images.githubusercontent.com/1869668/217858794-3252c5bb-a72e-46a0-8977-37d491a30686.png">

After:
<img width="1681" alt="Screenshot 2023-02-09 at 15 31 57" src="https://user-images.githubusercontent.com/1869668/217858693-0c67f802-0a87-4870-a903-282b3a58ea7a.png">
