### PR TITLE
Fix import stopping dist build on Jenkins

### DIFF
--- a/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.ts
+++ b/src/app/admin/subscribed-catalogue/subscribed-catalogue.component.ts
@@ -20,6 +20,7 @@ import {Component, OnInit} from '@angular/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {Title} from '@angular/platform-browser';
 import {
+  MdmResponse,
   SubscribedCatalogue,
   SubscribedCatalogueResponse,
   Uuid
@@ -34,7 +35,6 @@ import {EditingService} from '@mdm/services/editing.service';
 import {UIRouterGlobals} from '@uirouter/core';
 import {EMPTY, forkJoin, Observable, of} from 'rxjs';
 import {catchError, map, switchMap} from 'rxjs/operators';
-import {MdmResponse} from '../../../../../mdm-resources/src';
 
 @Component({
   selector: 'mdm-subscribed-catalogue',


### PR DESCRIPTION
This should fix the issue currently appearing in Jenkins:
```
Error: src/app/admin/subscribed-catalogue/subscribed-catalogue.component.ts:37:27 - error TS2307: Cannot find module '../../../../../mdm-resources/src' or its corresponding type declarations.
37 import {MdmResponse} from '../../../../../mdm-resources/src';
```
