### PR TITLE
gh-779 Pass profile filters for search via URL to Search Listing page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -214,8 +214,10 @@ export const pageRoutes: { states: Ng2StateDeclaration[] } = {
       name: 'appContainer.mainApp.twoSidePanel.catalogue.dataModel',
       url: '/dataModel/:id/{tabView:string}?{finalised:string}',
       component: DataModelComponent,
-      params: { tabView: { dynamic: true, value: null, squash: true },
-                finalised: { dynamic: true, value: null, squash: true, inherit: false} },
+      params: {
+        tabView: { dynamic: true, value: null, squash: true },
+        finalised: { dynamic: true, value: null, squash: true, inherit: false }
+      },
       data: {
         allowAnonymous: true
       }
@@ -448,35 +450,39 @@ export const pageRoutes: { states: Ng2StateDeclaration[] } = {
     },
     {
       name: 'appContainer.mainApp.catalogueSearchListing',
+      // For search URL, compress the parameter names as much as possible - metadata (md) query param value could be very long
       url:
-        '/search/listing?{contextDomainType:string}&{contextId:string}&{contextLabel:string}&{contextParentId:string}&{contextDataModelId:string}&{search:string}&{page:int}&{sort:string}&{order:string}&{pageSize:int}&{domainTypes:string}&{labelOnly:string}&{exactMatch:string}&{lastUpdatedAfter:string}&{lastUpdatedBefore:string}&{createdAfter:string}&{createdBefore:string}&{classifiers:string}',
+        '/search/listing?{cxdt:string}&{cxid:string}&{cxl:string}&{cxpid:string}&{cxmid:string}&{search:string}&{page:int}&{sort:string}&{order:string}&{pageSize:int}&{dt:string}&{l:bool}&{e:bool}&{lua:string}&{lub:string}&{ca:string}&{cb:string}&{cls:string}&{md:string}',
       component: CatalogueSearchListingComponent,
       data: {
         allowAnonymous: true
       },
       params: {
-        contextDomainType: null,
-        contextId: null,
-        contextLabel: null,
-        contextParentId: null,
-        contextDataModelId: null,
+        cxdt: null, // contextDomainType: string
+        cxid: null, // contextId: string
+        cxl: null, // contextLabel: string
+        cxpid: null, // contextParentId: string
+        cxmid: null, // contextDataModelId: string
         search: null,
         page: null,
         sort: null,
         order: null,
         pageSize: null,
-        labelOnly: 'false',
-        exactMatch: 'false',
-        domainTypes: {
+        l: false, // labelOnly: bool
+        e: false, // exactMatch: bool
+        dt: {
+          // domain types: array
           array: 'auto'
         },
-        classifiers: {
+        cls: {
+          // classifiers: array
           array: 'auto'
         },
-        lastUpdatedAfter: null,
-        lastUpdatedBefore: null,
-        createdAfter: null,
-        createdBefore: null
+        lua: null, // lastUpdatedAfter: string (date)
+        lub: null, // lastUpdatedBefore: string (date)
+        ca: null, // createdAfter: string (date)
+        cb: null, // createdBefore: string (date)
+        md: null // metadata: base64 encoded string
       }
     },
     {

--- a/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.spec.ts
@@ -25,6 +25,7 @@ import {
   ComponentHarness,
   setupTestModuleForComponent
 } from '@mdm/testing/testing.helpers';
+import { serializeDate } from '../catalogue-search.types';
 import { CatalogueSearchAdvancedFormComponent } from './catalogue-search-advanced-form.component';
 
 describe('CatalogueSearchFormAdvancedComponent', () => {
@@ -77,9 +78,9 @@ describe('CatalogueSearchFormAdvancedComponent', () => {
 
   it('it should format dates correctly', () => {
     harness.component.createdAfter.setValue(new Date('July 21, 1983 01:15:00'));
-    expect(
-      harness.component.formatDate(harness.component.createdAfter.value)
-    ).toMatch('1983-06-21');
+    expect(serializeDate(harness.component.createdAfter.value)).toMatch(
+      '1983-07-21'
+    );
   });
 
   it('it should return classifer lables in an array', () => {

--- a/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.ts
+++ b/src/app/catalogue-search/catalogue-search-advanced/catalogue-search-advanced-form.component.ts
@@ -127,18 +127,6 @@ export class CatalogueSearchAdvancedFormComponent implements OnInit, OnDestroy {
     this.unsubscribe$.complete();
   }
 
-  formatDate(date: Date) {
-    if (!date) {
-      return;
-    }
-
-    const yyyy: String = date.getFullYear().toString();
-    const mm: String = date.getMonth().toString().padStart(2, '0');
-    const dd: String = date.getDate().toString().padStart(2, '0');
-
-    return `${yyyy}-${mm}-${dd}`;
-  }
-
   onDateClear(control: string) {
     this.formGroup.get(control).setValue(null);
   }

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
@@ -91,7 +91,6 @@ export class CatalogueSearchListingComponent implements OnInit {
           // Profile filters must be mapped to the correct object type before they can be
           // used properly
           this.profileFilters = profileFilters;
-          console.log(this.profileFilters);
 
           if (!this.parameters.search || this.parameters.search === '') {
             return of<CatalogueSearchResultSet>({

--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
@@ -18,12 +18,13 @@ SPDX-License-Identifier: Apache-2.0
 import { Component, OnInit } from '@angular/core';
 import { MessageHandlerService, StateHandlerService } from '@mdm/services';
 import { UIRouterGlobals } from '@uirouter/core';
-import { EMPTY } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { EMPTY, of } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 import { CatalogueSearchService } from '../catalogue-search.service';
 import {
   CatalogueSearchContext,
   CatalogueSearchParameters,
+  CatalogueSearchProfileFilter,
   CatalogueSearchResultSet,
   getOrderFromSortByOptionString,
   getSortFromSortByOptionString,
@@ -56,6 +57,7 @@ export class CatalogueSearchListingComponent implements OnInit {
     { value: 'label-desc', displayName: 'Label (z-a)' }
   ];
   sortByDefaultOption: SortByOption = this.searchListingSortByOptions[0];
+  profileFilters?: CatalogueSearchProfileFilter[];
 
   constructor(
     private routerGlobals: UIRouterGlobals,
@@ -74,12 +76,48 @@ export class CatalogueSearchListingComponent implements OnInit {
       this.parameters.order
     );
 
-    if (!this.parameters.search || this.parameters.search === '') {
-      this.setEmptyResultPage();
-      return;
-    }
+    this.status = 'loading';
 
-    this.performSearch();
+    this.catalogueSearch
+      .mapProfileFilters(this.parameters.profileFiltersDto)
+      .pipe(
+        catchError(() => {
+          this.messageHandler.showWarning(
+            'A problem occurred when getting your profile filters.'
+          );
+          return of([] as CatalogueSearchProfileFilter[]); // Continue
+        }),
+        switchMap((profileFilters) => {
+          // Profile filters must be mapped to the correct object type before they can be
+          // used properly
+          this.profileFilters = profileFilters;
+          console.log(this.profileFilters);
+
+          if (!this.parameters.search || this.parameters.search === '') {
+            return of<CatalogueSearchResultSet>({
+              count: 0,
+              page: 1,
+              pageSize: 10,
+              items: []
+            });
+          }
+
+          // TODO: apply profileFilters (if any) to search endpoint
+          return this.catalogueSearch.search(this.parameters);
+        }),
+        catchError((error) => {
+          this.status = 'error';
+          this.messageHandler.showError(
+            'A problem occurred when searching.',
+            error
+          );
+          return EMPTY;
+        })
+      )
+      .subscribe((resultSet) => {
+        this.status = 'ready';
+        this.resultSet = resultSet;
+      });
   }
 
   /**
@@ -137,37 +175,6 @@ export class CatalogueSearchListingComponent implements OnInit {
     this.parameters.createdBefore = undefined;
     this.parameters.classifiers = [];
     this.updateSearch();
-  }
-
-  private setEmptyResultPage() {
-    this.resultSet = {
-      count: 0,
-      page: 1,
-      pageSize: 10,
-      items: []
-    };
-    this.status = 'ready';
-  }
-
-  private performSearch() {
-    this.status = 'loading';
-
-    this.catalogueSearch
-      .search(this.parameters)
-      .pipe(
-        catchError((error) => {
-          this.status = 'error';
-          this.messageHandler.showError(
-            'A problem occurred when searching.',
-            error
-          );
-          return EMPTY;
-        })
-      )
-      .subscribe((resultSet) => {
-        this.resultSet = resultSet;
-        this.status = 'ready';
-      });
   }
 
   /**

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.html
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.html
@@ -19,8 +19,14 @@ SPDX-License-Identifier: Apache-2.0
   <div class="profile-filter-list__title">
     <h4 class="marginless">Profile Filters</h4>
     <span class="mdm--badge mdm--element-count">{{ filters.length }}</span>
+    <span>Add up to {{ max }} filters</span>
   </div>
-  <button mat-stroked-button color="primary" (click)="addFilter()">
+  <button
+    mat-stroked-button
+    color="primary"
+    [disabled]="filters.length >= max"
+    (click)="addFilter()"
+  >
     <span class="fas fa-plus"></span>
     Add
   </button>

--- a/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.spec.ts
+++ b/src/app/catalogue-search/catalogue-search-profile-filter-list/catalogue-search-profile-filter-list.component.spec.ts
@@ -155,6 +155,19 @@ describe('CatalogueSearchProfileFiltersComponent', () => {
       expect(harness.component.filters.length).toBe(0);
       expect(valueChangeSpy).toHaveBeenCalled();
     });
+
+    it('should not add more rows than allowed maximum', () => {
+      harness.component.ngOnInit();
+
+      Array.from(Array(harness.component.max).keys()).forEach(() =>
+        harness.component.addFilter()
+      );
+
+      expect(harness.component.filters.length).toBe(harness.component.max);
+
+      harness.component.addFilter();
+      expect(harness.component.filters.length).toBe(harness.component.max);
+    });
   });
 
   describe('filter rows', () => {

--- a/src/app/catalogue-search/catalogue-search.service.spec.ts
+++ b/src/app/catalogue-search/catalogue-search.service.spec.ts
@@ -15,18 +15,231 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+import {
+  MdmResponse,
+  ProfileDefinition,
+  ProfileDefinitionResponse,
+  ProfileField,
+  ProfileSummary,
+  ProfileSummaryResponse
+} from '@maurodatamapper/mdm-resources';
+import { MdmResourcesService } from '@mdm/modules/resources';
 import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+import { cold } from 'jest-marbles';
+import { Observable } from 'rxjs';
 
 import { CatalogueSearchService } from './catalogue-search.service';
 
 describe('CatalogueSearchService', () => {
   let service: CatalogueSearchService;
 
+  const resourcesStub = {
+    profile: {
+      provider: jest.fn() as jest.MockedFunction<
+        (
+          namespace: string,
+          name: string,
+          version?: string
+        ) => Observable<ProfileSummaryResponse>
+      >,
+      definition: jest.fn() as jest.MockedFunction<
+        (
+          namespace: string,
+          name: string
+        ) => Observable<ProfileDefinitionResponse>
+      >
+    }
+  };
+
   beforeEach(() => {
-    service = setupTestModuleForService(CatalogueSearchService);
+    service = setupTestModuleForService(CatalogueSearchService, {
+      providers: [
+        {
+          provide: MdmResourcesService,
+          useValue: resourcesStub
+        }
+      ]
+    });
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('map profile fields', () => {
+    const namespace1 = 'test.namespace.1';
+    const namespace2 = 'test.namespace.2';
+
+    const profile1 = 'TestProfile1';
+    const profile2 = 'TestProfile2';
+
+    const version1 = '1.0.0';
+    const version2 = '2.0.0';
+
+    const key1 = 'key1';
+    const key2 = 'key2';
+
+    const value1 = 'value1';
+    const value2 = 'value2';
+
+    const buildProfileSummary = (
+      namespace: string,
+      name: string,
+      version: string
+    ): ProfileSummary => {
+      return {
+        name,
+        namespace,
+        version
+      } as ProfileSummary;
+    };
+
+    const buildProfileField = (key: string): ProfileField => {
+      return {
+        metadataPropertyName: key
+      } as ProfileField;
+    };
+
+    const buildProfileDefinition = (
+      fields: ProfileField[]
+    ): ProfileDefinition => {
+      return {
+        sections: [
+          {
+            name: 'section1',
+            fields
+          }
+        ]
+      };
+    };
+
+    const buildResponse = <T>(value: T): MdmResponse<T> => {
+      return {
+        body: value
+      };
+    };
+
+    const provider1 = buildProfileSummary(namespace1, profile1, version1);
+    const provider2 = buildProfileSummary(namespace2, profile2, version2);
+    const definition = buildProfileDefinition([
+      buildProfileField(key1),
+      buildProfileField(key2)
+    ]);
+
+    beforeEach(() => {
+      // Provider mock response
+      resourcesStub.profile.provider.mockImplementation((ns, n, v) => {
+        const response = buildResponse(
+          ns === namespace2 && n === profile2 && v === version2
+            ? provider2
+            : provider1
+        );
+        return cold('a|', {
+          a: response
+        });
+      });
+
+      // Definition mock response
+      resourcesStub.profile.definition.mockImplementation(() =>
+        cold('a|', {
+          a: buildResponse(definition)
+        })
+      );
+    });
+
+    it('should return empty list when no DTO is provided', () => {
+      const expected$ = cold('(a|)', { a: [] });
+      const actual$ = service.mapProfileFilters(null);
+      expect(actual$).toBeObservable(expected$);
+    });
+
+    it('should return a single namespace and single field', () => {
+      const dto = {
+        [`${namespace1}|${profile1}|${version1}`]: {
+          [key1]: value1
+        }
+      };
+
+      const expected$ = cold('-(a|)', {
+        a: [
+          {
+            provider: provider1,
+            key: definition.sections[0].fields[0],
+            value: value1
+          }
+        ]
+      });
+
+      const actual$ = service.mapProfileFilters(dto);
+      expect(actual$).toBeObservable(expected$);
+    });
+
+    it('should return a single namespace and multiple fields', () => {
+      const dto = {
+        [`${namespace1}|${profile1}|${version1}`]: {
+          [key1]: value1,
+          [key2]: value2
+        }
+      };
+
+      const expected$ = cold('-(a|)', {
+        a: [
+          {
+            provider: provider1,
+            key: definition.sections[0].fields[0],
+            value: value1
+          },
+          {
+            provider: provider1,
+            key: definition.sections[0].fields[1],
+            value: value2
+          }
+        ]
+      });
+
+      const actual$ = service.mapProfileFilters(dto);
+      expect(actual$).toBeObservable(expected$);
+    });
+
+    it('should return multiple namespaces and multiple fields', () => {
+      const dto = {
+        [`${namespace1}|${profile1}|${version1}`]: {
+          [key1]: value1,
+          [key2]: value2
+        },
+        [`${namespace2}|${profile2}|${version2}`]: {
+          [key1]: value1,
+          [key2]: value2
+        }
+      };
+
+      const expected$ = cold('-(a|)', {
+        a: [
+          {
+            provider: provider1,
+            key: definition.sections[0].fields[0],
+            value: value1
+          },
+          {
+            provider: provider1,
+            key: definition.sections[0].fields[1],
+            value: value2
+          },
+          {
+            provider: provider2,
+            key: definition.sections[0].fields[0],
+            value: value1
+          },
+          {
+            provider: provider2,
+            key: definition.sections[0].fields[1],
+            value: value2
+          }
+        ]
+      });
+
+      const actual$ = service.mapProfileFilters(dto);
+      expect(actual$).toBeObservable(expected$);
+    });
   });
 });

--- a/src/app/catalogue-search/catalogue-search.service.ts
+++ b/src/app/catalogue-search/catalogue-search.service.ts
@@ -22,17 +22,25 @@ import {
   CatalogueItemSearchResult,
   MdmIndexBody,
   PageParameters,
+  ProfileDefinition,
+  ProfileDefinitionResponse,
+  ProfileSummary,
+  ProfileSummaryResponse,
   SearchQueryParameters
 } from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { Observable } from 'rxjs';
+import { forkJoin, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
   CatalogueSearchContext,
   CatalogueSearchParameters,
+  CatalogueSearchProfileFilter,
+  CatalogueSearchProfileFilterDto,
   CatalogueSearchResultSet,
   defaultPage,
-  defaultPageSize
+  defaultPageSize,
+  serializeDate,
+  ungroupProfileFiltersDto
 } from './catalogue-search.types';
 
 @Injectable({
@@ -61,6 +69,62 @@ export class CatalogueSearchService {
         };
       })
     );
+  }
+
+  /**
+   * Maps a {@link CatalogueSearchProfileFilterDto} into a full featured list of profile filters with usable
+   * information.
+   *
+   * @param dto The DTO to map and transform.
+   * @returns A list of {@link CatalogueSearchProfileFilter} objects.
+   *
+   * The DTO provided will only contain the essential information:
+   *
+   * 1. Profile provider - namespace, name and version
+   * 2. Metadata key
+   * 3. Metadata value
+   *
+   * Once unpacked, this function will then also fetch secondary information, such as the profile provider and
+   * metadata key display names.
+   */
+  mapProfileFilters(
+    dto?: CatalogueSearchProfileFilterDto
+  ): Observable<CatalogueSearchProfileFilter[]> {
+    if (!dto) {
+      return of([]);
+    }
+
+    const ungroupedDto = ungroupProfileFiltersDto(dto);
+
+    const foo = ungroupedDto.map((item) => {
+      const provider$: Observable<ProfileSummary> = this.resources.profile
+        .provider(item.namespace, item.name, item.version)
+        .pipe(map((response: ProfileSummaryResponse) => response.body));
+
+      const definition$: Observable<ProfileDefinition> = this.resources.profile
+        .definition(item.namespace, item.name)
+        .pipe(map((response: ProfileDefinitionResponse) => response.body));
+
+      return forkJoin([provider$, definition$]).pipe(
+        map(([provider, definition]) => {
+          const fields = definition.sections.flatMap(
+            (section) => section.fields
+          );
+
+          const key = fields.find(
+            (field) => field.metadataPropertyName === item.key
+          );
+
+          return {
+            provider,
+            key,
+            value: item.value
+          };
+        })
+      );
+    });
+
+    return forkJoin(foo);
   }
 
   /**
@@ -104,10 +168,10 @@ export class CatalogueSearchService {
       order: params.order,
       domainTypes: params.domainTypes,
       labelOnly: params.labelOnly,
-      lastUpdatedAfter: params.lastUpdatedAfter,
-      lastUpdatedBefore: params.lastUpdatedBefore,
-      createdAfter: params.createdAfter,
-      createdBefore: params.createdBefore,
+      lastUpdatedAfter: serializeDate(params.lastUpdatedAfter),
+      lastUpdatedBefore: serializeDate(params.lastUpdatedBefore),
+      createdAfter: serializeDate(params.createdAfter),
+      createdBefore: serializeDate(params.createdBefore),
       classifiers: params.classifiers
     };
   }

--- a/src/app/catalogue-search/catalogue-search.types.spec.ts
+++ b/src/app/catalogue-search/catalogue-search.types.spec.ts
@@ -1,0 +1,315 @@
+/*
+Copyright 2020-2023 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { ProfileField, ProfileSummary } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueSearchProfileFilter,
+  deserializeProfileFiltersToDto,
+  mapProfileFiltersToDto,
+  serializeProfileFiltersDto,
+  ungroupProfileFiltersDto
+} from './catalogue-search.types';
+
+describe('catalogue-search.types', () => {
+  describe('profile filters', () => {
+    const namespace1 = 'test.namespace.1';
+    const namespace2 = 'test.namespace.2';
+
+    const profile1 = 'TestProfile1';
+    const profile2 = 'TestProfile2';
+
+    const version1 = '1.0.0';
+    const version2 = '2.0.0';
+
+    const key1 = 'key1';
+    const key2 = 'key2';
+
+    const value1 = 'value1';
+    const value2 = 'value2';
+
+    const buildProfileFilter = (
+      namespace: string,
+      name: string,
+      version: string,
+      key: string,
+      value: string
+    ): CatalogueSearchProfileFilter => {
+      return {
+        provider: {
+          namespace,
+          name,
+          version
+        } as ProfileSummary,
+        key: {
+          metadataPropertyName: key
+        } as ProfileField,
+        value
+      };
+    };
+
+    describe('mapProfileFiltersToDto', () => {
+      it('should map a single namespace and field to a DTO', () => {
+        const filters = [
+          buildProfileFilter(namespace1, profile1, version1, key1, value1)
+        ];
+
+        const expected = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1
+          }
+        };
+
+        const actual = mapProfileFiltersToDto(filters);
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('should map a single namespace and multiple fields to a DTO', () => {
+        const filters = [
+          buildProfileFilter(namespace1, profile1, version1, key1, value1),
+          buildProfileFilter(namespace1, profile1, version1, key2, value2)
+        ];
+
+        const expected = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1,
+            [key2]: value2
+          }
+        };
+
+        const actual = mapProfileFiltersToDto(filters);
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('should map multiple namespaces and multiple fields to a DTO', () => {
+        const filters = [
+          buildProfileFilter(namespace1, profile1, version1, key1, value1),
+          buildProfileFilter(namespace1, profile1, version1, key2, value2),
+          buildProfileFilter(namespace2, profile2, version2, key1, value1),
+          buildProfileFilter(namespace2, profile2, version2, key2, value2)
+        ];
+
+        const expected = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1,
+            [key2]: value2
+          },
+          [`${namespace2}|${profile2}|${version2}`]: {
+            [key1]: value1,
+            [key2]: value2
+          }
+        };
+
+        const actual = mapProfileFiltersToDto(filters);
+        expect(actual).toStrictEqual(expected);
+      });
+    });
+
+    describe('ungroupProfileFiltersDto', () => {
+      it('should unmap a single namespace and field', () => {
+        const dto = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1
+          }
+        };
+
+        const expected = [
+          {
+            namespace: namespace1,
+            name: profile1,
+            version: version1,
+            key: key1,
+            value: value1
+          }
+        ];
+
+        const actual = ungroupProfileFiltersDto(dto);
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('should unmap a single namespace and multiple fields', () => {
+        const dto = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1,
+            [key2]: value2
+          }
+        };
+
+        const expected = [
+          {
+            namespace: namespace1,
+            name: profile1,
+            version: version1,
+            key: key1,
+            value: value1
+          },
+          {
+            namespace: namespace1,
+            name: profile1,
+            version: version1,
+            key: key2,
+            value: value2
+          }
+        ];
+
+        const actual = ungroupProfileFiltersDto(dto);
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('should unmap multiple namespaces and multiple fields', () => {
+        const dto = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1,
+            [key2]: value2
+          },
+          [`${namespace2}|${profile2}|${version2}`]: {
+            [key1]: value1,
+            [key2]: value2
+          }
+        };
+
+        const expected = [
+          {
+            namespace: namespace1,
+            name: profile1,
+            version: version1,
+            key: key1,
+            value: value1
+          },
+          {
+            namespace: namespace1,
+            name: profile1,
+            version: version1,
+            key: key2,
+            value: value2
+          },
+          {
+            namespace: namespace2,
+            name: profile2,
+            version: version2,
+            key: key1,
+            value: value1
+          },
+          {
+            namespace: namespace2,
+            name: profile2,
+            version: version2,
+            key: key2,
+            value: value2
+          }
+        ];
+
+        const actual = ungroupProfileFiltersDto(dto);
+        expect(actual).toStrictEqual(expected);
+      });
+    });
+
+    describe('serializeProfileFiltersDto', () => {
+      it('should serialize filters with one namespace and field', () => {
+        const filters = [
+          buildProfileFilter(namespace1, profile1, version1, key1, value1)
+        ];
+
+        const expected =
+          'eyJ0ZXN0Lm5hbWVzcGFjZS4xfFRlc3RQcm9maWxlMXwxLjAuMCI6eyJrZXkxIjoidmFsdWUxIn19';
+
+        const dto = mapProfileFiltersToDto(filters);
+        const actual = serializeProfileFiltersDto(dto);
+        expect(actual).toBe(expected);
+      });
+
+      it('should serialize filters with one namespace and multiple fields', () => {
+        const filters = [
+          buildProfileFilter(namespace1, profile1, version1, key1, value1),
+          buildProfileFilter(namespace1, profile1, version1, key2, value2)
+        ];
+
+        const expected =
+          'eyJ0ZXN0Lm5hbWVzcGFjZS4xfFRlc3RQcm9maWxlMXwxLjAuMCI6eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6InZhbHVlMiJ9fQ==';
+
+        const dto = mapProfileFiltersToDto(filters);
+        const actual = serializeProfileFiltersDto(dto);
+        expect(actual).toBe(expected);
+      });
+
+      it('should serialize filters with multiple namespaces and multiple fields', () => {
+        const filters = [
+          buildProfileFilter(namespace1, profile1, version1, key1, value1),
+          buildProfileFilter(namespace1, profile1, version1, key2, value2),
+          buildProfileFilter(namespace2, profile2, version2, key1, value1),
+          buildProfileFilter(namespace2, profile2, version2, key2, value2)
+        ];
+
+        const expected =
+          'eyJ0ZXN0Lm5hbWVzcGFjZS4xfFRlc3RQcm9maWxlMXwxLjAuMCI6eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6InZhbHVlMiJ9LCJ0ZXN0Lm5hbWVzcGFjZS4yfFRlc3RQcm9maWxlMnwyLjAuMCI6eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6InZhbHVlMiJ9fQ==';
+
+        const dto = mapProfileFiltersToDto(filters);
+        const actual = serializeProfileFiltersDto(dto);
+        expect(actual).toBe(expected);
+      });
+    });
+
+    describe('deserializeProfileFiltersToDto', () => {
+      it('should deserialize filters with one namespace and field', () => {
+        const base64 =
+          'eyJ0ZXN0Lm5hbWVzcGFjZS4xfFRlc3RQcm9maWxlMXwxLjAuMCI6eyJrZXkxIjoidmFsdWUxIn19';
+
+        const expected = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1
+          }
+        };
+
+        const actual = deserializeProfileFiltersToDto(base64);
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('should deserialize filters with one namespace and multiple fields', () => {
+        const base64 =
+          'eyJ0ZXN0Lm5hbWVzcGFjZS4xfFRlc3RQcm9maWxlMXwxLjAuMCI6eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6InZhbHVlMiJ9fQ==';
+
+        const expected = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1,
+            [key2]: value2
+          }
+        };
+
+        const actual = deserializeProfileFiltersToDto(base64);
+        expect(actual).toStrictEqual(expected);
+      });
+
+      it('should deserialize filters with multiple namespaces and multiple fields', () => {
+        const base64 =
+          'eyJ0ZXN0Lm5hbWVzcGFjZS4xfFRlc3RQcm9maWxlMXwxLjAuMCI6eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6InZhbHVlMiJ9LCJ0ZXN0Lm5hbWVzcGFjZS4yfFRlc3RQcm9maWxlMnwyLjAuMCI6eyJrZXkxIjoidmFsdWUxIiwia2V5MiI6InZhbHVlMiJ9fQ==';
+
+        const expected = {
+          [`${namespace1}|${profile1}|${version1}`]: {
+            [key1]: value1,
+            [key2]: value2
+          },
+          [`${namespace2}|${profile2}|${version2}`]: {
+            [key1]: value1,
+            [key2]: value2
+          }
+        };
+
+        const actual = deserializeProfileFiltersToDto(base64);
+        expect(actual).toStrictEqual(expected);
+      });
+    });
+  });
+});

--- a/src/app/catalogue-search/catalogue-search.types.ts
+++ b/src/app/catalogue-search/catalogue-search.types.ts
@@ -154,7 +154,7 @@ export const mapProfileFiltersToDto = (
 
 /**
  * Unpack a {@link CatalogueSearchProfileFilterDto} and flatten into a straight list of
- * objects containint the key information contained in the DTO.
+ * objects containing the key information contained in the DTO.
  *
  * @param dto A DTO to unpack.
  * @returns A flattened list of objects containing the key information from the DTO.
@@ -205,7 +205,7 @@ export const serializeProfileFiltersDto = (
  * @param base64String The encoded string to decode and deserialize
  * @returns A {@link CatalogueSearchProfileFilterDto} object.
  *
- * With the decoded DTO, you will need to transform into into suitable {@link CatalogueSearchProfileFilter}
+ * With the decoded DTO, you will need to transform into suitable {@link CatalogueSearchProfileFilter}
  * objects.
  *
  * @see {@link CatalogueSearchService.mapProfileFilters}

--- a/src/app/catalogue-search/catalogue-search.types.ts
+++ b/src/app/catalogue-search/catalogue-search.types.ts
@@ -17,7 +17,9 @@ SPDX-License-Identifier: Apache-2.0
 */
 import {
   CatalogueItemDomainType,
-  CatalogueItemSearchResult
+  CatalogueItemSearchResult,
+  ProfileField,
+  ProfileSummary
 } from '@maurodatamapper/mdm-resources';
 import { RawParams, StateParams } from '@uirouter/core';
 
@@ -57,6 +59,162 @@ export interface CatalogueSearchContext {
   parentId?: string;
   dataModelId?: string;
 }
+
+/**
+ * Represents a criteria filter using Profiles.
+ *
+ * This type of filter presents three key attributes:
+ *
+ * 1. The profile to match against - effectively, the namespace of the profile/metadata
+ * 2. The metadata property name to match against
+ * 3. The value to search for on this key
+ */
+export interface CatalogueSearchProfileFilter {
+  provider: ProfileSummary;
+  key: ProfileField;
+  value: string;
+}
+
+/**
+ * A data transfer object (DTO) comprising the same information as a list of {@link CatalogueSearchProfileFilter}
+ * values but compressed for better transfer.
+ *
+ * @see mapProfileFiltersToDto
+ */
+export interface CatalogueSearchProfileFilterDto {
+  [ns: string]: {
+    [key: string]: string;
+  };
+}
+
+/**
+ * Maps a list of {@link CatalogueSearchProfileFilter} objects into a compressed data transfer object (DTO)
+ * ready to be passed as data to other pages.
+ *
+ * @param filters The profile filters to transform into the DTO.
+ * @returns The minimal DTO containing the same information.
+ *
+ * The resulting DTO is designed to compress the important information from {@link CatalogueSearchProfileFilter} objects
+ * into a minimal JSON object. Information is grouped by profile namespace/name/version, and each group lists each key/value
+ * pair.
+ *
+ * For example, this list:
+ *
+ * ```ts
+ * [
+ *   {
+ *     provider: {
+ *       namespace: 'uk.ac.maurodatamapper.profiles',
+ *       name: 'TestProfile',
+ *       version: '1.0.0',
+ *       // etc...
+ *     },
+ *     key: {
+ *       metadataPropertyName: 'profileKey',
+ *       // etc...
+ *     },
+ *     value: 'some value'
+ *   }
+ * ]
+ * ```
+ *
+ * Would be transformed into this:
+ *
+ * ```json
+ * {
+ *   "uk.ac.maurodatamapper.profiles|TestProfile|1.0.0": {
+ *     "profileKey": "some value"
+ *   }
+ * }
+ * ```
+ *
+ * The reason for reducing this into a minimal DTO is to be able to compress and transfer the information
+ * across pages via URL query parameters.
+ *
+ * @see serializeProfileFiltersDto
+ */
+export const mapProfileFiltersToDto = (
+  filters: CatalogueSearchProfileFilter[]
+): CatalogueSearchProfileFilterDto => {
+  const grouped = filters.reduce((result, item) => {
+    // Must combine all profile provider information into one parsable string
+    const providerFullName = `${item.provider.namespace}|${item.provider.name}|${item.provider.version}`;
+
+    return {
+      ...result,
+      [providerFullName]: {
+        ...(result[providerFullName] || {}),
+        [item.key.metadataPropertyName]: item.value
+      }
+    };
+  }, {});
+
+  return grouped;
+};
+
+/**
+ * Unpack a {@link CatalogueSearchProfileFilterDto} and flatten into a straight list of
+ * objects containint the key information contained in the DTO.
+ *
+ * @param dto A DTO to unpack.
+ * @returns A flattened list of objects containing the key information from the DTO.
+ */
+export const ungroupProfileFiltersDto = (
+  dto: CatalogueSearchProfileFilterDto
+) => {
+  return Object.entries(dto).flatMap(([fullName, keyMap]) => {
+    // Full name is the same combined string created from mapProfileFiltersToDto()
+    const [namespace, name, version] = fullName.split('|');
+
+    return Object.entries(keyMap).map(([key, value]) => {
+      return {
+        namespace,
+        name,
+        version,
+        key,
+        value
+      };
+    });
+  });
+};
+
+/**
+ * Serializes the provided {@link CatalogueSearchProfileFilter} objects into a compressed, encoded string.
+ *
+ * @param filters The profile filter(s) to serialize
+ * @returns A Base64 encoded string of the information.
+ *
+ * This function is required to transform this large list/object structure into something that can be transferred
+ * via URL query parameters.
+ */
+export const serializeProfileFiltersDto = (
+  dto: CatalogueSearchProfileFilterDto
+): string => {
+  if (!dto) {
+    return undefined;
+  }
+
+  const json = JSON.stringify(dto);
+  const base64 = btoa(json); // Base64 encoded string
+  return base64;
+};
+
+/**
+ * Deserializes a Base64 encoded string which contains profile filter information.
+ *
+ * @param base64String The encoded string to decode and deserialize
+ * @returns A {@link CatalogueSearchProfileFilterDto} object.
+ *
+ * With the decoded DTO, you will need to transform into into suitable {@link CatalogueSearchProfileFilter}
+ * objects.
+ *
+ * @see {@link CatalogueSearchService.mapProfileFilters}
+ */
+export const deserializeProfileFiltersToDto = (base64String: string) => {
+  const decoded = atob(base64String); // Base64 decoded string
+  const dto = JSON.parse(decoded) as CatalogueSearchProfileFilterDto;
+  return dto;
+};
 
 /**
  * Represents the parameters to drive a Catalogue Search.
@@ -123,16 +281,34 @@ export interface CatalogueSearchParameters {
   /**
    * Optionally filter on dates, as yyyy-MM-dd
    */
-  lastUpdatedAfter?: string;
-  lastUpdatedBefore?: string;
-  createdAfter?: string;
-  createdBefore?: string;
+  lastUpdatedAfter?: Date;
+  lastUpdatedBefore?: Date;
+  createdAfter?: Date;
+  createdBefore?: Date;
 
   /**
    * AND matching on classifiers
    */
   classifiers?: string[];
+
+  /**
+   * Optional DTO containing filters for profiles and metadata search
+   */
+  profileFiltersDto?: CatalogueSearchProfileFilterDto;
 }
+
+export const serializeDate = (date: Date) => {
+  if (!date) {
+    return;
+  }
+
+  // Remember: getMonth() is zero based
+  const yyyy: String = date.getFullYear().toString();
+  const mm: String = (date.getMonth() + 1).toString().padStart(2, '0');
+  const dd: String = date.getDate().toString().padStart(2, '0');
+
+  return `${yyyy}-${mm}-${dd}`;
+};
 
 /**
  * Maps query parameters from a route to a {@link CatalogueSearchParameters} object.
@@ -151,26 +327,30 @@ export const mapStateParamsToSearchParameters = (
   // separate &domainTypes query parameter. If there is exactly one of these parameters, then
   // it comes from the router as a string. If there is more than one then they come as an array.
   // Here we make sure that we always end up with an array.
-  if (typeof query?.domainTypes === 'string') {
-    domainTypes = [query?.domainTypes];
-  } else if (query?.domainTypes instanceof Array) {
-    domainTypes = query?.domainTypes;
+  if (typeof query?.dt === 'string') {
+    domainTypes = [query?.dt];
+  } else if (query?.dt instanceof Array) {
+    domainTypes = query?.dt;
   }
 
-  if (typeof query?.classifiers === 'string') {
-    classifiers = [query?.classifiers];
-  } else if (query?.classifiers instanceof Array) {
-    classifiers = query?.classifiers;
+  if (typeof query?.cls === 'string') {
+    classifiers = [query?.cls];
+  } else if (query?.cls instanceof Array) {
+    classifiers = query?.cls;
   }
 
-  const hasContext = query?.contextDomainType && query?.contextId;
+  const hasContext = query?.cxdt && query?.cxid;
   const context: CatalogueSearchContext = {
-    id: query?.contextId,
-    domainType: query?.contextDomainType,
-    label: query?.contextLabel,
-    parentId: query?.contextParentId,
-    dataModelId: query?.contextDataModelId
+    id: query?.cxid,
+    domainType: query?.cxdt,
+    label: query?.cxl,
+    parentId: query?.cxpid,
+    dataModelId: query?.cxmid
   };
+
+  const profileFilterDto = query?.md
+    ? deserializeProfileFiltersToDto(query.md)
+    : undefined;
 
   return {
     ...(hasContext && { context }),
@@ -180,13 +360,14 @@ export const mapStateParamsToSearchParameters = (
     order: query?.order ?? undefined,
     pageSize: query?.pageSize ?? undefined,
     domainTypes,
-    labelOnly: query?.labelOnly === 'false' ? false : true,
-    exactMatch: query?.exactMatch === 'true' ? true : undefined,
-    lastUpdatedAfter: query?.lastUpdatedAfter ?? undefined,
-    lastUpdatedBefore: query?.lastUpdatedBefore ?? undefined,
-    createdAfter: query?.createdAfter ?? undefined,
-    createdBefore: query?.createdBefore ?? undefined,
-    classifiers
+    labelOnly: query?.l === false ? false : true,
+    exactMatch: query?.e === true ? true : undefined,
+    lastUpdatedAfter: query?.lua ? new Date(query.lua) : undefined,
+    lastUpdatedBefore: query?.lub ? new Date(query.lub) : undefined,
+    createdAfter: query?.ca ? new Date(query.ca) : undefined,
+    createdBefore: query?.cb ? new Date(query.cb) : undefined,
+    classifiers,
+    profileFiltersDto: profileFilterDto
   };
 };
 
@@ -195,37 +376,42 @@ export const mapSearchParametersToRawParams = (
 ): RawParams => {
   return {
     ...(parameters.context?.domainType && {
-      contextDomainType: parameters.context.domainType
+      cxdt: parameters.context.domainType
     }),
-    ...(parameters.context?.id && { contextId: parameters.context.id }),
+    ...(parameters.context?.id && { cxid: parameters.context.id }),
     ...(parameters.context?.parentId && {
-      contextParentId: parameters.context.parentId
+      cxpid: parameters.context.parentId
     }),
     ...(parameters.context?.label && {
-      contextLabel: parameters.context.label
+      cxl: parameters.context.label
     }),
     ...(parameters.context?.dataModelId && {
-      contextDataModelId: parameters.context.dataModelId
+      cxmid: parameters.context.dataModelId
     }),
     ...(parameters.search && { search: parameters.search }),
     ...(parameters.page && { page: parameters.page }),
     ...(parameters.sort && { sort: parameters.sort }),
     ...(parameters.order && { order: parameters.order }),
     ...(parameters.pageSize && { pageSize: parameters.pageSize }),
-    ...(parameters.domainTypes && { domainTypes: parameters.domainTypes }),
-    ...(parameters.labelOnly && { labelOnly: parameters.labelOnly }),
-    ...(parameters.exactMatch && { exactMatch: parameters.exactMatch }),
+    ...(parameters.domainTypes && { dt: parameters.domainTypes }),
+    ...(parameters.labelOnly && { l: parameters.labelOnly }),
+    ...(parameters.exactMatch && { e: parameters.exactMatch }),
     ...(parameters.lastUpdatedAfter && {
-      lastUpdatedAfter: parameters.lastUpdatedAfter
+      lua: serializeDate(parameters.lastUpdatedAfter)
     }),
     ...(parameters.lastUpdatedBefore && {
-      lastUpdatedBefore: parameters.lastUpdatedBefore
+      lub: serializeDate(parameters.lastUpdatedBefore)
     }),
-    ...(parameters.createdAfter && { createdAfter: parameters.createdAfter }),
+    ...(parameters.createdAfter && {
+      ca: serializeDate(parameters.createdAfter)
+    }),
     ...(parameters.createdBefore && {
-      createdBefore: parameters.createdBefore
+      cb: serializeDate(parameters.createdBefore)
     }),
-    ...(parameters.classifiers && { classifiers: parameters.classifiers })
+    ...(parameters.classifiers && { cls: parameters.classifiers }),
+    ...(parameters.profileFiltersDto && {
+      md: serializeProfileFiltersDto(parameters.profileFiltersDto)
+    })
   };
 };
 

--- a/src/app/catalogue-search/search-filters/search-filters.component.ts
+++ b/src/app/catalogue-search/search-filters/search-filters.component.ts
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
+import { MatDatepickerInputEvent } from '@angular/material/datepicker';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldAppearance } from '@angular/material/form-field';
 import { MatSelectChange } from '@angular/material/select';
@@ -134,7 +135,7 @@ export class SearchFiltersComponent implements OnInit {
 
   constructor(
     private resources: MdmResourcesService,
-    public dialog: MatDialog,
+    public dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -191,20 +192,8 @@ export class SearchFiltersComponent implements OnInit {
     this.filterChange.emit({ name: 'exactMatch', value: event.checked });
   }
 
-  onDateChange(name: string, event) {
-    // If date is not null, format as yyyy-MM-dd but ignoring timezone
-    let formatted: String = null;
-
-    if (event.value) {
-      const yyyy: String = event.value.getFullYear().toString();
-      const mm: String = (parseInt(event.value.getMonth(), 10) + 1)
-        .toString()
-        .padStart(2, '0');
-      const dd: String = event.value.getDate().toString().padStart(2, '0');
-
-      formatted = `${yyyy}-${mm}-${dd}`;
-    }
-    this.filterChange.emit({ name, value: formatted });
+  onDateChange(name: string, event: MatDatepickerInputEvent<Date>) {
+    this.filterChange.emit({ name, value: event.value });
   }
 
   onDateClear(name: string) {
@@ -220,19 +209,23 @@ export class SearchFiltersComponent implements OnInit {
   }
 
   openCatalogueItemSelectModal() {
-    this.dialog.open(CatalogueItemSelectModalComponent, { }).afterClosed().subscribe((catalogueItem) => {
-      if (catalogueItem) {
-        // When a Data Class is selected, we also need the Data Model ID, which should be in catalogueItem.modelId
-        this.contextChange.emit(
-          {
+    this.dialog
+      .open(CatalogueItemSelectModalComponent, {})
+      .afterClosed()
+      .subscribe((catalogueItem) => {
+        if (catalogueItem) {
+          // When a Data Class is selected, we also need the Data Model ID, which should be in catalogueItem.modelId
+          this.contextChange.emit({
             domainType: catalogueItem.domainType,
             id: catalogueItem.id,
             label: catalogueItem.label,
             parentId: catalogueItem.parentId ?? null,
-            dataModelId: catalogueItem.domainType === 'DataClass' ? catalogueItem.modelId : null,
-          }
-        );
-      }
-    });
+            dataModelId:
+              catalogueItem.domainType === 'DataClass'
+                ? catalogueItem.modelId
+                : null
+          });
+        }
+      });
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "@mdm/*": ["./app/*"],
       "@env/*": ["./environments/*"]
     },
-    "emitDecoratorMetadata" : true,
+    "emitDecoratorMetadata": true,
     "outDir": "./dist/",
     "sourceMap": true,
     "declaration": false,
@@ -17,16 +17,9 @@
     "importHelpers": true,
     "esModuleInterop": true,
     "target": "es2020",
-    "types": [
-      "jest"
-    ],
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2018",
-      "dom"
-    ]
+    "types": ["jest"],
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2020", "dom"]
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
- Transform filters defined by `mdm-catalogue-search-profile-filter-list` into a serialized DTO
- Pass DTO using query parameters via URL, encoded as a Base 64 string
- DTO is as compact as possible without losing information, so as to not break URL length limits
- Deserialize and transform back the DTO to get the original list state to start the search
- **Note**: this task does not actually perform the search with these filters - see #781

Additional notes:

- Update tsconfig to target ES2020
- Update and add tests to support the new feature
- Change routing query parameters to Search Listing page. Cut down some query parameters in length
- Re-use functions to convert `CatalogueSearchParameters` to UI router state params in Search page
- Refactor date handling for search
  - Move serialisation function out of component into shared types file
  - Serialize/deserialize all dates inside helper functions so code isn't dotted around the place
  - Fixed bug converting Date to string, month value was wrong because it was zero-based
- Fetch only latest profile providers
- Add maximum number of profile filters allowed

To test at the moment - there is no UI to show the profile filters selected in the Search Listing page, so you can either debug `ngOnInit()` of `CatalogueSearchListingComponent` or add a `console.log()` call to output the deserialized state.

Resolves #779 