### PR TITLE
gh-777 Add profile search filter selection to Search page

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
   post {
     always {
       outputTestResults()
-      zulipNotification(topic: 'mdm-ui')
+      //zulipNotification(topic: 'mdm-ui')
     }
   }
 }

--- a/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.html
+++ b/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.html
@@ -15,180 +15,171 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div class="container mb-2">
-  <button mat-stroked-button color="primary" (click)="toggleAdvancedSearch()">
-    {{ advancedSearch ? 'Less filters' : 'More filters...' }}
-  </button>
-</div>
-<div *ngIf="advancedSearch">
-  <form [formGroup]="formGroup" (keyup.enter)="callParentSearch()" role="form">
-    <div class="container">
-      <div class="row search-section">
-        <div class="col">
-          <div>
-            <mat-checkbox
-              class="checkbox-filter"
-              color="primary"
-              formControlName="labelOnly"
-              >Label only</mat-checkbox
-            >
-            <mat-checkbox
-              class="checkbox-filter"
-              color="primary"
-              formControlName="exactMatch"
-              >Exact match</mat-checkbox
-            >
-          </div>
-        </div>
-      </div>
-      <div class="row search-section">
-        <div class="col">
-          <mdm-model-selector-tree
-            [ngModel]="context.value"
-            (ngModelChange)="contextValue = $event"
-            [ngModelOptions]="{ standalone: true }"
-            ngDefaultControl
-            [placeholder]="
-              'Choose a Folder, Data Model, Data Class, or Terminology:'
-            "
-            [accepts]="['Folder', 'DataModel', 'DataClass', 'Terminology']"
+<form [formGroup]="formGroup" role="form">
+  <div class="container">
+    <div class="row search-section">
+      <div class="col">
+        <div>
+          <mat-checkbox
+            class="checkbox-filter"
+            color="primary"
+            formControlName="labelOnly"
+            >Label only</mat-checkbox
           >
-          </mdm-model-selector-tree>
-        </div>
-      </div>
-      <div class="row search-section-columns">
-        <div class="col">
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Domain type</mat-label>
-            <mat-select formControlName="domainTypes" multiple>
-              <mat-option value="DataModel">Data Model</mat-option>
-              <mat-option value="DataClass">Data Class</mat-option>
-              <mat-option value="DataElement">Data Element</mat-option>
-              <mat-option value="DataType">Data Type</mat-option>
-              <mat-option value="EnumerationValue"
-                >Enumeration Value</mat-option
-              >
-              <mat-option value="ReferenceDataModel"
-                >Reference Data Model</mat-option
-              >
-            </mat-select>
-          </mat-form-field>
-        </div>
-
-        <div class="col">
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Select classifiers</mat-label>
-            <mat-select formControlName="classifiers" multiple>
-              <mat-option
-                *ngFor="let classification of classifications"
-                [value]="classification"
-              >
-                {{ classification.label }}</mat-option
-              >
-            </mat-select>
-          </mat-form-field>
-        </div>
-      </div>
-
-      <div class="row search-section-columns">
-        <div class="col">
-          <mat-form-field
-            appearance="outline"
-            class="full-width form-field-align-center"
+          <mat-checkbox
+            class="checkbox-filter"
+            color="primary"
+            formControlName="exactMatch"
+            >Exact match</mat-checkbox
           >
-            <mat-label>Last Updated After</mat-label>
-            <input
-              matInput
-              [matDatepicker]="updatedAfter"
-              [formControl]="lastUpdatedAfter"
-            />
-            <mat-icon
-              matDatepickerToggleIcon
-              (click)="onDateClear('lastUpdatedAfter')"
-              >clear</mat-icon
-            >
-            <mat-datepicker-toggle
-              matSuffix
-              [for]="updatedAfter"
-            ></mat-datepicker-toggle>
-            <mat-datepicker #updatedAfter></mat-datepicker>
-          </mat-form-field>
-        </div>
-
-        <div class="col">
-          <mat-form-field
-            appearance="outline"
-            class="full-width form-field-align-center"
-          >
-            <mat-label>Last Updated Before</mat-label>
-            <input
-              matInput
-              [matDatepicker]="updatedBefore"
-              [formControl]="lastUpdatedBefore"
-            />
-            <mat-icon
-              matDatepickerToggleIcon
-              (click)="onDateClear('lastUpdatedBefore')"
-              >clear</mat-icon
-            >
-            <mat-datepicker-toggle
-              matSuffix
-              [for]="updatedBefore"
-            ></mat-datepicker-toggle>
-            <mat-datepicker #updatedBefore></mat-datepicker>
-          </mat-form-field>
-        </div>
-      </div>
-
-      <div class="row search-section-columns">
-        <div class="col">
-          <mat-form-field
-            appearance="outline"
-            class="full-width form-field-align-center"
-          >
-            <mat-label>Created After</mat-label>
-            <input
-              matInput
-              [matDatepicker]="createdAfterPicker"
-              [formControl]="createdAfter"
-            />
-            <mat-icon
-              matDatepickerToggleIcon
-              (click)="onDateClear('createdAfter')"
-              >clear</mat-icon
-            >
-            <mat-datepicker-toggle
-              matSuffix
-              [for]="createdAfterPicker"
-            ></mat-datepicker-toggle>
-            <mat-datepicker #createdAfterPicker></mat-datepicker>
-          </mat-form-field>
-        </div>
-
-        <div class="col">
-          <mat-form-field
-            appearance="outline"
-            class="full-width form-field-align-center"
-          >
-            <mat-label>Created Before</mat-label>
-            <input
-              matInput
-              [matDatepicker]="createdBeforePicker"
-              [formControl]="createdBefore"
-            />
-            <mat-icon
-              matDatepickerToggleIcon
-              (click)="onDateClear('createdBefore')"
-              >clear</mat-icon
-            >
-            <mat-datepicker-toggle
-              matSuffix
-              [for]="createdBeforePicker"
-            ></mat-datepicker-toggle>
-            <mat-datepicker #createdBeforePicker></mat-datepicker>
-          </mat-form-field>
         </div>
       </div>
     </div>
-  </form>
-</div>
+    <div class="row search-section">
+      <div class="col">
+        <mdm-model-selector-tree
+          [ngModel]="context.value"
+          (ngModelChange)="contextValue = $event"
+          [ngModelOptions]="{ standalone: true }"
+          ngDefaultControl
+          [placeholder]="
+            'Choose a Folder, Data Model, Data Class, or Terminology:'
+          "
+          [accepts]="['Folder', 'DataModel', 'DataClass', 'Terminology']"
+        >
+        </mdm-model-selector-tree>
+      </div>
+    </div>
+    <div class="row search-section-columns">
+      <div class="col">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Domain type</mat-label>
+          <mat-select formControlName="domainTypes" multiple>
+            <mat-option value="DataModel">Data Model</mat-option>
+            <mat-option value="DataClass">Data Class</mat-option>
+            <mat-option value="DataElement">Data Element</mat-option>
+            <mat-option value="DataType">Data Type</mat-option>
+            <mat-option value="EnumerationValue">Enumeration Value</mat-option>
+            <mat-option value="ReferenceDataModel"
+              >Reference Data Model</mat-option
+            >
+          </mat-select>
+        </mat-form-field>
+      </div>
+
+      <div class="col">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Select classifiers</mat-label>
+          <mat-select formControlName="classifiers" multiple>
+            <mat-option
+              *ngFor="let classification of classifications"
+              [value]="classification"
+            >
+              {{ classification.label }}</mat-option
+            >
+          </mat-select>
+        </mat-form-field>
+      </div>
+    </div>
+
+    <div class="row search-section-columns">
+      <div class="col">
+        <mat-form-field
+          appearance="outline"
+          class="full-width form-field-align-center"
+        >
+          <mat-label>Last Updated After</mat-label>
+          <input
+            matInput
+            [matDatepicker]="updatedAfter"
+            [formControl]="lastUpdatedAfter"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('lastUpdatedAfter')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle
+            matSuffix
+            [for]="updatedAfter"
+          ></mat-datepicker-toggle>
+          <mat-datepicker #updatedAfter></mat-datepicker>
+        </mat-form-field>
+      </div>
+
+      <div class="col">
+        <mat-form-field
+          appearance="outline"
+          class="full-width form-field-align-center"
+        >
+          <mat-label>Last Updated Before</mat-label>
+          <input
+            matInput
+            [matDatepicker]="updatedBefore"
+            [formControl]="lastUpdatedBefore"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('lastUpdatedBefore')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle
+            matSuffix
+            [for]="updatedBefore"
+          ></mat-datepicker-toggle>
+          <mat-datepicker #updatedBefore></mat-datepicker>
+        </mat-form-field>
+      </div>
+    </div>
+
+    <div class="row search-section-columns">
+      <div class="col">
+        <mat-form-field
+          appearance="outline"
+          class="full-width form-field-align-center"
+        >
+          <mat-label>Created After</mat-label>
+          <input
+            matInput
+            [matDatepicker]="createdAfterPicker"
+            [formControl]="createdAfter"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('createdAfter')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle
+            matSuffix
+            [for]="createdAfterPicker"
+          ></mat-datepicker-toggle>
+          <mat-datepicker #createdAfterPicker></mat-datepicker>
+        </mat-form-field>
+      </div>
+
+      <div class="col">
+        <mat-form-field
+          appearance="outline"
+          class="full-width form-field-align-center"
+        >
+          <mat-label>Created Before</mat-label>
+          <input
+            matInput
+            [matDatepicker]="createdBeforePicker"
+            [formControl]="createdBefore"
+          />
+          <mat-icon
+            matDatepickerToggleIcon
+            (click)="onDateClear('createdBefore')"
+            >clear</mat-icon
+          >
+          <mat-datepicker-toggle
+            matSuffix
+            [for]="createdBeforePicker"
+          ></mat-datepicker-toggle>
+          <mat-datepicker #createdBeforePicker></mat-datepicker>
+        </mat-form-field>
+      </div>
+    </div>
+  </div>
+</form>

--- a/src/app/catalogue-search/catalogue-search-form/catalogue-search-form.component.ts
+++ b/src/app/catalogue-search/catalogue-search-form/catalogue-search-form.component.ts
@@ -15,9 +15,17 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output
+} from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
+import { Subject, takeUntil } from 'rxjs';
 
 /**
  * Top-level component that represents the overall Catalogue Search page.
@@ -30,15 +38,18 @@ import { MatFormFieldAppearance } from '@angular/material/form-field';
   templateUrl: './catalogue-search-form.component.html',
   styleUrls: ['./catalogue-search-form.component.scss']
 })
-export class CatalogueSearchFormComponent implements OnInit {
+export class CatalogueSearchFormComponent implements OnInit, OnDestroy {
   @Input() appearance: MatFormFieldAppearance = 'outline';
   @Input() routeSearchTerm?: string = '';
 
+  @Output() valueChange = new EventEmitter<void>();
   @Output() searchEvent = new EventEmitter<string>();
 
   formGroup = new FormGroup({
     searchTerms: new FormControl(this.routeSearchTerm)
   });
+
+  private unsubscribe$ = new Subject<void>();
 
   get searchTerms() {
     return this.formGroup.controls.searchTerms;
@@ -46,6 +57,15 @@ export class CatalogueSearchFormComponent implements OnInit {
 
   ngOnInit(): void {
     this.searchTerms.setValue(this.routeSearchTerm);
+
+    this.formGroup.valueChanges
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(() => this.valueChange.emit());
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 
   reset() {

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.html
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.html
@@ -1,3 +1,20 @@
+<!--
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
 <div class="container profile-filter-list__header">
   <div class="profile-filter-list__title">
     <h4 class="marginless">Profile Filters</h4>

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.html
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.html
@@ -1,0 +1,96 @@
+<div class="container profile-filter-list__header">
+  <div class="profile-filter-list__title">
+    <h4 class="marginless">Profile Filters</h4>
+    <span class="mdm--badge mdm--element-count">{{ filters.length }}</span>
+  </div>
+  <button mat-stroked-button color="primary" (click)="addFilter()">
+    <span class="fas fa-plus"></span>
+    Add
+  </button>
+</div>
+<form
+  *ngIf="providers"
+  class="profile-filter-list__table"
+  [formGroup]="formGroup"
+>
+  <div class="container" formArrayName="filters">
+    <div
+      class="row"
+      *ngFor="let filter of filters.controls; let i = index"
+      [formGroup]="filter"
+    >
+      <div class="col">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Profile</mat-label>
+          <mat-select formControlName="provider">
+            <mat-option *ngFor="let provider of providers" [value]="provider"
+              >{{ provider.displayName }} ({{ provider.namespace }})</mat-option
+            >
+          </mat-select>
+          <mat-error *ngIf="filter.controls.provider.errors?.required"
+            >Select a profile</mat-error
+          >
+        </mat-form-field>
+      </div>
+      <div class="col">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Key</mat-label>
+          <mat-select formControlName="key">
+            <!--
+              Sections and options depend on a ProfileDefinition being loaded (decided by the "provider" field)
+              and being mapped to a hidden FormGroup control
+            -->
+            <mat-optgroup
+              *ngFor="let section of filter.controls.definition.value?.sections ?? []"
+              [label]="section.name"
+            >
+              <mat-option *ngFor="let key of section.fields" [value]="key">{{
+                key.fieldName
+              }}</mat-option>
+            </mat-optgroup>
+          </mat-select>
+          <mat-error *ngIf="filter.controls.key.errors?.required"
+            >Select a key</mat-error
+          >
+        </mat-form-field>
+      </div>
+      <div class="col profile-filter-list__value-col">
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Value</mat-label>
+          <!-- Select control for enumeration keys -->
+          <mat-select
+            *ngIf="
+              filter.controls.key.value &&
+              filter.controls.key.value.dataType === 'enumeration'
+            "
+            formControlName="value"
+          >
+            <mat-option
+              *ngFor="let allowed of filter.controls.key.value.allowedValues"
+              [value]="allowed"
+              >{{ allowed }}</mat-option
+            >
+          </mat-select>
+          <!-- Regular input for everything else -->
+          <input
+            matInput
+            *ngIf="filter.controls.key.value?.dataType !== 'enumeration'"
+            formControlName="value"
+          />
+          <mat-error *ngIf="filter.controls.value.errors?.required"
+            >Select a value</mat-error
+          >
+        </mat-form-field>
+        <button
+          mat-button
+          color="warn"
+          (click)="removeFilter(i)"
+          aria-label="Remove"
+          matTooltip="Remove"
+        >
+          <span class="fas fa-times"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.scss
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.scss
@@ -1,0 +1,30 @@
+.profile-filter-list {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-content: center;
+    margin-bottom: 1em;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  &__value-col {
+    display: flex;
+    align-items: flex-start;
+
+    button {
+      margin-top: 16px;
+    }
+  }
+
+  &__table {
+    .row {
+      padding-top: 0.5em;
+      border-top: 1px solid #e5e5e5;
+    }
+  }
+}

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.scss
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.scss
@@ -1,3 +1,20 @@
+/*
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 .profile-filter-list {
   &__header {
     display: flex;

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.spec.ts
@@ -1,3 +1,20 @@
+/*
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 import { FormGroup, Validators } from '@angular/forms';
 import {
   ProfileDefinition,
@@ -152,6 +169,7 @@ describe('CatalogueSearchProfileFiltersComponent', () => {
     });
 
     it('should have form fields setup correctly', () => {
+      /* eslint-disable @typescript-eslint/unbound-method */
       expect(formGroup.controls.provider).toBeDefined();
       expect(formGroup.controls.provider.value).toBe(null);
       expect(
@@ -172,6 +190,7 @@ describe('CatalogueSearchProfileFiltersComponent', () => {
 
       expect(formGroup.controls.definition).toBeDefined();
       expect(formGroup.controls.key.value).toBe(null);
+      /* eslint-enable @typescript-eslint/unbound-method */
     });
 
     it('should fetch a profile definition when a provider is selected', () => {

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.spec.ts
@@ -1,0 +1,235 @@
+import { FormGroup, Validators } from '@angular/forms';
+import {
+  ProfileDefinition,
+  ProfileDefinitionResponse,
+  ProfileSummary,
+  ProfileSummaryIndexResponse
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import {
+  ComponentHarness,
+  setupTestModuleForComponent
+} from '@mdm/testing/testing.helpers';
+import { Observable, of } from 'rxjs';
+
+import { CatalogueSearchProfileFilterListComponent } from './catalogue-search-profile-filter-list.component';
+
+describe('CatalogueSearchProfileFiltersComponent', () => {
+  let harness: ComponentHarness<CatalogueSearchProfileFilterListComponent>;
+
+  const resourcesStub = {
+    profile: {
+      definition: jest.fn() as jest.MockedFunction<
+        (
+          namespace: string,
+          name: string
+        ) => Observable<ProfileDefinitionResponse>
+      >,
+      providers: jest.fn() as jest.MockedFunction<
+        () => Observable<ProfileSummaryIndexResponse>
+      >
+    }
+  };
+
+  beforeEach(async () => {
+    harness = await setupTestModuleForComponent(
+      CatalogueSearchProfileFilterListComponent,
+      {
+        providers: [
+          {
+            provide: MdmResourcesService,
+            useValue: resourcesStub
+          }
+        ]
+      }
+    );
+  });
+
+  const providers: ProfileSummary[] = [...Array(2).keys()].map((i) => ({
+    name: `profile${i}`,
+    namespace: 'uk.ac.mauro.test',
+    metadataNamespace: 'uk.ac.mauro.test.profile',
+    version: '1',
+    displayName: `Profile ${i}`,
+    domains: [],
+    knownMetadataKeys: [],
+    providerType: 'test',
+    allowsExtraMetadataKeys: false
+  }));
+
+  beforeEach(() => {
+    resourcesStub.profile.providers.mockImplementation(() =>
+      of({
+        body: providers
+      })
+    );
+  });
+
+  afterEach(() => harness.component.ngOnDestroy());
+
+  it('should create', () => {
+    expect(harness.isComponentCreated).toBeTruthy();
+    expect(harness.component.providers).toStrictEqual([]);
+    expect(harness.component.filters.length).toBe(0);
+  });
+
+  it('should fetch all providers on initialisation', () => {
+    harness.component.ngOnInit();
+    expect(harness.component.providers).toStrictEqual(providers);
+  });
+
+  describe('table modifications', () => {
+    it.each([0, 1, 2])(
+      'should create a new row when initial row count is %p',
+      (initial) => {
+        harness.component.ngOnInit();
+
+        Array.from(Array(initial).keys()).forEach(() =>
+          harness.component.addFilter()
+        );
+        expect(harness.component.filters.length).toBe(initial);
+
+        const valueChangeSpy = jest.spyOn(
+          harness.component.valueChange,
+          'emit'
+        );
+
+        harness.component.addFilter();
+        expect(harness.component.filters.length).toBe(initial + 1);
+        expect(valueChangeSpy).toHaveBeenCalled();
+      }
+    );
+
+    it.each([
+      [1, 2],
+      [0, 1],
+      [3, 5]
+    ])(
+      'should remove row %p when initial row count is %p',
+      (index, initial) => {
+        harness.component.ngOnInit();
+
+        Array.from(Array(initial).keys()).forEach(() =>
+          harness.component.addFilter()
+        );
+        expect(harness.component.filters.length).toBe(initial);
+
+        const valueChangeSpy = jest.spyOn(
+          harness.component.valueChange,
+          'emit'
+        );
+
+        harness.component.removeFilter(index);
+        expect(harness.component.filters.length).toBe(initial - 1);
+        expect(valueChangeSpy).toHaveBeenCalled();
+      }
+    );
+
+    it('should reset all rows back to zero', () => {
+      harness.component.ngOnInit();
+
+      harness.component.addFilter();
+      harness.component.addFilter();
+      expect(harness.component.filters.length).toBe(2);
+
+      const valueChangeSpy = jest.spyOn(harness.component.valueChange, 'emit');
+
+      harness.component.reset();
+      expect(harness.component.filters.length).toBe(0);
+      expect(valueChangeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('filter rows', () => {
+    let formGroup: FormGroup<any>;
+
+    beforeEach(() => {
+      // Initialise and add at least one row
+      harness.component.ngOnInit();
+      harness.component.addFilter();
+
+      formGroup = harness.component.filters.at(0) as FormGroup<any>;
+    });
+
+    it('should have form fields setup correctly', () => {
+      expect(formGroup.controls.provider).toBeDefined();
+      expect(formGroup.controls.provider.value).toBe(null);
+      expect(
+        formGroup.controls.provider.hasValidator(Validators.required)
+      ).toBe(true);
+
+      expect(formGroup.controls.key).toBeDefined();
+      expect(formGroup.controls.key.value).toBe(null);
+      expect(formGroup.controls.key.hasValidator(Validators.required)).toBe(
+        true
+      );
+
+      expect(formGroup.controls.value).toBeDefined();
+      expect(formGroup.controls.value.value).toBe('');
+      expect(formGroup.controls.value.hasValidator(Validators.required)).toBe(
+        true
+      );
+
+      expect(formGroup.controls.definition).toBeDefined();
+      expect(formGroup.controls.key.value).toBe(null);
+    });
+
+    it('should fetch a profile definition when a provider is selected', () => {
+      const provider = providers[0];
+
+      const definition: ProfileDefinition = {
+        sections: [
+          {
+            name: 'section',
+            fields: [
+              {
+                fieldName: 'field',
+                dataType: 'string',
+                metadataPropertyName: 'field'
+              }
+            ]
+          }
+        ]
+      };
+
+      resourcesStub.profile.definition.mockImplementationOnce(() =>
+        of({
+          body: definition
+        })
+      );
+
+      formGroup.controls.provider.setValue(provider);
+
+      expect(formGroup.controls.definition.value).toStrictEqual(definition);
+      expect(resourcesStub.profile.definition).toHaveBeenCalledWith(
+        provider.namespace,
+        provider.name
+      );
+    });
+
+    it('should reset dependent fields when provider changes', () => {
+      formGroup.controls.provider.setValue('initial provider');
+      formGroup.controls.key.setValue('key test');
+      formGroup.controls.value.setValue('value test');
+
+      expect(formGroup.controls.key.value).not.toBeNull();
+      expect(formGroup.controls.value.value).not.toBe('');
+
+      formGroup.controls.provider.setValue('new provider');
+
+      expect(formGroup.controls.key.value).toBeNull();
+      expect(formGroup.controls.value.value).toBeNull();
+    });
+
+    it('should reset dependent fields when key changes', () => {
+      formGroup.controls.key.setValue('initial key');
+      formGroup.controls.value.setValue('value test');
+
+      expect(formGroup.controls.value.value).not.toBe('');
+
+      formGroup.controls.key.setValue('new key');
+
+      expect(formGroup.controls.value.value).toBeNull();
+    });
+  });
+});

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.ts
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.ts
@@ -1,0 +1,121 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  Output,
+  EventEmitter
+} from '@angular/core';
+import { FormArray, FormControl, FormGroup, Validators } from '@angular/forms';
+import {
+  ProfileDefinition,
+  ProfileDefinitionResponse,
+  ProfileField,
+  ProfileSummary,
+  ProfileSummaryIndexResponse
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
+import { map, Subject, switchMap, takeUntil } from 'rxjs';
+
+@Component({
+  selector: 'mdm-catalogue-search-profile-filter-list',
+  templateUrl: './catalogue-search-profile-filter-list.component.html',
+  styleUrls: ['./catalogue-search-profile-filter-list.component.scss']
+})
+export class CatalogueSearchProfileFilterListComponent
+  implements OnInit, OnDestroy {
+  @Output() valueChange = new EventEmitter<void>();
+
+  providers: ProfileSummary[] = [];
+  formGroup = new FormGroup({
+    filters: new FormArray([])
+  });
+
+  private unsubscribe$ = new Subject<void>();
+
+  get filters() {
+    return this.formGroup.controls.filters;
+  }
+
+  constructor(private resources: MdmResourcesService) {}
+
+  ngOnInit(): void {
+    this.resources.profile
+      .providers()
+      .pipe(
+        map((response: ProfileSummaryIndexResponse) =>
+          response.body.sort((a, b) =>
+            a.displayName.localeCompare(b.displayName)
+          )
+        )
+      )
+      .subscribe((providers: ProfileSummary[]) => (this.providers = providers));
+
+    this.formGroup.valueChanges
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(() => this.valueChange.emit());
+  }
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
+  }
+
+  addFilter() {
+    this.filters.push(this.createFilter());
+  }
+
+  removeFilter(index: number) {
+    this.filters.removeAt(index);
+  }
+
+  reset() {
+    this.filters.clear();
+  }
+
+  private createFilter() {
+    const filter = new FormGroup({
+      // Important fields required for search filters
+      provider: new FormControl<ProfileSummary>(null, Validators.required),
+      key: new FormControl<ProfileField>(null, Validators.required),
+      value: new FormControl('', Validators.required),
+
+      // Non-visible form controls, required as dependencies to above
+      definition: new FormControl<ProfileDefinition>(null)
+    });
+
+    // Track when the "provider" field changes, then fetch that profile definition
+    // to be able to select from the list of known fields. Set the definition to a
+    // special "backing" field for this form group, this will be used to render the key
+    // options to the mat-select in this row
+    filter.controls.provider.valueChanges
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        switchMap((provider) =>
+          this.resources.profile.definition(provider.namespace, provider.name)
+        ),
+        map((response: ProfileDefinitionResponse) => response.body)
+      )
+      .subscribe((definition) =>
+        filter.controls.definition.setValue(definition)
+      );
+
+    // When the provider changes, reset any previous key/value set
+    // Use reset() instead of setValue() so that dirty/pristine state is reset too
+    filter.controls.provider.valueChanges
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(() => {
+        filter.controls.key.reset();
+        filter.controls.value.reset();
+      });
+
+    // When the key changes, reset any previous value set
+    // Use reset() instead of setValue() so that dirty/pristine state is reset too
+    filter.controls.key.valueChanges
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(() => {
+        filter.controls.value.reset();
+      });
+
+    return filter;
+  }
+}

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.ts
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.ts
@@ -1,3 +1,20 @@
+/*
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 import {
   Component,
   OnInit,
@@ -73,6 +90,7 @@ export class CatalogueSearchProfileFilterListComponent
   }
 
   private createFilter() {
+    /* eslint-disable @typescript-eslint/unbound-method */
     const filter = new FormGroup({
       // Important fields required for search filters
       provider: new FormControl<ProfileSummary>(null, Validators.required),
@@ -82,6 +100,7 @@ export class CatalogueSearchProfileFilterListComponent
       // Non-visible form controls, required as dependencies to above
       definition: new FormControl<ProfileDefinition>(null)
     });
+    /* eslint-enable @typescript-eslint/unbound-method */
 
     // Track when the "provider" field changes, then fetch that profile definition
     // to be able to select from the list of known fields. Set the definition to a

--- a/src/app/catalogue-search/catalogue-search.module.ts
+++ b/src/app/catalogue-search/catalogue-search.module.ts
@@ -27,6 +27,7 @@ import { CatalogueSearchAdvancedFormComponent } from './catalogue-search-advance
 import { SearchFiltersComponent } from './search-filters/search-filters.component';
 import { FoldersTreeModule } from '@mdm/folders-tree/folders-tree.module';
 import { CatalogueItemSearchComponent } from './catalogue-item-search/catalogue-item-search.component';
+import { CatalogueSearchProfileFilterListComponent } from './catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component';
 
 @NgModule({
   declarations: [
@@ -36,7 +37,8 @@ import { CatalogueItemSearchComponent } from './catalogue-item-search/catalogue-
     CatalogueItemSearchResultComponent,
     CatalogueSearchAdvancedFormComponent,
     SearchFiltersComponent,
-    CatalogueItemSearchComponent
+    CatalogueItemSearchComponent,
+    CatalogueSearchProfileFilterListComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.html
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.html
@@ -16,42 +16,49 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="container">
-  <form>
-    <div class="highlight-box__content">
-      <mdm-catalogue-search-form
-        (searchEvent)="search()"
-      ></mdm-catalogue-search-form>
-      <div class="catalogue-search-advanced-form">
-        <mdm-catalogue-search-advanced-form (searchEvent)="search()">
-        </mdm-catalogue-search-advanced-form>
-      </div>
+  <div class="highlight-box__content">
+    <mdm-catalogue-search-form
+      (valueChange)="onValueChange()"
+      (searchEvent)="search()"
+    ></mdm-catalogue-search-form>
+    <div class="container mb-2">
+      <button mat-stroked-button color="primary" (click)="toggleShowMore()">
+        {{ showMore ? 'Less filters' : 'More filters...' }}
+      </button>
     </div>
+    <div *ngIf="showMore" class="catalogue-search-advanced-form">
+      <mdm-catalogue-search-advanced-form (valueChange)="onValueChange()">
+      </mdm-catalogue-search-advanced-form>
+      <mdm-catalogue-search-profile-filter-list
+        (valueChange)="onValueChange()"
+      ></mdm-catalogue-search-profile-filter-list>
+    </div>
+  </div>
 
-    <div class="container">
-      <div class="form-actions row">
-        <div class="col">
-          <div class="search-button">
-            <button
-              class="mr-1"
-              type="button"
-              mat-stroked-button
-              color="primary"
-              (click)="this.reset()"
-            >
-              Reset
-            </button>
-            <button
-              type="submit"
-              mat-flat-button
-              color="primary"
-              [disabled]="this.catalogueSearchFormComponent.formGroup.invalid"
-              (click)="search()"
-            >
-              Search
-            </button>
-          </div>
+  <div class="container">
+    <div class="form-actions row">
+      <div class="col">
+        <div class="search-button">
+          <button
+            class="mr-1"
+            type="button"
+            mat-stroked-button
+            color="primary"
+            (click)="this.reset()"
+          >
+            Reset
+          </button>
+          <button
+            type="submit"
+            mat-flat-button
+            color="primary"
+            [disabled]="!valid"
+            (click)="search()"
+          >
+            Search
+          </button>
         </div>
       </div>
     </div>
-  </form>
+  </div>
 </div>

--- a/src/app/catalogue-search/catalogue-search/catalogue-search.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search/catalogue-search.component.spec.ts
@@ -15,7 +15,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 import {
   CatalogueItemDomainType,
   Classifier,


### PR DESCRIPTION
Resolves #777 

- New child component for CatalogueSearchComponent
- Track state of all profile filters using Angular FormArray
- Use profile providers and definitions to guide user for which namespaces and keys to use for filters
- Clean up code in CatalogueSearchAdvancedForm
- Move "More filters" button to parent component
- Section on CatalogueSearch page now controls visibility of the advanced form and profile filter list
- Update code and tests to have @ViewChild mapping work
- Update parent/child communication to handle resets and track validity
- Add and update tests

# Notes

1. Values entered per filter are chosen either from a list of enumeration values or entered as strings. Only "enumeration" field types are especially supported at the moment.
2. The Search page does not pass these chosen filters on to the Search Listing page yet, see #779 

# Screenshots

![image](https://user-images.githubusercontent.com/3219480/224099070-3efed8eb-d150-47c0-995f-d1ebcd05d880.png)
