### PR TITLE
gh-331: avoid graphs to start too close to controls

### DIFF
--- a/src/app/diagram/diagram/diagram.component.ts
+++ b/src/app/diagram/diagram/diagram.component.ts
@@ -58,7 +58,6 @@ export class DiagramComponent implements OnInit {
   isLoading: boolean;
   isPopup = false;
 
-
   initPan: SvgPanZoom.Point;
   initZoom: number;
 
@@ -179,7 +178,9 @@ export class DiagramComponent implements OnInit {
     svg.setAttribute('width', '100%');
     svg.setAttribute('height', '100%');
     svg.querySelector('#svg-pan-zoom-controls').setAttribute('transform', 'translate(0 0) scale(0.75)');
-
+    // Avoid the content being too close to controls
+    this.svgPanZoom.zoomOut();
+    
     if (this.diagramComponent) {
       this.svgPanZoom.zoom(this.diagramComponent.svgPanZoom.getZoom());
       this.svgPanZoom.pan(this.diagramComponent.svgPanZoom.getPan());

--- a/src/app/diagram/diagram/diagram.component.ts
+++ b/src/app/diagram/diagram/diagram.component.ts
@@ -15,13 +15,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import {
-  Component,
-  ElementRef,
-  Input,
-  OnInit,
-  ViewChild,
-} from '@angular/core';
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { MessageHandlerService } from '@mdm/services/utility/message-handler.service';
@@ -34,12 +28,16 @@ import { DataflowDataelementDiagramService } from '../services/dataflow-dataelem
 import { DataflowDatamodelDiagramService } from '../services/dataflow-datamodel-diagram.service';
 import { ModelsMergingDiagramService } from '../services/models-merging-diagram.service';
 import { UmlClassDiagramService } from '../services/umlclass-diagram.service';
-import { DiagramCatalogueItem, DiagramMode, DiagramParameters } from './diagram.model';
+import {
+  DiagramCatalogueItem,
+  DiagramMode,
+  DiagramParameters
+} from './diagram.model';
 
 @Component({
   selector: 'mdm-diagram',
   templateUrl: './diagram.component.html',
-  styleUrls: ['./diagram.component.scss'],
+  styleUrls: ['./diagram.component.scss']
 })
 export class DiagramComponent implements OnInit {
   @Input() mode: DiagramMode;
@@ -79,7 +77,6 @@ export class DiagramComponent implements OnInit {
   }
 
   public ngOnInit(): void {
-
     if (this.diagramComponent) {
       this.diagramService = this.diagramComponent.diagramService;
     } else {
@@ -118,22 +115,27 @@ export class DiagramComponent implements OnInit {
       case 'model-merging-graph':
         this.diagramService = new ModelsMergingDiagramService(
           this.resourcesService,
-          this.messageHandler);
+          this.messageHandler
+        );
         break;
     }
     const observable = this.diagramService.getDiagramContent(params);
-    observable.subscribe((data) => {
+    observable.subscribe(
+      (data) => {
         // The diagram service is responsible for the graph
-      this.diagramService.render(data);
-      if (this.mode === 'model-merging-graph') {
-        // Bottom-to-top layout
-        this.diagramService.layoutNodes('BT');
-      } else {
-        this.diagramService.layoutNodes();
-      }
-    },
+        this.diagramService.render(data);
+        if (this.mode === 'model-merging-graph') {
+          // Bottom-to-top layout
+          this.diagramService.layoutNodes('BT');
+        } else {
+          this.diagramService.layoutNodes();
+        }
+      },
       (error) => {
-        this.messageHandler.showError('There was a problem getting the model hierarchy.', error);
+        this.messageHandler.showError(
+          'There was a problem getting the model hierarchy.',
+          error
+        );
       }
     );
   }
@@ -154,12 +156,12 @@ export class DiagramComponent implements OnInit {
       model: this.diagramService.graph,
       gridSize: 1,
       attributes: {
-        'font-family': '"Nunito Sans", sans-serif',
+        'font-family': '"Nunito Sans", sans-serif'
       } /* ,
       This doesn't yet work with the typescript definition...
       interactive: {
         stopDelegation: false
-      }*/,
+      }*/
     });
 
     this.paper.setInteractivity({ stopDelegation: false });
@@ -170,17 +172,19 @@ export class DiagramComponent implements OnInit {
       dblClickZoomEnabled: false,
       controlIconsEnabled: true,
       center: false,
-      fit: false,
+      fit: false
     };
 
     this.svgPanZoom = SvgPanZoom(svg, options);
     this.svgPanZoom.disablePan();
     svg.setAttribute('width', '100%');
     svg.setAttribute('height', '100%');
-    svg.querySelector('#svg-pan-zoom-controls').setAttribute('transform', 'translate(0 0) scale(0.75)');
+    svg
+      .querySelector('#svg-pan-zoom-controls')
+      .setAttribute('transform', 'translate(0 0) scale(0.75)');
     // Avoid the content being too close to controls
     this.svgPanZoom.zoomOut();
-    
+
     if (this.diagramComponent) {
       this.svgPanZoom.zoom(this.diagramComponent.svgPanZoom.getZoom());
       this.svgPanZoom.pan(this.diagramComponent.svgPanZoom.getPan());
@@ -189,10 +193,13 @@ export class DiagramComponent implements OnInit {
       this.svgPanZoom.enablePan();
     });
 
-    this.paper.on('cell:pointerup blank:pointerup', (cellView: joint.dia.CellView) => {
-      this.svgPanZoom.disablePan();
+    this.paper.on(
+      'cell:pointerup blank:pointerup',
+      (cellView: joint.dia.CellView) => {
+        this.svgPanZoom.disablePan();
         this.diagramService.onDrag(cellView);
-    });
+      }
+    );
 
     this.diagramService.getClickSubject().subscribe((result) => {
       if (result.newMode) {
@@ -210,7 +217,9 @@ export class DiagramComponent implements OnInit {
       }
     });
 
-    this.diagramService.currentComponent.subscribe(data => this.dataClassComponent = data);
+    this.diagramService.currentComponent.subscribe(
+      (data) => (this.dataClassComponent = data)
+    );
   }
 
   download(): void {
@@ -219,7 +228,9 @@ export class DiagramComponent implements OnInit {
     const height = this.diagramService.graph.getBBox().height;
 
     // copy the SVG and configure it
-    const svg: SVGElement = this.jointjsDiv.nativeElement.querySelector('svg').cloneNode(true) as SVGElement;
+    const svg: SVGElement = this.jointjsDiv.nativeElement
+      .querySelector('svg')
+      .cloneNode(true) as SVGElement;
     const panZoomControls = svg.querySelector('g#svg-pan-zoom-controls');
     panZoomControls.remove();
 
@@ -227,7 +238,13 @@ export class DiagramComponent implements OnInit {
     svg.setAttribute('viewBox', `0 0 ${width + 80} ${height + 80}`);
     svg.setAttribute('style', 'font-family: sans-serif;');
     this.jointjsDiv.nativeElement.append(svg);
-    this.downloadService.downloadSVGAsPNG(svg, 'diagram.png', scale, width, height);
+    this.downloadService.downloadSVGAsPNG(
+      svg,
+      'diagram.png',
+      scale,
+      width,
+      height
+    );
     svg.remove();
   }
 
@@ -289,7 +306,9 @@ export class DiagramComponent implements OnInit {
   save = () => {
     switch (this.mode) {
       case 'dataflow-class':
-        this.diagramService.updateDataClassComponentLevel(this.dataClassComponent);
+        this.diagramService.updateDataClassComponentLevel(
+          this.dataClassComponent
+        );
         this.isEdit = false;
         break;
       case 'dataflow-element':


### PR DESCRIPTION
After playing around and reading a lot of documentation about jointjs I have not found a clean good way of setting an offset or padding to the paper. Tried to set origin to different coordinates as their [online example ](https://www.jointjs.com/demos/paper-attributes) seems to suggest that could do the trick. Nothing of what I tried has worked so I ended up with 2 alternatives:
1. Adding a rectangle on the top left to avoid anything else to occupied that space.
2. Start the diagram with lower zoom.

Of those 2 options, I think option 2 is the best. It seems to solve the problem, but please, I'd love to hear any other suggestions.

Fixes #331 