### PR TITLE
gh-459 - Rows disappear from Enumeration table

### DIFF
--- a/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.html
+++ b/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.html
@@ -76,7 +76,7 @@ SPDX-License-Identifier: Apache-2.0
     [dataSource]="displayItems"
     cdkDropList
     [cdkDropListData]="dataSource"
-    (cdkDropListDropped)="dropTable($event)"
+    (cdkDropListDropped)="handleDrop($event)"
     class="mdm--mat-table table-striped"
   >
     <ng-container matColumnDef="group">

--- a/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.ts
+++ b/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.ts
@@ -246,10 +246,6 @@ export class McEnumerationListWithCategoryComponent
     }
   };
 
-  identify(item) {
-    return item.id;
-  }
-
   // Accepts the array and key
   groupBy = (array, key) => {
     // Return the end result

--- a/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.ts
+++ b/src/app/utility/mc-enumeration-list-with-category/mc-enumeration-list-with-category.component.ts
@@ -135,8 +135,13 @@ export class McEnumerationListWithCategoryComponent
     this.unsubscribe$.complete();
   }
 
-  // Drag and drop
-  dropTable(event: CdkDragDrop<any[]>) {
+  // Handle drag and drop events
+  handleDrop(event: CdkDragDrop<any[]>) {
+    // If the drop event takes place outside of the table, leave the table unchanged.
+    if (!event.isPointerOverContainer) {
+      return;
+    }
+
     const prevIndex = this.displayItems.findIndex(
       (r) => r.id === event.item.data.id
     );


### PR DESCRIPTION
Add additional control flow to handle the case where an item is dropped outside of the table. 
In that scenario, just return the table to it's previous state. 

Additionally, remove unused method and renamed drop event.

Fixes #459 