### PR TITLE
gh-279 Remove restriction for signed in users to include superseded models

### DIFF
--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -349,17 +349,16 @@ export class FoldersTreeComponent implements OnChanges, OnDestroy {
   }
 
   async expand(node: MdmTreeItem) {
-    let options: any = {};
-    if (this.shared.isLoggedIn()) {
-      options = {
-        queryStringParams: {
-          includeDeleted:
-            this.userSettingsHandler.get('includeDeleted') || false,
-          includeModelSuperseded:
-            this.userSettingsHandler.get('includeModelSuperseded') || false
-        }
-      };
-    }
+    const options: any = {
+      queryStringParams: {
+        includeDeleted:
+          (this.shared.isLoggedIn() &&
+            this.userSettingsHandler.get('includeDeleted')) ||
+          false,
+        includeModelSuperseded:
+          this.userSettingsHandler.get('includeModelSuperseded') || false
+      }
+    };
 
     try {
       switch (node.domainType) {

--- a/src/app/services/model-tree.service.ts
+++ b/src/app/services/model-tree.service.ts
@@ -85,19 +85,19 @@ export class ModelTreeService implements OnDestroy {
   }
 
   getLocalCatalogueTreeNodes(noCache?: boolean): Observable<MdmTreeItem[]> {
-    let options: any = {};
-    if (this.sharedService.isLoggedIn()) {
-      options = {
-        queryStringParams: {
-          includeDocumentSuperseded:
-            this.userSettingsHandler.get('includeDocumentSuperseded') || false,
-          includeModelSuperseded:
-            this.userSettingsHandler.get('includeModelSuperseded') || false,
-          includeDeleted:
-            this.userSettingsHandler.get('includeDeleted') || false
-        }
-      };
-    }
+    const options: any = {
+      queryStringParams: {
+        includeDocumentSuperseded:
+          this.userSettingsHandler.get('includeDocumentSuperseded') || false,
+        includeModelSuperseded:
+          this.userSettingsHandler.get('includeModelSuperseded') || false,
+        includeDeleted:
+          (this.sharedService.isLoggedIn() &&
+            this.userSettingsHandler.get('includeDeleted')) ||
+          false
+      }
+    };
+
     if (noCache) {
       options.queryStringParams.noCache = true;
     }

--- a/src/app/shared/models/models.component.html
+++ b/src/app/shared/models/models.component.html
@@ -58,7 +58,6 @@ SPDX-License-Identifier: Apache-2.0
                     type="button"
                     mat-stroked-button
                     [matMenuTriggerFor]="filterMenu"
-                    *ngIf="isLoggedIn()"
                     matTooltipPosition="below"
                     matTooltip="Filters"
                     [disabled]="levels.current === 1"

--- a/src/app/shared/models/models.component.ts
+++ b/src/app/shared/models/models.component.ts
@@ -198,11 +198,12 @@ export class ModelsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.title.setTitle('Models');
 
+    this.includeModelSuperseded =
+      this.userSettingsHandler.get('includeModelSuperseded') || false;
+    this.showSupersededModels =
+      this.userSettingsHandler.get('showSupersededModels') || false;
+
     if (this.sharedService.isLoggedIn()) {
-      this.includeModelSuperseded =
-        this.userSettingsHandler.get('includeModelSuperseded') || false;
-      this.showSupersededModels =
-        this.userSettingsHandler.get('showSupersededModels') || false;
       this.includeDeleted =
         this.userSettingsHandler.get('includeDeleted') || false;
 
@@ -437,15 +438,15 @@ export class ModelsComponent implements OnInit, OnDestroy {
     this[filerName] = !this[filerName];
     this.reloading = true;
 
+    this.userSettingsHandler.update(
+      'includeModelSuperseded',
+      this.includeModelSuperseded
+    );
+    this.userSettingsHandler.update(
+      'showSupersededModels',
+      this.showSupersededModels
+    );
     if (this.sharedService.isLoggedIn()) {
-      this.userSettingsHandler.update(
-        'includeModelSuperseded',
-        this.includeModelSuperseded
-      );
-      this.userSettingsHandler.update(
-        'showSupersededModels',
-        this.showSupersededModels
-      );
       this.userSettingsHandler.update('includeDeleted', this.includeDeleted);
       this.userSettingsHandler.saveOnServer();
     }
@@ -602,10 +603,14 @@ export class ModelsComponent implements OnInit, OnDestroy {
 
   private loadApiContentProperties(properties: ApiProperty[]) {
     this.isRootFolderRestricted = JSON.parse(
-      this.getContentProperty(properties, 'security.restrict.root.folder') ?? 'false'
+      this.getContentProperty(properties, 'security.restrict.root.folder') ??
+        'false'
     );
     this.isClassifierCreateRestricted = JSON.parse(
-      this.getContentProperty(properties, 'security.restrict.classifier.create') ?? 'false'
+      this.getContentProperty(
+        properties,
+        'security.restrict.classifier.create'
+      ) ?? 'false'
     );
   }
 


### PR DESCRIPTION
Anonymous users can now access this filter in the model tree and maintain their preferences locally.

Resolves #279 

![image](https://user-images.githubusercontent.com/3219480/221928052-cf92d6df-078a-4e1a-85b5-1e8a314a2028.png)
