### PR TITLE
gh-782 Update the visuals of the Search and Search Listing pages

### DIFF
--- a/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.html
+++ b/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.html
@@ -20,30 +20,31 @@ SPDX-License-Identifier: Apache-2.0
   class="mdm-catalogue-item-search-result panel panel-default mdm--shadow-block"
 >
   <div class="mdm-catalogue-item-search-result__header">
-    <span>
-      <h3>
+    <h3>
+      <a [href]="linkUrl">
         {{ item.label }}
-      </h3>
-      <mdm-breadcrumb
-        *ngIf="showBreadcrumb"
-        class="mdm-data-element-search-result__header__breadcrumb"
-        [item]="item"
-      ></mdm-breadcrumb>
-    </span>
-    <span>
-      {{ item.domainType }}
-    </span>
+      </a>
+    </h3>
+    <mdm-breadcrumb
+      *ngIf="showBreadcrumb"
+      class="mdm-data-element-search-result__header__breadcrumb"
+      [item]="item"
+    ></mdm-breadcrumb>
   </div>
   <div class="panel-body">
+    <span class="item-type">{{ item.domainType }}</span>
     <div
       *ngIf="item.description"
       class="mdm-catalogue-item-search-result__content"
     >
-    <mdm-more-description [description]="item.description">
-    </mdm-more-description>
+      <mdm-more-description [description]="item.description">
+      </mdm-more-description>
     </div>
-    <div class="mdm-catalogue-item-search-result__footer">
-      <a [href]="linkUrl">View Details</a>
+    <div
+      *ngIf="!item.description"
+      class="mdm-catalogue-item-search-result__content mdm-catalogue-item-search-result__no-content"
+    >
+      No description available
     </div>
   </div>
 </div>

--- a/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.scss
+++ b/src/app/catalogue-search/catalogue-item-search-result/catalogue-item-search-result.component.scss
@@ -30,6 +30,11 @@ SPDX-License-Identifier: Apache-2.0
     &__header {
       background-color: $search-result-heading-background-color;
       color: $search-result-heading-color;
+
+      a {
+        color: $search-result-heading-color;
+        text-decoration: underline;
+      }
     }
   }
 }
@@ -61,6 +66,16 @@ $search-result-border-radius: 4px;
     }
   }
 
+  .panel-body {
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    padding: 0;
+  }
+
+  .item-type {
+    margin: 1em 1em 0em 1em;
+  }
+
   &__content,
   &__footer {
     padding: $search-result-content-padding;
@@ -69,7 +84,7 @@ $search-result-border-radius: 4px;
     border-radius: $search-result-border-radius;
   }
 
-  .panel-body {
-    padding: 0;
+  &__no-content {
+    font-style: italic;
   }
 }

--- a/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.html
+++ b/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.html
@@ -15,56 +15,50 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="input-group">
-  <button
-    mat-button
-    color="primary"
-    (click)="toggleAdvancedSearch()"
-    class="ml-1 px-1"
-  >
-    Advanced
+<div class="container mb-2">
+  <button mat-stroked-button color="primary" (click)="toggleAdvancedSearch()">
+    {{ advancedSearch ? 'Less filters' : 'More filters...' }}
   </button>
 </div>
-
-<div>
-  <ng-template [ngIf]="advancedSearch">
-    <form
-      [formGroup]="formGroup"
-      (keyup.enter)="callParentSearch()"
-      role="form"
-    >
-      <h5 class="marginless">Apply Restrictions and filters:</h5>
-      <ng-template [ngIf]="true">
-        <div class="row search-section">
-          <div class="col">
-            <mdm-model-selector-tree
-              [ngModel]="context.value"
-              (ngModelChange)="contextValue = $event"
-              [ngModelOptions]="{ standalone: true }"
-              ngDefaultControl
-              [placeholder]="'Choose a Folder, Data Model, Data Class, or Terminology:'"
-              [accepts]="['Folder', 'DataModel', 'DataClass', 'Terminology']"
-            >
-            </mdm-model-selector-tree>
-          </div>
-        </div>
-      </ng-template>
-
-      <div class="row search-section-columns">
+<div *ngIf="advancedSearch">
+  <form [formGroup]="formGroup" (keyup.enter)="callParentSearch()" role="form">
+    <div class="container">
+      <div class="row search-section">
         <div class="col">
           <div>
-            <mat-checkbox class="checkbox-filter" formControlName="labelOnly"
+            <mat-checkbox
+              class="checkbox-filter"
+              color="primary"
+              formControlName="labelOnly"
               >Label only</mat-checkbox
             >
-            <mat-checkbox class="checkbox-filter" formControlName="exactMatch"
+            <mat-checkbox
+              class="checkbox-filter"
+              color="primary"
+              formControlName="exactMatch"
               >Exact match</mat-checkbox
             >
           </div>
         </div>
       </div>
+      <div class="row search-section">
+        <div class="col">
+          <mdm-model-selector-tree
+            [ngModel]="context.value"
+            (ngModelChange)="contextValue = $event"
+            [ngModelOptions]="{ standalone: true }"
+            ngDefaultControl
+            [placeholder]="
+              'Choose a Folder, Data Model, Data Class, or Terminology:'
+            "
+            [accepts]="['Folder', 'DataModel', 'DataClass', 'Terminology']"
+          >
+          </mdm-model-selector-tree>
+        </div>
+      </div>
       <div class="row search-section-columns">
         <div class="col">
-          <mat-form-field appearance="fill" class="full-width">
+          <mat-form-field appearance="outline" class="full-width">
             <mat-label>Domain type</mat-label>
             <mat-select formControlName="domainTypes" multiple>
               <mat-option value="DataModel">Data Model</mat-option>
@@ -82,7 +76,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
 
         <div class="col">
-          <mat-form-field appearance="fill" class="full-width">
+          <mat-form-field appearance="outline" class="full-width">
             <mat-label>Select classifiers</mat-label>
             <mat-select formControlName="classifiers" multiple>
               <mat-option
@@ -98,7 +92,10 @@ SPDX-License-Identifier: Apache-2.0
 
       <div class="row search-section-columns">
         <div class="col">
-          <mat-form-field appearance="fill" class="full-width">
+          <mat-form-field
+            appearance="outline"
+            class="full-width form-field-align-center"
+          >
             <mat-label>Last Updated After</mat-label>
             <input
               matInput
@@ -119,7 +116,10 @@ SPDX-License-Identifier: Apache-2.0
         </div>
 
         <div class="col">
-          <mat-form-field appearance="fill" class="full-width">
+          <mat-form-field
+            appearance="outline"
+            class="full-width form-field-align-center"
+          >
             <mat-label>Last Updated Before</mat-label>
             <input
               matInput
@@ -142,7 +142,10 @@ SPDX-License-Identifier: Apache-2.0
 
       <div class="row search-section-columns">
         <div class="col">
-          <mat-form-field appearance="fill" class="full-width">
+          <mat-form-field
+            appearance="outline"
+            class="full-width form-field-align-center"
+          >
             <mat-label>Created After</mat-label>
             <input
               matInput
@@ -163,7 +166,10 @@ SPDX-License-Identifier: Apache-2.0
         </div>
 
         <div class="col">
-          <mat-form-field appearance="fill" class="full-width">
+          <mat-form-field
+            appearance="outline"
+            class="full-width form-field-align-center"
+          >
             <mat-label>Created Before</mat-label>
             <input
               matInput
@@ -183,6 +189,6 @@ SPDX-License-Identifier: Apache-2.0
           </mat-form-field>
         </div>
       </div>
-    </form>
-  </ng-template>
+    </div>
+  </form>
 </div>

--- a/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.scss
+++ b/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.scss
@@ -17,20 +17,20 @@ SPDX-License-Identifier: Apache-2.0
 */
 div {
   .checkbox-filter {
-    margin-right: 10px;
+    margin-right: 2em;
   }
 
   .search-section {
     border: 1px solid #e5e5e5;
     border-radius: 4px;
-    padding: 4px;
-    margin: 1px;
+    padding: 1em 0;
+    margin: 1em 0;
   }
   .search-section-columns {
     border: 1px solid #e5e5e5;
     border-radius: 4px;
-    padding: 4px;
-    margin: 1px;
+    padding-top: 0.5em;
+    margin: 1em 0;
 
     .mat-datepicker-input {
       width: 85%;
@@ -39,9 +39,7 @@ div {
     mat-icon {
       position: relative;
       float: right;
-      top: -10px;
       cursor: pointer;
-      color: rgba(0, 0, 0, 0.54);
     }
   }
 

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.html
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.html
@@ -27,27 +27,29 @@ SPDX-License-Identifier: Apache-2.0
       </div>
     </div>
 
-    <div class="form-actions row">
-      <div class="col">
-        <div class="search-button">
-          <button
-            class="mr-1"
-            type="button"
-            mat-stroked-button
-            color="primary"
-            (click)="this.reset()"
-          >
-            Reset
-          </button>
-          <button
-            type="submit"
-            mat-flat-button
-            color="primary"
-            [disabled]="this.catalogueSearchFormComponent.formGroup.invalid"
-            (click)="search()"
-          >
-            Search
-          </button>
+    <div class="container">
+      <div class="form-actions row">
+        <div class="col">
+          <div class="search-button">
+            <button
+              class="mr-1"
+              type="button"
+              mat-stroked-button
+              color="primary"
+              (click)="this.reset()"
+            >
+              Reset
+            </button>
+            <button
+              type="submit"
+              mat-flat-button
+              color="primary"
+              [disabled]="this.catalogueSearchFormComponent.formGroup.invalid"
+              (click)="search()"
+            >
+              Search
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.scss
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.scss
@@ -17,10 +17,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 .search-button {
-  padding-right: 15px;
+  margin-top: 1em;
   float: right;
-}
-
-.mdm-catalogue-search-advanced-form {
-  padding-left: 15px;
 }

--- a/src/app/catalogue-search/search-filters/search-filters.component.html
+++ b/src/app/catalogue-search/search-filters/search-filters.component.html
@@ -29,24 +29,53 @@ SPDX-License-Identifier: Apache-2.0
     Reset All
   </button>
   <div class="mdm-search-filters__section">
-  <div class="input-group mb-3">
-    <button type="button" class="form-control" aria-label="Choose a catalogue item" (click)="openCatalogueItemSelectModal()">{{ context ? context.label : 'Choose a catalogue item'}}</button>
-    <div class="input-group-append">
-      <span class="input-group-text"><mat-icon
-        (click)="onContextClear()"
-        >clear</mat-icon
-      ></span>
+    <mat-divider></mat-divider>
+    <ul>
+      <li>
+        <mat-checkbox
+          color="primary"
+          [checked]="labelOnlyFilter.checked"
+          (change)="onLabelOnlyChange($event)"
+        >
+          Label Only
+        </mat-checkbox>
+      </li>
+      <li>
+        <mat-checkbox
+          color="primary"
+          [checked]="exactMatchFilter.checked"
+          (change)="onExactMatchChange($event)"
+        >
+          Exact Match
+        </mat-checkbox>
+      </li>
+    </ul>
+  </div>
+  <div class="mdm-search-filters__section">
+    <mat-divider></mat-divider>
+    <div class="input-group mb-3">
+      <button
+        type="button"
+        class="form-control"
+        aria-label="Choose a catalogue item"
+        (click)="openCatalogueItemSelectModal()"
+      >
+        {{ context ? context.label : 'Choose a catalogue item' }}
+      </button>
+      <div class="input-group-append">
+        <span class="input-group-text"
+          ><mat-icon (click)="onContextClear()">clear</mat-icon></span
+        >
+      </div>
     </div>
   </div>
-  </div>
-  <div>
-    <div class="mdm-search-filters__section">
+  <div class="mdm-search-filters__section">
+    <mat-form-field appearance="outline" class="full-width">
       <mat-label>Domain Type</mat-label>
       <mat-select
         (selectionChange)="onDomainTypeChange($event)"
         multiple
         placeholder="Domain Types"
-        class="form-control"
         [(ngModel)]="domainTypes"
       >
         <mat-option
@@ -56,110 +85,13 @@ SPDX-License-Identifier: Apache-2.0
           {{ domainType.name }}</mat-option
         >
       </mat-select>
-    </div>
-    <div class="mdm-search-filters__section">
-      <mat-label>Matching</mat-label>
-      <ul>
-        <li>
-          <mat-checkbox
-            color="primary"
-            [checked]="labelOnlyFilter.checked"
-            (change)="onLabelOnlyChange($event)"
-          >
-            Label Only
-          </mat-checkbox>
-        </li>
-        <li>
-          <mat-checkbox
-            color="primary"
-            [checked]="exactMatchFilter.checked"
-            (change)="onExactMatchChange($event)"
-          >
-            Exact Match
-          </mat-checkbox>
-        </li>
-      </ul>
-    </div>
-    <div class="mdm-search-filters__section">
-      <mat-label>Dates</mat-label>
-      <div>
-        <mat-form-field appearance="fill">
-          <mat-label>Updated After</mat-label>
-          <input
-            matInput
-            [matDatepicker]="lastUpdatedAfter"
-            (dateChange)="onDateChange('lastUpdatedAfter', $event)"
-            [value]="lastUpdatedAfterFilter.value"
-          />
-          <mat-icon class="clear-date"
-            matDatepickerToggleIcon
-            (click)="onDateClear('lastUpdatedAfter')"
-            >clear</mat-icon
-          >
-          <mat-datepicker-toggle matSuffix [for]="lastUpdatedAfter">
-          </mat-datepicker-toggle>
-          <mat-datepicker #lastUpdatedAfter></mat-datepicker>
-        </mat-form-field>
-        <mat-form-field appearance="fill">
-          <mat-label>Updated Before</mat-label>
-          <input
-            matInput
-            [matDatepicker]="lastUpdatedBefore"
-            (dateChange)="onDateChange('lastUpdatedBefore', $event)"
-            [value]="lastUpdatedBeforeFilter.value"
-          />
-          <mat-icon class="clear-date"
-            matDatepickerToggleIcon
-            (click)="onDateClear('lastUpdatedBefore')"
-            >clear</mat-icon
-          >
-          <mat-datepicker-toggle matSuffix [for]="lastUpdatedBefore">
-          </mat-datepicker-toggle>
-          <mat-datepicker #lastUpdatedBefore></mat-datepicker>
-        </mat-form-field>
-        <mat-form-field appearance="fill">
-          <mat-label>Created After</mat-label>
-          <input
-            matInput
-            [matDatepicker]="createdAfter"
-            (dateChange)="onDateChange('createdAfter', $event)"
-            [value]="createdAfterFilter.value"
-          />
-          <mat-icon class="clear-date"
-            matDatepickerToggleIcon
-            (click)="onDateClear('createdAfter')"
-            >clear</mat-icon
-          >
-          <mat-datepicker-toggle matSuffix [for]="createdAfter">
-          </mat-datepicker-toggle>
-          <mat-datepicker #createdAfter></mat-datepicker>
-        </mat-form-field>
-        <mat-form-field appearance="fill">
-          <mat-label>Created Before</mat-label>
-          <input
-            matInput
-            [matDatepicker]="createdBefore"
-            (dateChange)="onDateChange('createdBefore', $event)"
-            [value]="createdBeforeFilter.value"
-          />
-          <mat-icon class="clear-date"
-            matDatepickerToggleIcon
-            (click)="onDateClear('createdBefore')"
-            >clear</mat-icon
-          >
-          <mat-datepicker-toggle matSuffix [for]="createdBefore">
-          </mat-datepicker-toggle>
-          <mat-datepicker #createdBefore></mat-datepicker>
-        </mat-form-field>
-      </div>
-    </div>
-    <div class="mdm-search-filters__section" *ngIf="isReady">
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="full-width">
       <mat-label>Classifiers</mat-label>
       <mat-select
         (selectionChange)="onClassifiersChange($event)"
         multiple
         placeholder="Classifiers"
-        class="form-control"
         [(ngModel)]="classifiers"
       >
         <mat-option
@@ -169,6 +101,87 @@ SPDX-License-Identifier: Apache-2.0
           {{ classifier.label }}</mat-option
         >
       </mat-select>
+    </mat-form-field>
+  </div>
+  <div class="mdm-search-filters__section">
+    <mat-divider></mat-divider>
+    <div>
+      <mat-form-field
+        appearance="outline"
+        class="full-width form-field-align-center"
+      >
+        <mat-label>Updated After</mat-label>
+        <input
+          matInput
+          [matDatepicker]="lastUpdatedAfter"
+          (dateChange)="onDateChange('lastUpdatedAfter', $event)"
+          [value]="lastUpdatedAfterFilter.value"
+        />
+        <mat-icon
+          matDatepickerToggleIcon
+          (click)="onDateClear('lastUpdatedAfter')"
+          >clear</mat-icon
+        >
+        <mat-datepicker-toggle matSuffix [for]="lastUpdatedAfter">
+        </mat-datepicker-toggle>
+        <mat-datepicker #lastUpdatedAfter></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field
+        appearance="outline"
+        class="full-width form-field-align-center"
+      >
+        <mat-label>Updated Before</mat-label>
+        <input
+          matInput
+          [matDatepicker]="lastUpdatedBefore"
+          (dateChange)="onDateChange('lastUpdatedBefore', $event)"
+          [value]="lastUpdatedBeforeFilter.value"
+        />
+        <mat-icon
+          matDatepickerToggleIcon
+          (click)="onDateClear('lastUpdatedBefore')"
+          >clear</mat-icon
+        >
+        <mat-datepicker-toggle matSuffix [for]="lastUpdatedBefore">
+        </mat-datepicker-toggle>
+        <mat-datepicker #lastUpdatedBefore></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field
+        appearance="outline"
+        class="full-width form-field-align-center"
+      >
+        <mat-label>Created After</mat-label>
+        <input
+          matInput
+          [matDatepicker]="createdAfter"
+          (dateChange)="onDateChange('createdAfter', $event)"
+          [value]="createdAfterFilter.value"
+        />
+        <mat-icon matDatepickerToggleIcon (click)="onDateClear('createdAfter')"
+          >clear</mat-icon
+        >
+        <mat-datepicker-toggle matSuffix [for]="createdAfter">
+        </mat-datepicker-toggle>
+        <mat-datepicker #createdAfter></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field
+        appearance="outline"
+        class="full-width form-field-align-center"
+      >
+        <mat-label>Created Before</mat-label>
+        <input
+          matInput
+          [matDatepicker]="createdBefore"
+          (dateChange)="onDateChange('createdBefore', $event)"
+          [value]="createdBeforeFilter.value"
+        />
+        <mat-icon matDatepickerToggleIcon (click)="onDateClear('createdBefore')"
+          >clear</mat-icon
+        >
+        <mat-datepicker-toggle matSuffix [for]="createdBefore">
+        </mat-datepicker-toggle>
+        <mat-datepicker #createdBefore></mat-datepicker>
+      </mat-form-field>
     </div>
   </div>
 </div>

--- a/src/app/catalogue-search/search-filters/search-filters.component.scss
+++ b/src/app/catalogue-search/search-filters/search-filters.component.scss
@@ -21,7 +21,9 @@ SPDX-License-Identifier: Apache-2.0
   $primary: map-get($theme, primary);
   $accent: map-get($theme, accent);
 
-  $search-filters-heading-background-color: mat.get-color-from-palette($primary);
+  $search-filters-heading-background-color: mat.get-color-from-palette(
+    $primary
+  );
   $search-filters-heading-color: mat.get-color-from-palette(
     $primary,
     '500-contrast'
@@ -29,21 +31,23 @@ SPDX-License-Identifier: Apache-2.0
 
   .mdm-search-filters {
     &__header {
-      border-radius: 2px;
+      border-radius: 4px;
       background-color: $search-filters-heading-background-color;
       color: $search-filters-heading-color;
 
       h3 {
         font-weight: 500;
-        padding-left: 4px;
-        padding-top: 4px;
-        padding-bottom: 4px;
+        padding: 0.25em 0.5em;
         vertical-align: middle;
       }
     }
 
     &__section {
       margin-top: 1em;
+
+      .mat-divider {
+        margin: 0.85em 0;
+      }
     }
 
     ul {
@@ -62,10 +66,6 @@ SPDX-License-Identifier: Apache-2.0
       float: right;
       cursor: pointer;
       color: rgba(0, 0, 0, 0.5);
-    }
-
-    mat-icon.clear-date {
-      top: -8px;
     }
   }
 }

--- a/src/style/components/_forms.scss
+++ b/src/style/components/_forms.scss
@@ -16,17 +16,19 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-@import "style/abstracts/variables";
+@import 'style/abstracts/variables';
 
 /* Form specific style */
 form.mdm--form {
   background-color: #fff;
   border-radius: 5px;
   max-width: $forms-max-width;
-  .form-row div.mdm--form-input, .mat-form-field {
-      width: 100%;
+  .form-row div.mdm--form-input,
+  .mat-form-field {
+    width: 100%;
   }
-  .input-group input, .input-group textarea {
+  .input-group input,
+  .input-group textarea {
     border: 1px solid #e8e8e8;
     border-radius: 2px;
     box-shadow: none;
@@ -54,7 +56,7 @@ form.mdm--form.mdm--form-modal {
     padding: 12px 16px;
   }
 
-  .mdm--form-input{
+  .mdm--form-input {
     width: 100%;
   }
   .mat-form-field-infix {
@@ -87,21 +89,29 @@ form.mdm--form.mdm--form-modal {
 }
 /* Mat design reset */
 .register-modal {
-    .mat-form-field-appearance-outline .mat-form-field-wrapper {
-      margin: 0!important;
-    }
+  .mat-form-field-appearance-outline .mat-form-field-wrapper {
+    margin: 0 !important;
+  }
 }
 
 .outlined-input {
   height: 44px;
   line-height: 44px;
   border-radius: 5px;
-  border: 1px solid #e8e8e8!important;
+  border: 1px solid #e8e8e8 !important;
   box-shadow: none;
 }
 
 .outlined-block {
   border-radius: 5px;
-  border: 1px solid #e8e8e8!important;
+  border: 1px solid #e8e8e8 !important;
   box-shadow: none;
+}
+
+.form-field-align-center {
+  .mat-form-field-wrapper {
+    .mat-form-field-flex {
+      align-items: center;
+    }
+  }
 }


### PR DESCRIPTION
Resolves #782

- Better alignment of search page forms
- Use outline form field appearance on Search page
- Align search page filter sections
- Update search result links and description
- Make search results border clearer
- Use outline appearance for search listing filter controls
- Use dividers between search listing filter sections
- Make search checkbox filters consistent colours
- Put item type of search results in body of result

Updated screenshots:

![image](https://user-images.githubusercontent.com/3219480/223110314-4dd08445-bc36-4557-8928-1fad64f03f3d.png)

![image](https://user-images.githubusercontent.com/3219480/223110382-135c350a-20c4-404d-ac01-3695d5a2809c.png)
