### PR TITLE
gh-462 URL Encode filter values for index (list) endpoints

### DIFF
--- a/src/app/admin/api-property-table/api-property-table.component.ts
+++ b/src/app/admin/api-property-table/api-property-table.component.ts
@@ -15,20 +15,37 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { AfterViewInit, Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSelectChange } from '@angular/material/select';
-import { MatSort, Sort } from '@angular/material/sort';
+import { MatSort, Sort, SortDirection } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
-import { ApiPropertyEditableState, ApiPropertyEditType } from '@mdm/model/api-properties';
+import {
+  ApiPropertyEditableState,
+  ApiPropertyEditType
+} from '@mdm/model/api-properties';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { BroadcastService, MessageHandlerService, StateHandlerService } from '@mdm/services';
+import {
+  BroadcastService,
+  MessageHandlerService,
+  StateHandlerService
+} from '@mdm/services';
 import { catchError, switchMap } from 'rxjs/operators';
 
 export interface ApiPropertyTableViewChange {
   category?: string;
   sortBy?: string;
-  sortType?: string;
+  sortType?: SortDirection;
 }
 
 @Component({
@@ -36,14 +53,16 @@ export interface ApiPropertyTableViewChange {
   templateUrl: './api-property-table.component.html',
   styleUrls: ['./api-property-table.component.scss']
 })
-export class ApiPropertyTableComponent implements OnInit, OnChanges, AfterViewInit {
-
+export class ApiPropertyTableComponent
+  implements OnInit, OnChanges, AfterViewInit {
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
   @Input() properties: ApiPropertyEditableState[] = [];
   @Input() categories: string[] = [];
 
-  @Output() readonly viewChange = new EventEmitter<ApiPropertyTableViewChange>();
+  @Output() readonly viewChange = new EventEmitter<
+    ApiPropertyTableViewChange
+  >();
 
   @Output() valueCleared = new EventEmitter();
 
@@ -60,18 +79,21 @@ export class ApiPropertyTableComponent implements OnInit, OnChanges, AfterViewIn
     private resources: MdmResourcesService,
     private dialog: MatDialog,
     private messageHandler: MessageHandlerService,
-    private broadcast: BroadcastService) { }
+    private broadcast: BroadcastService
+  ) {}
 
   ngOnInit(): void {
     this.dataSource = new MatTableDataSource(this.properties);
   }
 
   ngAfterViewInit(): void {
-    this.sort.sortChange.subscribe((sort: Sort) => this.viewChange.emit({
-      category: this.selectedCategory,
-      sortBy: sort.active,
-      sortType: sort.direction
-    }));
+    this.sort.sortChange.subscribe((sort: Sort) =>
+      this.viewChange.emit({
+        category: this.selectedCategory,
+        sortBy: sort.active,
+        sortType: sort.direction
+      })
+    );
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -98,7 +120,9 @@ export class ApiPropertyTableComponent implements OnInit, OnChanges, AfterViewIn
       return;
     }
 
-    this.stateHandler.Go('appContainer.adminArea.apiPropertyEdit', { id: record.original.id });
+    this.stateHandler.Go('appContainer.adminArea.apiPropertyEdit', {
+      id: record.original.id
+    });
   }
 
   delete(record: ApiPropertyEditableState) {
@@ -113,24 +137,31 @@ export class ApiPropertyTableComponent implements OnInit, OnChanges, AfterViewIn
         }
       })
       .pipe(
-        switchMap(() => this.resources.apiProperties.remove(record.original.id)),
-        catchError(errors => {
-          this.messageHandler.showError('There was a problem deleting the property.', errors);
+        switchMap(() =>
+          this.resources.apiProperties.remove(record.original.id)
+        ),
+        catchError((errors) => {
+          this.messageHandler.showError(
+            'There was a problem deleting the property.',
+            errors
+          );
           return [];
         })
       )
       .subscribe(() => {
-        this.messageHandler.showSuccess(`Successfully deleted the property ${record.original.key}.`);
+        this.messageHandler.showSuccess(
+          `Successfully deleted the property ${record.original.key}.`
+        );
 
         this.broadcast.apiPropertyUpdated({
           key: record.original.key,
           value: record.original.value,
-          deleted: true });
+          deleted: true
+        });
 
         if (record.metadata.requiresReload) {
           this.stateHandler.reload();
-        }
-        else {
+        } else {
           this.viewChange.emit({
             category: this.selectedCategory,
             sortBy: this.sort.active,

--- a/src/app/admin/configuration/configuration.component.ts
+++ b/src/app/admin/configuration/configuration.component.ts
@@ -21,11 +21,16 @@ import { StateHandlerService } from '@mdm/services/handlers/state-handler.servic
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { MessageHandlerService } from '@mdm/services/utility/message-handler.service';
 import { Title } from '@angular/platform-browser';
-import { ApiPropertyEditableState, ApiPropertyEditType, propertyMetadata } from '@mdm/model/api-properties';
+import {
+  ApiPropertyEditableState,
+  ApiPropertyEditType,
+  propertyMetadata
+} from '@mdm/model/api-properties';
 import { catchError, map } from 'rxjs/operators';
 import { GridService } from '@mdm/services';
 import { ApiPropertyTableViewChange } from '../api-property-table/api-property-table.component';
 import { ApiPropertyIndexResponse } from '@maurodatamapper/mdm-resources';
+import { SortDirection } from '@angular/material/sort';
 
 @Component({
   selector: 'mdm-configuration',
@@ -50,7 +55,9 @@ export class ConfigurationComponent implements OnInit {
 
   ngOnInit() {
     this.getApiProperties();
-    this.activeTab = this.getTabDetailByName(this.uiRouterGlobals.params.tabView as string);
+    this.activeTab = this.getTabDetailByName(
+      this.uiRouterGlobals.params.tabView as string
+    );
     this.indexingStatus = '';
     this.title.setTitle('Configuration');
   }
@@ -58,15 +65,22 @@ export class ConfigurationComponent implements OnInit {
   getApiProperties(
     category?: string,
     sortBy?: string,
-    sortType?: string) {
-    const options = this.gridService.constructOptions(null, null, sortBy, sortType, null);
+    sortType?: SortDirection
+  ) {
+    const options = this.gridService.constructOptions(
+      null,
+      null,
+      sortBy,
+      sortType,
+      null
+    );
 
     this.resources.apiProperties
       .list(options)
       .pipe(
         map((response: ApiPropertyIndexResponse) => {
-          return response.body.items.map<ApiPropertyEditableState>(item => {
-            let metadata = propertyMetadata.find(m => m.key === item.key);
+          return response.body.items.map<ApiPropertyEditableState>((item) => {
+            let metadata = propertyMetadata.find((m) => m.key === item.key);
             if (!metadata) {
               metadata = {
                 key: item.key,
@@ -83,27 +97,33 @@ export class ConfigurationComponent implements OnInit {
             };
           });
         }),
-        catchError(errors => {
-          this.messageHandler.showError('There was a problem getting the configuration properties.', errors);
+        catchError((errors) => {
+          this.messageHandler.showError(
+            'There was a problem getting the configuration properties.',
+            errors
+          );
           return [];
         })
       )
       .subscribe((data: ApiPropertyEditableState[]) => {
         if (category) {
-          this.apiProperties = data.filter(p => p.metadata.category === category);
+          this.apiProperties = data.filter(
+            (p) => p.metadata.category === category
+          );
           return;
         }
 
         this.apiProperties = data;
 
         const backendCategories = data
-          .map(prop => prop.metadata.category)
-          .filter(cat => cat && cat.length > 0);
+          .map((prop) => prop.metadata.category)
+          .filter((cat) => cat && cat.length > 0);
 
-        const knownCategories = propertyMetadata
-          .map(prop => prop.category);
+        const knownCategories = propertyMetadata.map((prop) => prop.category);
 
-        this.apiPropertyCategories = [...new Set(backendCategories.concat(knownCategories).sort())];
+        this.apiPropertyCategories = [
+          ...new Set(backendCategories.concat(knownCategories).sort())
+        ];
       });
   }
 
@@ -113,7 +133,11 @@ export class ConfigurationComponent implements OnInit {
 
   tabSelected(itemsName) {
     const tab = this.getTabDetail(itemsName);
-    this.stateHandler.Go('configuration', { tabView: tab.name }, { notify: false, location: tab.index !== 0 });
+    this.stateHandler.Go(
+      'configuration',
+      { tabView: tab.name },
+      { notify: false, location: tab.index !== 0 }
+    );
   }
 
   getTabDetail(tabIndex) {
@@ -141,10 +165,11 @@ export class ConfigurationComponent implements OnInit {
   rebuildIndex() {
     this.indexingStatus = 'start';
 
-    this.resources.admin.rebuildLuceneIndexes(null).subscribe(() => {
+    this.resources.admin.rebuildLuceneIndexes(null).subscribe(
+      () => {
         this.indexingStatus = 'success';
       },
-      error => {
+      (error) => {
         if (error.status === 418) {
           this.indexingStatus = 'success';
           if (error.error && error.error.timeTaken) {
@@ -153,6 +178,7 @@ export class ConfigurationComponent implements OnInit {
         } else {
           this.indexingStatus = 'error';
         }
-    });
+      }
+    );
   }
 }

--- a/src/app/services/grid.service.spec.ts
+++ b/src/app/services/grid.service.spec.ts
@@ -1,0 +1,98 @@
+/*
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { SortDirection } from '@angular/material/sort';
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+import { GridService } from './grid.service';
+
+describe('GridService', () => {
+  let service: GridService;
+
+  beforeEach(() => {
+    service = setupTestModuleForService(GridService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('construct options', () => {
+    it.each<
+      [
+        number | undefined,
+        number | undefined,
+        string | undefined,
+        SortDirection | undefined
+      ]
+    >([
+      [10, 0, undefined, undefined],
+      [20, 3, undefined, undefined],
+      [undefined, undefined, 'name', 'asc'],
+      [undefined, undefined, 'desc', 'desc'],
+      [50, undefined, 'name', 'asc'],
+      [25, 4, 'label', 'desc']
+    ])(
+      'should construct options for pageSize: %p, pageIndex: %p, sortBy: %p, sortType: %p',
+      (pageSize, pageIndex, sortBy, sortType) => {
+        const expected = {
+          ...(pageSize && { max: pageSize }),
+          ...(pageIndex && { offset: pageIndex }),
+          ...(sortBy && { sort: sortBy }),
+          ...(sortType && { order: sortType })
+        };
+
+        const actual = service.constructOptions(
+          pageSize,
+          pageIndex,
+          sortBy,
+          sortType
+        );
+
+        expect(actual).toStrictEqual(expected);
+      }
+    );
+
+    it.each([
+      { label: 'test' },
+      { description: 'start' },
+      { label: 'test', description: 'something' }
+    ])('should construct options with filters %p', (filters) => {
+      const expected = {
+        ...filters
+      };
+
+      const actual = service.constructOptions(null, null, null, null, filters);
+
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it.each(['test+', 'test[1]', 'test&another', 'money$', 'question?'])(
+      'should construct URL encoded filters for value %p',
+      (filter) => {
+        const expected = {
+          test: encodeURIComponent(filter)
+        };
+
+        const actual = service.constructOptions(null, null, null, null, {
+          test: filter
+        });
+
+        expect(actual).toStrictEqual(expected);
+      }
+    );
+  });
+});

--- a/src/app/services/grid.service.ts
+++ b/src/app/services/grid.service.ts
@@ -16,6 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable, Output, EventEmitter } from '@angular/core';
+import { SortDirection } from '@angular/material/sort';
 import { FilterQueryParameters } from '@maurodatamapper/mdm-resources';
 
 @Injectable({
@@ -45,30 +46,25 @@ export class GridService {
     pageSize?: number,
     pageIndex?: number,
     sortBy?: string,
-    sortType?: string,
-    filters?: {}
+    sortType?: SortDirection,
+    filters?: { [key: string]: any }
   ): FilterQueryParameters {
-    const options = {};
+    const parsedFilters = Object.entries(filters ?? {}).reduce(
+      (prev, [key, value]) => {
+        return {
+          ...prev,
+          [key]: encodeURIComponent(value)
+        };
+      },
+      {}
+    );
 
-    if (pageSize) {
-      options['max'] = pageSize;
-    }
-    if (pageIndex) {
-      options['offset'] = pageIndex;
-    }
-    if (sortBy) {
-      options['sort'] = sortBy;
-    }
-    if (sortType) {
-      options['order'] = sortType;
-    }
-
-    if (filters) {
-      Object.keys(filters).forEach((key) => {
-        options[key] = filters[key];
-      });
-    }
-
-    return options;
+    return {
+      ...(pageSize && { max: pageSize }),
+      ...(pageIndex && { offset: pageIndex }),
+      ...(sortBy && { sort: sortBy }),
+      ...(sortType && { order: sortType }),
+      ...parsedFilters
+    };
   }
 }

--- a/src/app/shared/annotation-list/annotation-list.component.ts
+++ b/src/app/shared/annotation-list/annotation-list.component.ts
@@ -15,17 +15,28 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, AfterViewInit, Input, ViewChild, EventEmitter, ChangeDetectorRef } from '@angular/core';
+import {
+  Component,
+  AfterViewInit,
+  Input,
+  ViewChild,
+  EventEmitter,
+  ChangeDetectorRef
+} from '@angular/core';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { SecurityHandlerService } from '@mdm/services/handlers/security-handler.service';
 import { MessageHandlerService } from '@mdm/services/utility/message-handler.service';
 import { EMPTY, merge, Observable } from 'rxjs';
 import { catchError, map, startWith, switchMap } from 'rxjs/operators';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, SortDirection } from '@angular/material/sort';
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { EditingService } from '@mdm/services/editing.service';
 import { GridService } from '@mdm/services';
-import { CatalogueItem, ModelDomainType, Securable } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItem,
+  ModelDomainType,
+  Securable
+} from '@maurodatamapper/mdm-resources';
 import { UserDetails } from '@mdm/services/handlers/security-handler.model';
 
 @Component({
@@ -38,7 +49,8 @@ export class AnnotationListComponent implements AfterViewInit {
   @Input() domainType: ModelDomainType;
 
   @ViewChild(MatSort, { static: true }) sort: MatSort;
-  @ViewChild(MdmPaginatorComponent, { static: true }) paginator: MdmPaginatorComponent;
+  @ViewChild(MdmPaginatorComponent, { static: true })
+  paginator: MdmPaginatorComponent;
 
   currentUser: UserDetails;
   displayedColumns: string[] = ['lastUpdated'];
@@ -54,7 +66,8 @@ export class AnnotationListComponent implements AfterViewInit {
     private messageHandler: MessageHandlerService,
     private changeRef: ChangeDetectorRef,
     private editingService: EditingService,
-    private gridService: GridService) { }
+    private gridService: GridService
+  ) {}
 
   ngAfterViewInit() {
     this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
@@ -88,7 +101,7 @@ export class AnnotationListComponent implements AfterViewInit {
           return EMPTY;
         })
       )
-      .subscribe(data => {
+      .subscribe((data) => {
         this.records = data;
       });
   }
@@ -97,17 +110,20 @@ export class AnnotationListComponent implements AfterViewInit {
     pageSize?: number,
     pageIndex?: number,
     sortBy?: string,
-    sortType?: string,): Observable<any> {
+    sortType?: SortDirection
+  ): Observable<any> {
     const options = this.gridService.constructOptions(
       pageSize,
       pageIndex,
       sortBy,
-      sortType);
+      sortType
+    );
 
     return this.resources.catalogueItem.listAnnotations(
       this.domainType,
       this.parent.id,
-      options);
+      options
+    );
   }
 
   add() {
@@ -132,7 +148,7 @@ export class AnnotationListComponent implements AfterViewInit {
   }
 
   cancelEdit(record: any, index: number) {
-    this.editingService.confirmCancelAsync().subscribe(confirm => {
+    this.editingService.confirmCancelAsync().subscribe((confirm) => {
       if (!confirm) {
         return;
       }
@@ -155,8 +171,11 @@ export class AnnotationListComponent implements AfterViewInit {
     this.resources.catalogueItem
       .saveAnnotations(this.domainType, this.parent.id, resource)
       .pipe(
-        catchError(error => {
-          this.messageHandler.showError('There was a problem adding the comment.', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem adding the comment.',
+            error
+          );
           return EMPTY;
         })
       )
@@ -174,14 +193,22 @@ export class AnnotationListComponent implements AfterViewInit {
     };
 
     this.resources.catalogueItem
-      .saveAnnotationChildren(this.domainType, this.parent.id, annotation.id, resource)
+      .saveAnnotationChildren(
+        this.domainType,
+        this.parent.id,
+        annotation.id,
+        resource
+      )
       .pipe(
-        catchError(error => {
-          this.messageHandler.showError('There was a problem saving the comment.', error);
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem saving the comment.',
+            error
+          );
           return EMPTY;
         })
       )
-      .subscribe(response => {
+      .subscribe((response) => {
         annotation.childAnnotations = annotation.childAnnotations || [];
         annotation.childAnnotations.push(response.body);
         annotation.newChildText = '';
@@ -192,8 +219,7 @@ export class AnnotationListComponent implements AfterViewInit {
   showChildren(annotation: any) {
     if (annotation.show) {
       annotation.show = false;
-    }
-    else {
+    } else {
       annotation.newChildText = '';
       annotation.show = true;
     }

--- a/src/app/shared/attachment-list/attachment-list.component.ts
+++ b/src/app/shared/attachment-list/attachment-list.component.ts
@@ -22,18 +22,26 @@ import {
   ViewChildren,
   ViewChild,
   ElementRef,
-  EventEmitter,
+  EventEmitter
 } from '@angular/core';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { MessageHandlerService } from '@mdm/services/utility/message-handler.service';
 import { EMPTY, merge, Observable } from 'rxjs';
 import { catchError, map, startWith, switchMap } from 'rxjs/operators';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, SortDirection } from '@angular/material/sort';
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { GridService, SharedService } from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
 import { MatTableDataSource } from '@angular/material/table';
-import { CatalogueItem, CatalogueItemDomainType, ModelDomainType, ReferenceFile, ReferenceFileCreatePayload, ReferenceFileIndexResponse, Securable } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItem,
+  CatalogueItemDomainType,
+  ModelDomainType,
+  ReferenceFile,
+  ReferenceFileCreatePayload,
+  ReferenceFileIndexResponse,
+  Securable
+} from '@maurodatamapper/mdm-resources';
 import { EditableRecord } from '@mdm/model/editable-forms';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -44,7 +52,7 @@ export interface ReferenceFileEditor {
 @Component({
   selector: 'mdm-attachment-list',
   templateUrl: './attachment-list.component.html',
-  styleUrls: ['./attachment-list.component.sass'],
+  styleUrls: ['./attachment-list.component.sass']
 })
 export class AttachmentListComponent implements AfterViewInit {
   @Input() parent: CatalogueItem & Securable;
@@ -52,7 +60,8 @@ export class AttachmentListComponent implements AfterViewInit {
 
   @ViewChildren('filters', { read: ElementRef }) filters: ElementRef[];
   @ViewChild(MatSort, { static: false }) sort: MatSort;
-  @ViewChild(MdmPaginatorComponent, { static: true }) paginator: MdmPaginatorComponent;
+  @ViewChild(MdmPaginatorComponent, { static: true })
+  paginator: MdmPaginatorComponent;
 
   filterEvent = new EventEmitter<any>();
   hideFilters = true;
@@ -63,7 +72,9 @@ export class AttachmentListComponent implements AfterViewInit {
   filter: {};
   canEdit: boolean;
   records: EditableRecord<ReferenceFile, ReferenceFileEditor>[] = [];
-  dataSource = new MatTableDataSource<EditableRecord<ReferenceFile, ReferenceFileEditor>>();
+  dataSource = new MatTableDataSource<
+    EditableRecord<ReferenceFile, ReferenceFileEditor>
+  >();
   apiEndpoint: string;
 
   constructor(
@@ -72,7 +83,8 @@ export class AttachmentListComponent implements AfterViewInit {
     private sharedService: SharedService,
     private editingService: EditingService,
     private gridService: GridService,
-    private dialog: MatDialog) { }
+    private dialog: MatDialog
+  ) {}
 
   ngAfterViewInit() {
     this.apiEndpoint = this.sharedService.backendURL;
@@ -95,9 +107,10 @@ export class AttachmentListComponent implements AfterViewInit {
             this.paginator.pageOffset,
             this.sort.active,
             this.sort.direction,
-            this.filter);
+            this.filter
+          );
         }),
-        map(data => {
+        map((data) => {
           this.totalItemCount = data.body.count;
           this.isLoadingResults = false;
           return data.body.items;
@@ -108,15 +121,19 @@ export class AttachmentListComponent implements AfterViewInit {
         })
       )
       .subscribe((data: ReferenceFile[]) => {
-        this.records = data.map(item => new EditableRecord<ReferenceFile, ReferenceFileEditor>(
-          item,
-          {
-            fileName: item.fileName
-          },
-          {
-            isNew: false,
-            inEdit: false
-          }));
+        this.records = data.map(
+          (item) =>
+            new EditableRecord<ReferenceFile, ReferenceFileEditor>(
+              item,
+              {
+                fileName: item.fileName
+              },
+              {
+                isNew: false,
+                inEdit: false
+              }
+            )
+        );
 
         this.dataSource.data = this.records;
       });
@@ -143,14 +160,16 @@ export class AttachmentListComponent implements AfterViewInit {
     pageSize?: number,
     pageIndex?: number,
     sortBy?: string,
-    sortType?: string,
-    filters?: any): Observable<ReferenceFileIndexResponse> {
+    sortType?: SortDirection,
+    filters?: any
+  ): Observable<ReferenceFileIndexResponse> {
     const options = this.gridService.constructOptions(
       pageSize,
       pageIndex,
       sortBy,
       sortType,
-      filters);
+      filters
+    );
 
     return this.resources.catalogueItem.listReferenceFiles(
       this.domainType,
@@ -159,7 +178,10 @@ export class AttachmentListComponent implements AfterViewInit {
     );
   }
 
-  cancelEdit(record: EditableRecord<ReferenceFile, ReferenceFileEditor>, index: number) {
+  cancelEdit(
+    record: EditableRecord<ReferenceFile, ReferenceFileEditor>,
+    index: number
+  ) {
     if (record.isNew) {
       this.records.splice(index, 1);
       this.records = [].concat(this.records);
@@ -185,9 +207,18 @@ export class AttachmentListComponent implements AfterViewInit {
         }
       })
       .pipe(
-        switchMap(() => this.resources.catalogueItem.removeReferenceFile(this.domainType, this.parent.id, record.source.id)),
-        catchError(error => {
-          this.messageHandler.showError('There was a problem deleting the attachment.', error);
+        switchMap(() =>
+          this.resources.catalogueItem.removeReferenceFile(
+            this.domainType,
+            this.parent.id,
+            record.source.id
+          )
+        ),
+        catchError((error) => {
+          this.messageHandler.showError(
+            'There was a problem deleting the attachment.',
+            error
+          );
           return EMPTY;
         })
       )
@@ -210,15 +241,18 @@ export class AttachmentListComponent implements AfterViewInit {
       {
         isNew: true,
         inEdit: true
-      });
+      }
+    );
 
     this.records = [].concat([newRecord]).concat(this.records);
     this.dataSource.data = this.records;
     this.editingService.setFromCollection(this.records);
-  };
+  }
 
-
-  save(record: EditableRecord<ReferenceFile, ReferenceFileEditor>, index: number) {
+  save(
+    record: EditableRecord<ReferenceFile, ReferenceFileEditor>,
+    index: number
+  ) {
     const fileName = `File${index}`;
     const file = this.getFile(fileName);
     const reader = new FileReader();
@@ -238,8 +272,11 @@ export class AttachmentListComponent implements AfterViewInit {
       this.resources.catalogueItem
         .saveReferenceFiles(this.domainType, this.parent.id, data)
         .pipe(
-          catchError(error => {
-            this.messageHandler.showError('There was a problem saving the attachment.', error);
+          catchError((error) => {
+            this.messageHandler.showError(
+              'There was a problem saving the attachment.',
+              error
+            );
             return EMPTY;
           })
         )

--- a/src/app/shared/data-classes-list/data-classes-list.component.ts
+++ b/src/app/shared/data-classes-list/data-classes-list.component.ts
@@ -29,7 +29,7 @@ import { StateHandlerService } from '@mdm/services/handlers/state-handler.servic
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { merge, Observable } from 'rxjs';
 import { catchError, map, startWith, switchMap } from 'rxjs/operators';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, SortDirection } from '@angular/material/sort';
 import { MatTable } from '@angular/material/table';
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { MatDialog } from '@angular/material/dialog';
@@ -198,7 +198,7 @@ export class DataClassesListComponent implements AfterViewInit {
     pageSize?: number,
     pageIndex?: number,
     sortBy?: string,
-    sortType?: string,
+    sortType?: SortDirection,
     filters?: {}
   ): Observable<any> {
     const options = this.gridService.constructOptions(

--- a/src/app/shared/data-elements-list/data-elements-list.component.ts
+++ b/src/app/shared/data-elements-list/data-elements-list.component.ts
@@ -29,7 +29,7 @@ import { StateHandlerService } from '@mdm/services/handlers/state-handler.servic
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { merge, Observable } from 'rxjs';
 import { catchError, map, startWith, switchMap } from 'rxjs/operators';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, SortDirection } from '@angular/material/sort';
 import { MatTable } from '@angular/material/table';
 import { MdmPaginatorComponent } from '../mdm-paginator/mdm-paginator';
 import { MatDialog } from '@angular/material/dialog';
@@ -106,8 +106,8 @@ export class DataElementsListComponent implements AfterViewInit {
           this.isLoadingResults = true;
           this.isOrderedDataSource = true;
           if (!this.sort?.direction) {
-             this.isOrderedDataSource = false;
-             [this.sort.active, this.sort.direction] = ['idx', 'asc'];
+            this.isOrderedDataSource = false;
+            [this.sort.active, this.sort.direction] = ['idx', 'asc'];
           }
           return this.dataElementsFetch(
             this.paginator?.pageSize,
@@ -233,7 +233,7 @@ export class DataElementsListComponent implements AfterViewInit {
     pageSize?: number,
     pageIndex?: number,
     sortBy?: string,
-    sortType?: string,
+    sortType?: SortDirection,
     filters?: {}
   ): Observable<any> {
     const options = this.gridService.constructOptions(

--- a/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
+++ b/src/app/subscribed-catalogues/newer-versions/newer-versions.component.ts
@@ -15,8 +15,15 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { AfterViewInit, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
-import { MatSort } from '@angular/material/sort';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild
+} from '@angular/core';
+import { MatSort, SortDirection } from '@angular/material/sort';
 import { QueryParameters, Uuid } from '@maurodatamapper/mdm-resources';
 import { FederatedDataModel } from '@mdm/model/federated-data-model';
 import { MdmResourcesService } from '@mdm/modules/resources';
@@ -31,8 +38,8 @@ import { catchError, map, startWith, switchMap } from 'rxjs/operators';
   styleUrls: ['./newer-versions.component.scss']
 })
 export class NewerVersionsComponent implements AfterViewInit {
-
-  @ViewChild(MdmPaginatorComponent, { static: false }) paginator: MdmPaginatorComponent;
+  @ViewChild(MdmPaginatorComponent, { static: false })
+  paginator: MdmPaginatorComponent;
   @ViewChild(MatSort, { static: false }) sort: MatSort;
 
   @Input() catalogueItem: FederatedDataModel;
@@ -50,7 +57,8 @@ export class NewerVersionsComponent implements AfterViewInit {
   constructor(
     private resouces: MdmResourcesService,
     private gridService: GridService,
-    private stateHandler: StateHandlerService) { }
+    private stateHandler: StateHandlerService
+  ) {}
 
   ngAfterViewInit(): void {
     merge(this.sort.sortChange, this.paginator.page)
@@ -58,7 +66,12 @@ export class NewerVersionsComponent implements AfterViewInit {
         startWith({}),
         switchMap(() => {
           this.isLoadingResults = true;
-          return this.fetchNewerVersions(this.paginator.pageSize, this.paginator.pageOffset, this.sort.active, this.sort.direction);
+          return this.fetchNewerVersions(
+            this.paginator.pageSize,
+            this.paginator.pageOffset,
+            this.sort.active,
+            this.sort.direction
+          );
         }),
         map((data: any) => {
           this.totalNewVersionCount = data.body.newerPublishedModels.length;
@@ -72,27 +85,37 @@ export class NewerVersionsComponent implements AfterViewInit {
           return [];
         })
       )
-      .subscribe(data => {
+      .subscribe((data) => {
         this.newVersionsRecords = data;
-
-
       });
   }
 
-  fetchNewerVersions(pageSize?: number, pageIndex?: number, sortBy?: string, sortType?: string) {
+  fetchNewerVersions(
+    pageSize?: number,
+    pageIndex?: number,
+    sortBy?: string,
+    sortType?: SortDirection
+  ) {
     // Future proofing to enable paging if number of versions increases
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const options: QueryParameters = this.gridService.constructOptions(pageSize, pageIndex, sortBy, sortType);
-    return this.resouces.subscribedCatalogues
-      .newerVersions(
-        this.catalogueId,
-        this.catalogueItem.modelId,
-        {},
-        { handleGetErrors: false });
+    const options: QueryParameters = this.gridService.constructOptions(
+      pageSize,
+      pageIndex,
+      sortBy,
+      sortType
+    );
+    return this.resouces.subscribedCatalogues.newerVersions(
+      this.catalogueId,
+      this.catalogueItem.modelId,
+      {},
+      { handleGetErrors: false }
+    );
   }
 
   navigateToNewerVersion(record: FederatedDataModel) {
-    this.stateHandler.Go('appContainer.mainApp.twoSidePanel.catalogue.federatedDataModel', { parentId: this.catalogueId, id: record.modelId });
+    this.stateHandler.Go(
+      'appContainer.mainApp.twoSidePanel.catalogue.federatedDataModel',
+      { parentId: this.catalogueId, id: record.modelId }
+    );
   }
-
 }

--- a/src/app/terminology/term-list/term-list.component.ts
+++ b/src/app/terminology/term-list/term-list.component.ts
@@ -24,7 +24,7 @@ import {
   Output,
   ViewChild
 } from '@angular/core';
-import { MatSort } from '@angular/material/sort';
+import { MatSort, SortDirection } from '@angular/material/sort';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import {
   Term,
@@ -119,9 +119,14 @@ export class TermListComponent implements AfterViewInit {
 
   applyFilter() {
     this.filter = {
-      ...(this.codeFilter && this.codeFilter !== '' && { code: this.codeFilter }),
-      ...(this.definitionFilter && this.definitionFilter !== '' && { definition: this.definitionFilter }),
-      ...(this.descriptionFilter && this.descriptionFilter !== '' && { description: this.descriptionFilter })
+      ...(this.codeFilter &&
+        this.codeFilter !== '' && { code: this.codeFilter }),
+      ...(this.definitionFilter &&
+        this.definitionFilter !== '' && { definition: this.definitionFilter }),
+      ...(this.descriptionFilter &&
+        this.descriptionFilter !== '' && {
+          description: this.descriptionFilter
+        })
     };
 
     this.filterEvent.emit();
@@ -137,7 +142,7 @@ export class TermListComponent implements AfterViewInit {
     pageSize?: number,
     pageIndex?: number,
     sortBy?: string,
-    sortType?: string,
+    sortType?: SortDirection,
     filters?: {}
   ): Observable<TermIndexResponse> {
     const options = this.gridService.constructOptions(


### PR DESCRIPTION
- Refactor grid construct options function
- Add tests

Fixes #462 

As an example, filtering by this value:

![image](https://user-images.githubusercontent.com/3219480/221910296-f82f4501-ddfc-431f-8839-93b7df6fbf1e.png)

Now produces this URL (note the `label` query parameter):

```
http://localhost:8080/api/dataModels/1d2843ec-afd8-44a5-a7e1-7823dc12faba/dataClasses/6beba70b-c43e-4482-b93f-bae20eb751ef/dataElements?max=50&sort=idx&order=asc&label=test%5B%5D
```