### PR TITLE
gh-661 - Enumeration functionality fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
   post {
     always {
       outputTestResults()
-      zulipNotification(topic: 'mdm-ui')
+      // zulipNotification(topic: 'mdm-ui')
     }
   }
 }

--- a/src/app/shared/mdm-paginator/mdm-paginator.ts
+++ b/src/app/shared/mdm-paginator/mdm-paginator.ts
@@ -26,17 +26,16 @@ export class MdmPaginatorComponent extends MatPaginator implements OnInit {
   ngOnInit(): void {
     super.ngOnInit();
 
-    this.pageSizeOptions = [5, 10, 20, 50];
-
     const settings = JSON.parse(localStorage.getItem('userSettings'));
     if (settings) {
-      // If there is no pageSize specified then use the settings value, if any
+      // If there is no pageSize or pageSizeOptions specified then use the settings value, if any.
       this.pageSize = this.pageSize ?? settings.countPerTable;
-      this.pageSizeOptions =  settings.counts;
+      this.pageSizeOptions = this.pageSizeOptions ?? settings.counts;
     }
 
-    // If still no pageSize then default to 20
+    // Set defaults if still no values.
     this.pageSize = this.pageSize ?? 20;
+    this.pageSizeOptions = this.pageSizeOptions ?? [5, 10, 20, 50];
   }
 
   get pageOffset() {
@@ -48,5 +47,4 @@ export class MdmPaginatorComponent extends MatPaginator implements OnInit {
     this.pageIndex = value.pageIndex;
     this.page.emit(value);
   }
-
 }

--- a/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.html
+++ b/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.html
@@ -368,6 +368,8 @@ SPDX-License-Identifier: Apache-2.0
 <div class="mdm--mat-pagination">
   <mdm-paginator
     [length]="enumsCount"
+    [pageSize]="pageSize"
+    [pageSizeOptions]="pageSizes"
     (page)="pageSizeClicked($event)"
     showFirstLastButtons
   ></mdm-paginator>


### PR DESCRIPTION
I was unable to recreate the final step mentioned in the ticket. That is, seeing an error message when adding the 21st item. 

However, I did notice the following:

The mdm-enumeration-with-list component (parent) has a pageSize property that is set from a userSettings blob. However, it is _not_ passed down to the child mdm-pagination component (child). Instead, the pagination component looks in local storage for the pageSize setting.  Therefore, when the parent is compiling the list of items to display it is doing so with different pageSize value than it’s child pagination component is displaying. **This gives the impression that you can't add more than 20 items because the parent only displays parent.pageSize number of options and this value is out of sync with what the pagination component is displaying.** In fact, the additional items are being added to the total list of options, but not added to a dynamically generated displayItems list that computes how many of the total options to show based on the pageSize.

Example, there are 25 enumerationOptions in total and the the pageSize is set in parent to 20 and so _only_ 20 items are placed in a tracking array displayItems. However, the pagination component has a pageSize of 50 because that's what the local storage setting is set to. This leads to conflicting info on the screen. I know I’ve added more than 20 items and it says I should be seeing up to 50. However, only 20 appear. What's worse, is that the NextPage button isn't available so the only way to see the items currently is to switch the number of results to display to something other than 50 and then it will allow you to click NextPage, or if you select 50 again it will correctly place all the options in the displayItems array. 

Fixes #661 