### PR TITLE
gh-624 Track changed state in bulk editor tabs

### DIFF
--- a/src/app/bulk-edit/bulk-edit-container/bulk-edit-container.component.html
+++ b/src/app/bulk-edit/bulk-edit-container/bulk-edit-container.component.html
@@ -35,4 +35,6 @@ SPDX-License-Identifier: Apache-2.0
   [(context)]="context"
   (cancel)="cancel()"
   (previous)="previous()"
+  (changed)="onChanged()"
+  (saved)="onSaved()"
 ></mdm-bulk-edit-editor-group>

--- a/src/app/bulk-edit/bulk-edit-container/bulk-edit-container.component.spec.ts
+++ b/src/app/bulk-edit/bulk-edit-container/bulk-edit-container.component.spec.ts
@@ -19,7 +19,7 @@ import { Title } from '@angular/platform-browser';
 import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
 import { MauroItemProviderService } from '@mdm/mauro/mauro-item-provider.service';
 import { MauroIdentifier, MauroItem } from '@mdm/mauro/mauro-item.types';
-import { MessageHandlerService } from '@mdm/services';
+import { MessageHandlerService, StateHandlerService } from '@mdm/services';
 import { EditingService } from '@mdm/services/editing.service';
 import {
   ComponentHarness,
@@ -40,10 +40,16 @@ interface TitleStub {
 
 interface EditingStub {
   start: jest.Mock;
+  stop: jest.Mock;
+  confirmCancelAsync: jest.Mock;
 }
 
 interface MessageHandlerStub {
   showSuccess: jest.Mock;
+}
+
+interface StateHandlerStub {
+  GoPrevious: jest.Mock;
 }
 
 describe('BulkEditBaseComponent', () => {
@@ -64,11 +70,17 @@ describe('BulkEditBaseComponent', () => {
   };
 
   const editingStub: EditingStub = {
-    start: jest.fn()
+    start: jest.fn(),
+    stop: jest.fn(),
+    confirmCancelAsync: jest.fn()
   };
 
   const messageHandlerStub: MessageHandlerStub = {
     showSuccess: jest.fn()
+  };
+
+  const stateHandlerStub: StateHandlerStub = {
+    GoPrevious: jest.fn()
   };
 
   const id = '123';
@@ -102,6 +114,10 @@ describe('BulkEditBaseComponent', () => {
         {
           provide: MessageHandlerService,
           useValue: messageHandlerStub
+        },
+        {
+          provide: StateHandlerService,
+          useValue: stateHandlerStub
         }
       ]
     });
@@ -111,6 +127,9 @@ describe('BulkEditBaseComponent', () => {
 
   beforeEach(() => {
     itemProviderStub.get.mockImplementationOnce(() => of(dataModel));
+    stateHandlerStub.GoPrevious.mockClear();
+    editingStub.stop.mockClear();
+    editingStub.confirmCancelAsync.mockClear();
   });
 
   it('should create', () => {
@@ -122,20 +141,111 @@ describe('BulkEditBaseComponent', () => {
 
     expect(harness.component.parent).toBe(dataModel);
     expect(harness.component.currentStep).toBe(BulkEditStep.Selection);
+    expect(harness.component.hasChanged).toBe(false);
     expect(titleStub.setTitle).toHaveBeenCalledWith(
       `Bulk Edit - ${dataModel.label}`
     );
     expect(editingStub.start).toHaveBeenCalled();
   });
 
+  it('should mark as changed when changed event emitted', () => {
+    expect(harness.component.hasChanged).toBe(false);
+    harness.component.onChanged();
+    expect(harness.component.hasChanged).toBe(true);
+  });
+
+  it('should mark as not changed when saved event emitted', () => {
+    harness.component.hasChanged = true;
+    expect(harness.component.hasChanged).toBe(true);
+    harness.component.onSaved();
+    expect(harness.component.hasChanged).toBe(false);
+  });
+
   it('should move to next step', () => {
     harness.component.next();
     expect(harness.component.currentStep).toBe(BulkEditStep.Editor);
+    expect(harness.component.hasChanged).toBe(false);
   });
 
-  it('should move to previous step', () => {
+  it('should move to previous step when nothing has changed', () => {
     harness.component.currentStep = BulkEditStep.Editor;
+    harness.component.hasChanged = false;
     harness.component.previous();
     expect(harness.component.currentStep).toBe(BulkEditStep.Selection);
+    expect(harness.component.hasChanged).toBe(false);
+    expect(editingStub.confirmCancelAsync).not.toHaveBeenCalled();
+  });
+
+  it('should confirm to move to previous step when data has changed and accept', () => {
+    harness.component.currentStep = BulkEditStep.Editor;
+    harness.component.hasChanged = true;
+
+    editingStub.confirmCancelAsync.mockImplementationOnce(() => of(true));
+
+    harness.component.previous();
+
+    expect(harness.component.currentStep).toBe(BulkEditStep.Selection);
+    expect(harness.component.hasChanged).toBe(false);
+    expect(editingStub.confirmCancelAsync).toHaveBeenCalled();
+  });
+
+  it('should confirm to move to previous step when data has changed and cancel', () => {
+    harness.component.currentStep = BulkEditStep.Editor;
+    harness.component.hasChanged = true;
+
+    editingStub.confirmCancelAsync.mockImplementationOnce(() => of(false));
+
+    harness.component.previous();
+
+    expect(harness.component.currentStep).toBe(BulkEditStep.Editor);
+    expect(harness.component.hasChanged).toBe(true);
+    expect(editingStub.confirmCancelAsync).toHaveBeenCalled();
+  });
+
+  it('should cancel from selection step', () => {
+    harness.component.currentStep = BulkEditStep.Selection;
+
+    harness.component.cancel();
+
+    expect(editingStub.stop).toHaveBeenCalled();
+    expect(stateHandlerStub.GoPrevious).toHaveBeenCalled();
+    expect(editingStub.confirmCancelAsync).not.toHaveBeenCalled();
+  });
+
+  it('should close from editor step when no changes made', () => {
+    harness.component.currentStep = BulkEditStep.Editor;
+    harness.component.hasChanged = false;
+
+    harness.component.cancel();
+
+    expect(editingStub.stop).toHaveBeenCalled();
+    expect(stateHandlerStub.GoPrevious).toHaveBeenCalled();
+    expect(editingStub.confirmCancelAsync).not.toHaveBeenCalled();
+  });
+
+  it('should close from editor step when changes made and accept', () => {
+    harness.component.currentStep = BulkEditStep.Editor;
+    harness.component.hasChanged = true;
+
+    editingStub.confirmCancelAsync.mockImplementationOnce(() => of(true));
+
+    harness.component.cancel();
+
+    expect(editingStub.stop).toHaveBeenCalled();
+    expect(stateHandlerStub.GoPrevious).toHaveBeenCalled();
+    expect(editingStub.confirmCancelAsync).toHaveBeenCalled();
+  });
+
+  it('should close from editor step when changes made and cancel', () => {
+    harness.component.currentStep = BulkEditStep.Editor;
+    harness.component.hasChanged = true;
+
+    editingStub.confirmCancelAsync.mockImplementationOnce(() => of(false));
+
+    harness.component.cancel();
+
+    expect(editingStub.stop).not.toHaveBeenCalled();
+    expect(stateHandlerStub.GoPrevious).not.toHaveBeenCalled();
+    expect(editingStub.confirmCancelAsync).toHaveBeenCalled();
   });
 });

--- a/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.html
+++ b/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.html
@@ -16,7 +16,12 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div class="mdm-bulk-edit__container-controls">
-  <button mat-stroked-button color="primary" type="button" (click)="onPrevious()">
+  <button
+    mat-stroked-button
+    color="primary"
+    type="button"
+    (click)="onPrevious()"
+  >
     <span class="fas fa-tasks"></span>
     Select items
   </button>
@@ -32,6 +37,8 @@ SPDX-License-Identifier: Apache-2.0
       *ngIf="tab"
       [rootItem]="context.rootItem"
       [(tab)]="tabs[index]"
+      (changed)="onTabChanged($event, tabs[index])"
+      (saved)="onTabSaved(tabs[index])"
     ></mdm-bulk-edit-editor>
   </mat-tab>
 </mat-tab-group>

--- a/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.ts
+++ b/src/app/bulk-edit/bulk-edit-editor-group/bulk-edit-editor-group.component.ts
@@ -28,6 +28,9 @@ export class BulkEditEditorGroupComponent implements OnInit {
   @Output() cancel = new EventEmitter<void>();
   @Output() previous = new EventEmitter<void>();
 
+  @Output() saved = new EventEmitter<any>();
+  @Output() changed = new EventEmitter<any>();
+
   /** Two way binding */
   @Input() context: BulkEditContext;
   @Output() contextChanged = new EventEmitter<BulkEditContext>();
@@ -51,5 +54,16 @@ export class BulkEditEditorGroupComponent implements OnInit {
 
   onPrevious() {
     this.previous.emit();
+  }
+
+  onTabChanged(changes, tab) {
+    this.changed.emit({
+      changes,
+      tab
+    });
+  }
+
+  onTabSaved(tab) {
+    this.saved.emit(tab);
   }
 }

--- a/src/app/bulk-edit/bulk-edit-editor/bulk-edit-editor.component.ts
+++ b/src/app/bulk-edit/bulk-edit-editor/bulk-edit-editor.component.ts
@@ -61,6 +61,9 @@ export class BulkEditEditorComponent implements OnInit {
 
   @Output() backEvent = new EventEmitter<void>();
 
+  @Output() saved = new EventEmitter<void>();
+  @Output() changed = new EventEmitter<any>();
+
   /** Two-way binding */
   @Input() tab: BulkEditProfileContext;
   @Output() tabChanged = new EventEmitter();
@@ -152,6 +155,8 @@ export class BulkEditEditorComponent implements OnInit {
         }
       });
     });
+
+    this.changed.emit(data);
   }
 
   validate() {
@@ -200,6 +205,7 @@ export class BulkEditEditorComponent implements OnInit {
         this.messageHandler.showSuccess(
           `'${this.tab.displayName}' was saved successfully.`
         );
+        this.saved.emit();
       });
   }
 
@@ -254,7 +260,7 @@ export class BulkEditEditorComponent implements OnInit {
   }
 
   private excludeAutoResizeColumns(columnIds) {
-    const pathColKey = 'Path';
+    const pathColKey = 'path';
     const pathId = this.gridColumnApi.getColumn(pathColKey).getColId();
     const pathIndex = columnIds.indexOf(pathId);
     if (pathIndex > -1) {


### PR DESCRIPTION
- Confirm switching panes or closing if values have changed but not been saved
- Also fixed bug with auto sizing columns due to wrong column key used

Resolves #624 

To test:

1. Bulk edit a model
2. Make your item/profile selections to view the editor tabs
3. Try closing or going back a step - both when you've made changes in each tab and when you haven't. A confirmation dialog should appear in the correct scenarios.