### PR TITLE
gh-781 - add profileFilters to searchQuery

### DIFF
--- a/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
+++ b/src/app/catalogue-search/catalogue-search-listing/catalogue-search-listing.component.ts
@@ -101,7 +101,6 @@ export class CatalogueSearchListingComponent implements OnInit {
             });
           }
 
-          // TODO: apply profileFilters (if any) to search endpoint
           return this.catalogueSearch.search(this.parameters);
         }),
         catchError((error) => {


### PR DESCRIPTION
Retrieve profileFilter information prior to firing off catalogue search request. A relatively straightforward transform of the values using an existing utility function that's already well tested hence why I haven't added additional tests. 

This is partnered with this PR: https://github.com/MauroDataMapper/mdm-resources/pull/102
which needs to be merged _before_ the PR checks will pass on this PR. 