### PR TITLE
gh-760: adding colour display for theme properties

### DIFF
--- a/src/app/admin/api-property-table/api-property-table.component.html
+++ b/src/app/admin/api-property-table/api-property-table.component.html
@@ -63,11 +63,11 @@ SPDX-License-Identifier: Apache-2.0
                 <span>Value</span>
             </th>
             <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                <span *ngIf="record.metadata.key.includes('theme.color')">{{record.original?.value}} <input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display"></span>
-                <span *ngIf="!record.metadata.key.includes('theme.color') && (record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html)" class="mdm-api-property-table__value--content">
+                <span *ngIf="record.metadata.key | matchThemeColorPattern">{{record.original?.value}} <input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display"></span>
+                <span *ngIf="!(record.metadata.key | matchThemeColorPattern) && (record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html)" class="mdm-api-property-table__value--content">
                     Content
                 </span>
-                <span *ngIf=" !record.metadata.key.includes('theme.color') && (record.metadata.editType === EditType.Value || record.metadata.editType === EditType.Boolean)">{{record.original?.value}}</span>
+                <span *ngIf=" !(record.metadata.key | matchThemeColorPattern) && (record.metadata.editType === EditType.Value || record.metadata.editType === EditType.Boolean)">{{record.original?.value}}</span>
             </td>
         </ng-container>
           <ng-container matColumnDef="icons">

--- a/src/app/admin/api-property-table/api-property-table.component.html
+++ b/src/app/admin/api-property-table/api-property-table.component.html
@@ -63,11 +63,11 @@ SPDX-License-Identifier: Apache-2.0
                 <span>Value</span>
             </th>
             <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                <span *ngIf="record.metadata.key.startsWith('explorer.theme.color')">{{record.original?.value}} <input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display"></span>
-                <span *ngIf="!record.metadata.key.startsWith('explorer.theme.color') && (record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html)" class="mdm-api-property-table__value--content">
+                <span *ngIf="record.metadata.key.includes('theme.color')">{{record.original?.value}} <input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display"></span>
+                <span *ngIf="!record.metadata.key.includes('theme.color') && (record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html)" class="mdm-api-property-table__value--content">
                     Content
                 </span>
-                <span *ngIf=" !record.metadata.key.startsWith('explorer.theme.color') && (record.metadata.editType === EditType.Value || record.metadata.editType === EditType.Boolean)">{{record.original?.value}}</span>
+                <span *ngIf=" !record.metadata.key.includes('theme.color') && (record.metadata.editType === EditType.Value || record.metadata.editType === EditType.Boolean)">{{record.original?.value}}</span>
             </td>
         </ng-container>
           <ng-container matColumnDef="icons">

--- a/src/app/admin/api-property-table/api-property-table.component.html
+++ b/src/app/admin/api-property-table/api-property-table.component.html
@@ -63,7 +63,7 @@ SPDX-License-Identifier: Apache-2.0
                 <span>Value</span>
             </th>
             <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                <span *ngIf="record.metadata.key | matchThemeColorPattern" class="mdm-api-property-table__colour-text">{{record.original?.value}} </span><input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display">
+                <span *ngIf="record.metadata.key | matchThemeColorPattern" class="mdm-api-property-table__colour-text">{{record.original?.value}} </span><input *ngIf="record.metadata.key | matchThemeColorPattern"  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display">
                 <span *ngIf="!(record.metadata.key | matchThemeColorPattern) && (record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html)" class="mdm-api-property-table__value--content">
                     Content
                 </span>

--- a/src/app/admin/api-property-table/api-property-table.component.html
+++ b/src/app/admin/api-property-table/api-property-table.component.html
@@ -63,10 +63,11 @@ SPDX-License-Identifier: Apache-2.0
                 <span>Value</span>
             </th>
             <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                <span *ngIf="record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html" class="mdm-api-property-table__value--content">
+                <span *ngIf="record.metadata.key.startsWith('explorer.theme.color')">{{record.original?.value}} <input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display"></span>
+                <span *ngIf="!record.metadata.key.startsWith('explorer.theme.color') && (record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html)" class="mdm-api-property-table__value--content">
                     Content
                 </span>
-                <span *ngIf="record.metadata.editType === EditType.Value || record.metadata.editType === EditType.Boolean">{{record.original?.value}}</span>
+                <span *ngIf=" !record.metadata.key.startsWith('explorer.theme.color') && (record.metadata.editType === EditType.Value || record.metadata.editType === EditType.Boolean)">{{record.original?.value}}</span>
             </td>
         </ng-container>
           <ng-container matColumnDef="icons">

--- a/src/app/admin/api-property-table/api-property-table.component.html
+++ b/src/app/admin/api-property-table/api-property-table.component.html
@@ -63,7 +63,7 @@ SPDX-License-Identifier: Apache-2.0
                 <span>Value</span>
             </th>
             <td mat-cell *matCellDef="let record" style="text-align: left; word-wrap: break-word;">
-                <span *ngIf="record.metadata.key | matchThemeColorPattern">{{record.original?.value}} <input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display"></span>
+                <span *ngIf="record.metadata.key | matchThemeColorPattern" class="mdm-api-property-table__colour-text">{{record.original?.value}} </span><input  type="color" value="{{record.original?.value}}" disabled class="mdm-api-property-table__colour-display">
                 <span *ngIf="!(record.metadata.key | matchThemeColorPattern) && (record.metadata.editType === EditType.Text || record.metadata.editType === EditType.Html)" class="mdm-api-property-table__value--content">
                     Content
                 </span>

--- a/src/app/admin/api-property-table/api-property-table.component.scss
+++ b/src/app/admin/api-property-table/api-property-table.component.scss
@@ -29,6 +29,11 @@ i.fa-globe {
     color: #076528;
 }
 
+.mdm-api-property-table__colour-text{
+    width: 100px;
+    display: inline-block;
+}
+
 .mdm-api-property-table__colour-display{
     width: 24px;
 }

--- a/src/app/admin/api-property-table/api-property-table.component.scss
+++ b/src/app/admin/api-property-table/api-property-table.component.scss
@@ -28,3 +28,7 @@ i.fa-cog {
 i.fa-globe {
     color: #076528;
 }
+
+.mdm-api-property-table__colour-display{
+    width: 24px;
+}

--- a/src/app/admin/api-property/api-property.component.html
+++ b/src/app/admin/api-property/api-property.component.html
@@ -56,13 +56,13 @@ SPDX-License-Identifier: Apache-2.0
     </div>
     <mat-form-field *ngIf="property.metadata.editType !== EditTypes.Html" appearance="outline">
         <mat-label>Value</mat-label>
-        <div *ngIf="key.value.includes('theme.color')" class="mdm-api-property__colour-input-container">
+        <div *ngIf="key.value | matchThemeColorPattern" class="mdm-api-property__colour-input-container">
             <input type="text" matInput name="value" formControlName="value" [value]="value.value" required>
             <input type="color" matInput name="value" formControlName="value" required [value]="value.value">
         </div>
-        <input *ngIf="!key.value.includes('theme.color') && property.metadata.editType === EditTypes.Value" matInput name="value" formControlName="value" required />
-        <textarea *ngIf="key.value.includes('theme.color')! && property.metadata.editType === EditTypes.Text" matInput name="value" formControlName="value" rows="9" required></textarea>
-        <mat-select *ngIf="!key.value.includes('theme.color') && property.metadata.editType === EditTypes.Boolean" formControlName="value" required>
+        <input *ngIf="!(key.value | matchThemeColorPattern) && property.metadata.editType === EditTypes.Value" matInput name="value" formControlName="value" required />
+        <textarea *ngIf="!(key.value | matchThemeColorPattern) && property.metadata.editType === EditTypes.Text" matInput name="value" formControlName="value" rows="9" required></textarea>
+        <mat-select *ngIf="!(key.value | matchThemeColorPattern) && property.metadata.editType === EditTypes.Boolean" formControlName="value" required>
           <mat-option [value]="'true'">Yes</mat-option>
           <mat-option [value]="'false'">No</mat-option>
         </mat-select>

--- a/src/app/admin/api-property/api-property.component.html
+++ b/src/app/admin/api-property/api-property.component.html
@@ -56,9 +56,13 @@ SPDX-License-Identifier: Apache-2.0
     </div>
     <mat-form-field *ngIf="property.metadata.editType !== EditTypes.Html" appearance="outline">
         <mat-label>Value</mat-label>
-        <input *ngIf="property.metadata.editType === EditTypes.Value" matInput name="value" formControlName="value" required />
-        <textarea *ngIf="property.metadata.editType === EditTypes.Text" matInput name="value" formControlName="value" rows="9" required></textarea>
-        <mat-select *ngIf="property.metadata.editType === EditTypes.Boolean" formControlName="value" required>
+        <div *ngIf="key.value.includes('theme.color')" class="mdm-api-property__colour-input-container">
+            <input type="text" matInput name="value" formControlName="value" [value]="value.value" required>
+            <input type="color" matInput name="value" formControlName="value" required [value]="value.value">
+        </div>
+        <input *ngIf="!key.value.includes('theme.color') && property.metadata.editType === EditTypes.Value" matInput name="value" formControlName="value" required />
+        <textarea *ngIf="key.value.includes('theme.color')! && property.metadata.editType === EditTypes.Text" matInput name="value" formControlName="value" rows="9" required></textarea>
+        <mat-select *ngIf="!key.value.includes('theme.color') && property.metadata.editType === EditTypes.Boolean" formControlName="value" required>
           <mat-option [value]="'true'">Yes</mat-option>
           <mat-option [value]="'false'">No</mat-option>
         </mat-select>

--- a/src/app/admin/api-property/api-property.component.scss
+++ b/src/app/admin/api-property/api-property.component.scss
@@ -34,3 +34,17 @@ SPDX-License-Identifier: Apache-2.0
     margin-top: -0.25em;
     position: relative;
 }
+
+.mdm-api-property__colour-input-container{
+    input{ 
+        display: inline;
+
+        &[type=text]{
+            width: 150px;
+        }
+        &[type=color]{
+            display: inline-block;
+            width: 24px;
+        }
+    }
+}

--- a/src/app/admin/api-property/api-property.component.scss
+++ b/src/app/admin/api-property/api-property.component.scss
@@ -40,7 +40,7 @@ SPDX-License-Identifier: Apache-2.0
         display: inline;
 
         &[type=text]{
-            width: 150px;
+            width: 100px;
         }
         &[type=color]{
             display: inline-block;

--- a/src/app/modules/admin/admin.module.ts
+++ b/src/app/modules/admin/admin.module.ts
@@ -27,6 +27,7 @@ import { ProfilesDashboardComponent } from '@mdm/profiles-dashboard/profiles-das
 import { OpenidConnectProviderTableComponent } from '@mdm/admin/openid-connect-provider-table/openid-connect-provider-table.component';
 import { OpenidConnectProviderComponent } from '@mdm/admin/openid-connect-provider/openid-connect-provider.component';
 import { DoiRedirectComponent } from '@mdm/doi-redirect/doi-redirect.component';
+import {MatchThemeColorPatternPipe} from '@mdm/pipes/matchThemeColorPattern.pipe';
 
 @NgModule({
   declarations: [
@@ -37,7 +38,8 @@ import { DoiRedirectComponent } from '@mdm/doi-redirect/doi-redirect.component';
     ProfilesDashboardComponent,
     OpenidConnectProviderTableComponent,
     OpenidConnectProviderComponent,
-    DoiRedirectComponent
+    DoiRedirectComponent,
+    MatchThemeColorPatternPipe
   ],
   imports: [CommonModule, AdminRoutesModule, SharedModule],
   exports: [
@@ -45,7 +47,8 @@ import { DoiRedirectComponent } from '@mdm/doi-redirect/doi-redirect.component';
     EmailsComponent,
     GroupMemberTableComponent,
     UserComponent,
-    ProfilesDashboardComponent
+    ProfilesDashboardComponent,
+    MatchThemeColorPatternPipe
   ]
 })
 export class AdminModule {}

--- a/src/app/pipes/matchThemeColorPatter.pipe.spec.ts
+++ b/src/app/pipes/matchThemeColorPatter.pipe.spec.ts
@@ -1,0 +1,150 @@
+/*
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import {MatchThemeColorPatternPipe} from '@mdm/pipes/matchThemeColorPattern.pipe';
+
+describe('MatchThemeColorPatternPipe', () => {
+    // This pipe is a pure, stateless function so no need for BeforeEach
+    const pipe = new MatchThemeColorPatternPipe();
+
+    it('should detect theme color pattern names', () => {
+        // Arrange
+        interface TestData {
+          stringToTest: string,
+          expectedOutcome:  boolean,
+        };
+        
+        const testingCases : TestData[]= [
+          {
+            stringToTest: "",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "explorer.theme.material.colors.primary",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.material.colors.accent",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.material.colors.warn",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.material.typography.fontfamily",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "explorer.theme.material.typography.bodyone",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "explorer.theme.material.typography.bodytwo",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "explorer.theme.material.typography.button",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "explorer.theme.regularcolors.requestcount",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.regularcolors.hyperlink",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.contrastcolors.page",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.contrastcolors.unsentrequest",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.contrastcolors.submittedrequest",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.contrastcolors.classrow",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "explorer.theme.material.colors.primary",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "email.theme.material.colors.primary",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "mauro.theme.material.colors.primary",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "mdm.theme.material.colors.accent",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "email.theme.material.colors.warn",
+            expectedOutcome: true,
+          },
+          {
+            stringToTest: "mdm.color.material.themes.accent",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "email.colors.material.theme.warn",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "email.admin_confirm_registration.body",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "email.password_reset.subject",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "datatype.date.formats",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "explorer.config.root_data_model_path",
+            expectedOutcome: false,
+          },
+          {
+            stringToTest: "explorer.theme.color.chip.unsent",
+            expectedOutcome: true,
+          },
+        ];
+    
+        // Act
+        testingCases.forEach((testCase) => {
+          const result = pipe.transform(testCase.stringToTest);
+          // Uncomment the line below is very useful for debuging the test. 
+          //console.log(`For element "${testCase.stringToTest}" expected is "${testCase.expectedOutcome}" actual response is "${result}"`);
+          
+          // Assert
+          expect(result).toBe(testCase.expectedOutcome);
+        });
+      });
+
+  });

--- a/src/app/pipes/matchThemeColorPattern.pipe.spec.ts
+++ b/src/app/pipes/matchThemeColorPattern.pipe.spec.ts
@@ -25,123 +25,123 @@ describe('MatchThemeColorPatternPipe', () => {
     it('should detect theme color pattern names', () => {
         // Arrange
         interface TestData {
-          stringToTest: string,
-          expectedOutcome:  boolean,
+          stringToTest: string;
+          expectedOutcome:  boolean;
         };
-        
+
         const testingCases : TestData[]= [
           {
-            stringToTest: "",
+            stringToTest: '',
             expectedOutcome: false,
           },
           {
-            stringToTest: "explorer.theme.material.colors.primary",
+            stringToTest: 'explorer.theme.material.colors.primary',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.material.colors.accent",
+            stringToTest: 'explorer.theme.material.colors.accent',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.material.colors.warn",
+            stringToTest: 'explorer.theme.material.colors.warn',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.material.typography.fontfamily",
+            stringToTest: 'explorer.theme.material.typography.fontfamily',
             expectedOutcome: false,
           },
           {
-            stringToTest: "explorer.theme.material.typography.bodyone",
+            stringToTest: 'explorer.theme.material.typography.bodyone',
             expectedOutcome: false,
           },
           {
-            stringToTest: "explorer.theme.material.typography.bodytwo",
+            stringToTest: 'explorer.theme.material.typography.bodytwo',
             expectedOutcome: false,
           },
           {
-            stringToTest: "explorer.theme.material.typography.button",
+            stringToTest: 'explorer.theme.material.typography.button',
             expectedOutcome: false,
           },
           {
-            stringToTest: "explorer.theme.regularcolors.requestcount",
+            stringToTest: 'explorer.theme.regularcolors.requestcount',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.regularcolors.hyperlink",
+            stringToTest: 'explorer.theme.regularcolors.hyperlink',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.contrastcolors.page",
+            stringToTest: 'explorer.theme.contrastcolors.page',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.contrastcolors.unsentrequest",
+            stringToTest: 'explorer.theme.contrastcolors.unsentrequest',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.contrastcolors.submittedrequest",
+            stringToTest: 'explorer.theme.contrastcolors.submittedrequest',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.contrastcolors.classrow",
+            stringToTest: 'explorer.theme.contrastcolors.classrow',
             expectedOutcome: true,
           },
           {
-            stringToTest: "explorer.theme.material.colors.primary",
+            stringToTest: 'explorer.theme.material.colors.primary',
             expectedOutcome: true,
           },
           {
-            stringToTest: "email.theme.material.colors.primary",
+            stringToTest: 'email.theme.material.colors.primary',
             expectedOutcome: true,
           },
           {
-            stringToTest: "mauro.theme.material.colors.primary",
+            stringToTest: 'mauro.theme.material.colors.primary',
             expectedOutcome: true,
           },
           {
-            stringToTest: "mdm.theme.material.colors.accent",
+            stringToTest: 'mdm.theme.material.colors.accent',
             expectedOutcome: true,
           },
           {
-            stringToTest: "email.theme.material.colors.warn",
+            stringToTest: 'email.theme.material.colors.warn',
             expectedOutcome: true,
           },
           {
-            stringToTest: "mdm.color.material.themes.accent",
+            stringToTest: 'mdm.color.material.themes.accent',
             expectedOutcome: false,
           },
           {
-            stringToTest: "email.colors.material.theme.warn",
+            stringToTest: 'email.colors.material.theme.warn',
             expectedOutcome: false,
           },
           {
-            stringToTest: "email.admin_confirm_registration.body",
+            stringToTest: 'email.admin_confirm_registration.body',
             expectedOutcome: false,
           },
           {
-            stringToTest: "email.password_reset.subject",
+            stringToTest: 'email.password_reset.subject',
             expectedOutcome: false,
           },
           {
-            stringToTest: "datatype.date.formats",
+            stringToTest: 'datatype.date.formats',
             expectedOutcome: false,
           },
           {
-            stringToTest: "explorer.config.root_data_model_path",
+            stringToTest: 'explorer.config.root_data_model_path',
             expectedOutcome: false,
           },
           {
-            stringToTest: "explorer.theme.color.chip.unsent",
+            stringToTest: 'explorer.theme.color.chip.unsent',
             expectedOutcome: true,
           },
         ];
-    
+
         // Act
         testingCases.forEach((testCase) => {
           const result = pipe.transform(testCase.stringToTest);
-          // Uncomment the line below is very useful for debuging the test. 
-          //console.log(`For element "${testCase.stringToTest}" expected is "${testCase.expectedOutcome}" actual response is "${result}"`);
-          
+          // Uncomment the line below is very useful for debuging the test.
+          // console.log(`For element "${testCase.stringToTest}" expected is "${testCase.expectedOutcome}" actual response is "${result}"`);
+
           // Assert
           expect(result).toBe(testCase.expectedOutcome);
         });

--- a/src/app/pipes/matchThemeColorPattern.pipe.ts
+++ b/src/app/pipes/matchThemeColorPattern.pipe.ts
@@ -19,21 +19,20 @@ SPDX-License-Identifier: Apache-2.0
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'matchThemeColorPattern',
-    pure: true,
-  })
-  export class MatchThemeColorPatternPipe implements PipeTransform {
-  
-    constructor() {}
-  
-   public transform( value: string): boolean {
-        // This expression matches any text with
-        // no numeric characters which contains
-        // theme and then color somewhere within the string.
-        // It can have other text in between, but theme has
-        // to be found before color.
-        const regexThemeColorPattern = /\D*theme\D*color\D*/;
-        
-        return regexThemeColorPattern.test(value);
-    }
+  name: 'matchThemeColorPattern',
+  pure: true
+})
+export class MatchThemeColorPatternPipe implements PipeTransform {
+  constructor() {}
+
+  public transform(value: string): boolean {
+    // This expression matches any text with
+    // no numeric characters which contains
+    // theme and then color somewhere within the string.
+    // It can have other text in between, but theme has
+    // to be found before color.
+    const regexThemeColorPattern = /\D*theme\D*color\D*/;
+
+    return regexThemeColorPattern.test(value);
   }
+}

--- a/src/app/pipes/matchThemeColorPattern.pipe.ts
+++ b/src/app/pipes/matchThemeColorPattern.pipe.ts
@@ -1,0 +1,39 @@
+/*
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'matchThemeColorPattern',
+    pure: true,
+  })
+  export class MatchThemeColorPatternPipe implements PipeTransform {
+  
+    constructor() {}
+  
+   public transform( value: string): boolean {
+        // This expression matches any text with
+        // no numeric characters which contains
+        // theme and then color somewhere within the string.
+        // It can have other text in between, but theme has
+        // to be found before color.
+        const regexThemeColorPattern = /\D*theme\D*color\D*/;
+        
+        return regexThemeColorPattern.test(value);
+    }
+  }


### PR DESCRIPTION
On property display, added a disabled input of type color to show the selected colour of the property value.
On property edit/add if the key of the property contains "theme.color" show 2 inputs, the user can use both of them, one is an input text where the hex code of the colour can be pasted, the other is an input of type colour so we can have an html colour picker.

As discussed in a conversation with @NigelPalmer,  in the issue description we say to check the key of the property and look for those which starts with "explorer.theme.color" but after some thought we changed that to be properties that contain "theme.color" since in the future this might be used to also theme mdm-ui.

Closes #760 