### PR TITLE
Fix issue when creating dataTypes

### DIFF
--- a/src/app/data-type/data-type.component.ts
+++ b/src/app/data-type/data-type.component.ts
@@ -26,10 +26,16 @@ import { EditingService } from '@mdm/services/editing.service';
 import {
   ElementTypesService,
   MessageHandlerService,
-  SecurityHandlerService,
+  SecurityHandlerService
 } from '@mdm/services';
 import { DefaultProfileItem } from '@mdm/model/defaultProfileModel';
-import { DataModel, DataType, DataTypeDetail, DataTypeDetailResponse, Uuid } from '@maurodatamapper/mdm-resources';
+import {
+  DataModel,
+  DataType,
+  DataTypeDetail,
+  DataTypeDetailResponse,
+  Uuid
+} from '@maurodatamapper/mdm-resources';
 import { TabCollection } from '@mdm/model/ui.model';
 import { BaseComponent } from '@mdm/shared/base/base.component';
 
@@ -38,7 +44,8 @@ import { BaseComponent } from '@mdm/shared/base/base.component';
   templateUrl: './data-type.component.html',
   styleUrls: ['./data-type.component.scss']
 })
-export class DataTypeComponent extends BaseComponent
+export class DataTypeComponent
+  extends BaseComponent
   implements OnInit, AfterViewInit {
   @ViewChild('tab', { static: false }) tabGroup: MatTabGroup;
 
@@ -84,7 +91,7 @@ export class DataTypeComponent extends BaseComponent
     private messageHandler: MessageHandlerService,
     private securityHandler: SecurityHandlerService,
     private elementTypes: ElementTypesService,
-    private editingService: EditingService,
+    private editingService: EditingService
   ) {
     super();
   }
@@ -97,12 +104,9 @@ export class DataTypeComponent extends BaseComponent
       this.stateHandler.NotFound({ location: false });
       return;
     }
-    this.resources.dataModel.get(this.dataModelId).subscribe(
-      (result) =>
-      {
-        this.dataModel = result.body;
-      }
-    );
+    this.resources.dataModel.get(this.dataModelId).subscribe((result) => {
+      this.dataModel = result.body;
+    });
 
     this.title.setTitle('Data Type');
 

--- a/src/app/data-type/data-type.component.ts
+++ b/src/app/data-type/data-type.component.ts
@@ -54,7 +54,6 @@ export class DataTypeComponent
   dataModel: DataModel;
   id: Uuid;
   activeTab: number;
-  showExtraTabs: boolean;
   showEditForm = false;
 
   loadingData = false;
@@ -133,8 +132,6 @@ export class DataTypeComponent
 
         this.dataType.classifiers = this.dataType.classifiers || [];
         this.loadingData = false;
-        this.showExtraTabs =
-          !this.sharedService.isLoggedIn() || !this.dataType.editable;
       },
       () => {
         this.loadingData = false;

--- a/src/app/data-type/data-type.component.ts
+++ b/src/app/data-type/data-type.component.ts
@@ -20,7 +20,6 @@ import { UIRouterGlobals } from '@uirouter/core';
 import { StateHandlerService } from '../services/handlers/state-handler.service';
 import { Title } from '@angular/platform-browser';
 import { MdmResourcesService } from '@mdm/modules/resources';
-import { SharedService } from '../services/shared.service';
 import { MatTabGroup } from '@angular/material/tabs';
 import { EditingService } from '@mdm/services/editing.service';
 import {
@@ -86,7 +85,6 @@ export class DataTypeComponent
     private uiRouterGlobals: UIRouterGlobals,
     private stateHandler: StateHandlerService,
     private resources: MdmResourcesService,
-    private sharedService: SharedService,
     private messageHandler: MessageHandlerService,
     private securityHandler: SecurityHandlerService,
     private elementTypes: ElementTypesService,

--- a/src/app/dataElement/data-element/data-element.component.ts
+++ b/src/app/dataElement/data-element/data-element.component.ts
@@ -90,17 +90,6 @@ export class DataElementComponent
     'rules',
     'annotations'
   ]);
-  newlyAddedDataType = {
-    label: '',
-    description: '',
-
-    metadata: [],
-    domainType: 'PrimitiveType',
-    enumerationValues: [],
-    classifiers: [],
-    referencedDataClass: '',
-    referencedTerminology: ''
-  };
 
   constructor(
     private resourcesService: MdmResourcesService,

--- a/src/app/dataElement/data-element/data-element.component.ts
+++ b/src/app/dataElement/data-element/data-element.component.ts
@@ -215,20 +215,20 @@ export class DataElementComponent
         resource.minMultiplicity = item.minMultiplicity as number;
         resource.maxMultiplicity = item.maxMultiplicity;
       } else if (item.controlType === ProfileControlTypes.dataType) {
-        const castedValue = item.value as DataType;
+        const dataType = item.value as DataType;
 
         // Backend dataType groups several frontend types into one
         // (i.e. frontend's referenceType and dataModelReferenceType
         // both map to backend's ModelDataType)
         const dataTypeDomainType = this.elementTypes.isModelDataType(
-          castedValue.domainType
+          dataType.domainType
         )
           ? CatalogueItemDomainType.ModelDataType
-          : castedValue.domainType;
+          : dataType.domainType;
 
-        castedValue.domainType = dataTypeDomainType;
+        dataType.domainType = dataTypeDomainType;
 
-        resource.dataType = castedValue;
+        resource.dataType = dataType;
       } else {
         resource[item.propertyName] = item.value;
       }

--- a/src/app/dataElement/data-element/data-element.component.ts
+++ b/src/app/dataElement/data-element/data-element.component.ts
@@ -26,16 +26,18 @@ import { MatTabGroup } from '@angular/material/tabs';
 import { Title } from '@angular/platform-browser';
 import { EditingService } from '@mdm/services/editing.service';
 import {
+  ElementTypesService,
   GridService,
   MessageHandlerService,
   SecurityHandlerService
 } from '@mdm/services';
 import { McSelectPagination } from '@mdm/utility/mc-select/mc-select.component';
 import {
+  CatalogueItemDomainType,
   DataElement,
   DataElementDetail,
   DataElementDetailResponse,
-  DataTypeReference
+  DataType
 } from '@maurodatamapper/mdm-resources';
 import {
   DefaultProfileItem,
@@ -101,7 +103,8 @@ export class DataElementComponent
     private gridService: GridService,
     private title: Title,
     private securityHandler: SecurityHandlerService,
-    private editingService: EditingService
+    private editingService: EditingService,
+    private elementTypes: ElementTypesService
   ) {
     super();
     if (
@@ -136,7 +139,9 @@ export class DataElementComponent
   }
 
   ngOnInit() {
-    this.activeTab = this.tabs.getByName(this.uiRouterGlobals.params.tabView as string).index;
+    this.activeTab = this.tabs.getByName(
+      this.uiRouterGlobals.params.tabView as string
+    ).index;
     this.tabSelected(this.activeTab);
 
     this.showExtraTabs = this.sharedService.isLoggedIn();
@@ -210,7 +215,20 @@ export class DataElementComponent
         resource.minMultiplicity = item.minMultiplicity as number;
         resource.maxMultiplicity = item.maxMultiplicity;
       } else if (item.controlType === ProfileControlTypes.dataType) {
-        resource.dataType = item.value as DataTypeReference;
+        let castedValue = item.value as DataType;
+
+        // Backend dataType groups several frontend types into one
+        // (i.e. frontend's referenceType and dataModelReferenceType
+        // both map to backend's ModelDataType)
+        const dataTypeDomainType = this.elementTypes.isModelDataType(
+          castedValue.domainType
+        )
+          ? CatalogueItemDomainType.ModelDataType
+          : castedValue.domainType;
+
+        castedValue.domainType = dataTypeDomainType;
+
+        resource.dataType = castedValue;
       } else {
         resource[item.propertyName] = item.value;
       }

--- a/src/app/dataElement/data-element/data-element.component.ts
+++ b/src/app/dataElement/data-element/data-element.component.ts
@@ -215,7 +215,7 @@ export class DataElementComponent
         resource.minMultiplicity = item.minMultiplicity as number;
         resource.maxMultiplicity = item.maxMultiplicity;
       } else if (item.controlType === ProfileControlTypes.dataType) {
-        let castedValue = item.value as DataType;
+        const castedValue = item.value as DataType;
 
         // Backend dataType groups several frontend types into one
         // (i.e. frontend's referenceType and dataModelReferenceType

--- a/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.html
+++ b/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.html
@@ -41,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
             *ngIf="item.controlType === profileControlType.text"
             matInput
             type="text"
-            name="{item.displayName}}"
+            name="{{item.displayName}}"
             [(ngModel)]="item.value"
             value="item.value"
             class="outlined-input form-control"
@@ -121,6 +121,7 @@ SPDX-License-Identifier: Apache-2.0
                   [parentDataModel]="data.parentCatalogueItem"
                   [showClassification]="false"
                   [showParentDataModel]="false"
+                  [showLabelAndDescription]="true"
                 >
                 </mdm-data-type-inline>
               </div>

--- a/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.html
+++ b/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.html
@@ -26,11 +26,11 @@ SPDX-License-Identifier: Apache-2.0
         </td>
         <td [attr.data-cy]="item.propertyName">
           <mdm-element-alias
-          *ngIf="item.controlType === profileControlType.aliases"
-          [aliases]="item.value"
-          [readOnly]="false"
-        >
-        </mdm-element-alias>
+            *ngIf="item.controlType === profileControlType.aliases"
+            [aliases]="item.value"
+            [readOnly]="false"
+          >
+          </mdm-element-alias>
           <mdm-content-editor
             *ngIf="item.controlType === profileControlType.html"
             [(content)]="item.value"
@@ -41,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
             *ngIf="item.controlType === profileControlType.text"
             matInput
             type="text"
-            name="{{item.displayName}}"
+            name="{{ item.displayName }}"
             [(ngModel)]="item.value"
             value="item.value"
             class="outlined-input form-control"
@@ -92,91 +92,91 @@ SPDX-License-Identifier: Apache-2.0
             </div>
           </div>
 
-            <div  *ngIf="item.controlType === profileControlType.dataType">
-              <div *ngIf="!showNewInlineDataType">
-                Please select a Data Type below or
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  (click)="toggleShowNewInlineDataType(item)"
-                >
-                  Add a new Data Type
-                </button>
-              </div>
-              <div *ngIf="showNewInlineDataType">
-                Please
-                <button
-                  mat-stroked-button
-                  color="primary"
-                  (click)="toggleShowNewInlineDataType(item)"
-                >
-                  select a Data Type
-                </button>
-                or Add a new Data Type by completing the form below:
-              </div>
-
-              <div *ngIf="showNewInlineDataType">
-                <mdm-data-type-inline
-                  [model]="item.value"
-                  [parentDataModel]="data.parentCatalogueItem"
-                  [showClassification]="false"
-                  [showParentDataModel]="false"
-                  [showLabelAndDescription]="true"
-                >
-                </mdm-data-type-inline>
-              </div>
-              <div *ngIf="!showNewInlineDataType">
-                <mdm-select
-                  [width]="'100%'"
-                  [acceptTypedInput]="true"
-                  [valueType]="'dynamic'"
-                  [defaultValue]="item.value"
-                  [hasError]="dataTypeErrors"
-                  [loadDynamicValues]="fetchDataTypes"
-                  [loadAllOnClick]="true"
-                  [minInputLength]="1"
-                  [idProperty]="'id'"
-                  [pagination]="pagination"
-                  [displayProperty]="'label'"
-                  [searchProperty]="'label'"
-                  (selectEvent)="onDataTypeSelect($event[0], item)"
-                >
-                  <ng-template
-                    #lineContent
-                    let-item="item"
-                    let-searchTerm="inputText"
-                  >
-                    <div
-                      [innerHTML]="item.label | mchighlighter: searchTerm"
-                    ></div>
-                    <div>
-                      <mdm-element-link
-                        [element]="item"
-                        [showTypeTitle]="true"
-                        [showLink]="false"
-                      ></mdm-element-link>
-                      <mdm-element-link
-                        [element]="item"
-                        [showTypeTitle]="true"
-                        [showLink]="false"
-                      >
-                      </mdm-element-link>
-                    </div>
-                  </ng-template>
-                </mdm-select>
-              </div>
-              <span class="help-block errorMessage" *ngIf="dataTypeErrors"
-                ><small>{{ dataTypeErrors }}</small></span
+          <div *ngIf="item.controlType === profileControlType.dataType">
+            <div *ngIf="!showNewInlineDataType">
+              Please select a Data Type below or
+              <button
+                mat-stroked-button
+                color="primary"
+                (click)="toggleShowNewInlineDataType(item)"
               >
-
+                Add a new Data Type
+              </button>
             </div>
-            <mdm-element-classifications
+            <div *ngIf="showNewInlineDataType">
+              Please
+              <button
+                mat-stroked-button
+                color="primary"
+                (click)="toggleShowNewInlineDataType(item)"
+              >
+                select a Data Type
+              </button>
+              or Add a new Data Type by completing the form below:
+            </div>
+
+            <div *ngIf="showNewInlineDataType">
+              <mdm-data-type-inline
+                [model]="item.value"
+                [parentDataModel]="data.parentCatalogueItem"
+                [showClassification]="false"
+                [showParentDataModel]="false"
+                [showLabelAndDescription]="true"
+                (validationStatusEvent)="validationStatusEventHandler($event)"
+              >
+              </mdm-data-type-inline>
+            </div>
+            <div *ngIf="!showNewInlineDataType">
+              <mdm-select
+                [width]="'100%'"
+                [acceptTypedInput]="true"
+                [valueType]="'dynamic'"
+                [defaultValue]="item.value"
+                [hasError]="dataTypeErrors"
+                [loadDynamicValues]="fetchDataTypes"
+                [loadAllOnClick]="true"
+                [minInputLength]="1"
+                [idProperty]="'id'"
+                [pagination]="pagination"
+                [displayProperty]="'label'"
+                [searchProperty]="'label'"
+                (selectEvent)="onDataTypeSelect($event[0], item)"
+              >
+                <ng-template
+                  #lineContent
+                  let-item="item"
+                  let-searchTerm="inputText"
+                >
+                  <div
+                    [innerHTML]="item.label | mchighlighter: searchTerm"
+                  ></div>
+                  <div>
+                    <mdm-element-link
+                      [element]="item"
+                      [showTypeTitle]="true"
+                      [showLink]="false"
+                    ></mdm-element-link>
+                    <mdm-element-link
+                      [element]="item"
+                      [showTypeTitle]="true"
+                      [showLink]="false"
+                    >
+                    </mdm-element-link>
+                  </div>
+                </ng-template>
+              </mdm-select>
+            </div>
+            <span class="help-block errorMessage" *ngIf="dataTypeErrors"
+              ><small>{{ dataTypeErrors }}</small></span
+            >
+          </div>
+          <mdm-element-classifications
             *ngIf="item.controlType === profileControlType.classifications"
             [readOnly]="false"
             [(classifications)]="item.value"
             name="classifiers"
             [property]="'classifiers'"
-            (classificationsChanged)="classificationChanged($event,item)"
+            (classificationsChanged)="classificationChanged($event, item)"
           >
           </mdm-element-classifications>
         </td>

--- a/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.ts
+++ b/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.ts
@@ -20,7 +20,10 @@ SPDX-License-Identifier: Apache-2.0
 
 import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { CatalogueItemDomainType } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  DataType
+} from '@maurodatamapper/mdm-resources';
 import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 import {
   DefaultProfileModalConfiguration,
@@ -57,6 +60,8 @@ export class DefaultProfileEditorModalComponent implements OnInit {
     protected editing: EditingService
   ) {}
 
+  newDataTypeHasErrors = false;
+
   ngOnInit(): void {}
 
   save() {
@@ -77,7 +82,7 @@ export class DefaultProfileEditorModalComponent implements OnInit {
           hasError = true;
         }
       } else if (item.controlType === ProfileControlTypes.dataType) {
-        hasError = !this.validateDataType(item);
+        hasError = this.newDataTypeHasErrors;
       }
     });
 
@@ -99,48 +104,6 @@ export class DefaultProfileEditorModalComponent implements OnInit {
 
   public get profileControlType(): typeof ProfileControlTypes {
     return ProfileControlTypes;
-  }
-
-  validateDataType(item: any) {
-    let isValid = true;
-
-    if (!this.showNewInlineDataType) {
-      return true;
-    }
-    if (!item.value.label || item.value.label.trim().length === 0) {
-      isValid = false;
-    }
-    // Check if for EnumerationType, at least one value is added
-    if (
-      item.value.domainType === CatalogueItemDomainType.EnumerationType &&
-      item.value.enumerationValues.length === 0
-    ) {
-      isValid = false;
-    }
-    // Check if for ReferenceType, the dataClass is selected
-    if (
-      item.value.domainType === CatalogueItemDomainType.ReferenceType &&
-      !item.value.referencedDataClass
-    ) {
-      isValid = false;
-    }
-
-    // Check if for TerminologyType, the terminology is selected
-    if (
-      item.value.domainType === CatalogueItemDomainType.TerminologyType &&
-      !item.value.referencedTerminology
-    ) {
-      isValid = false;
-    }
-
-    if (!isValid) {
-      this.dataTypeErrors = '';
-      this.dataTypeErrors =
-        'Please fill in all required values for the new Data Type';
-      return false;
-    } else {
-      return true;
-    }
   }
 
   fetchDataTypes = (text, loadAll, offset, limit) => {
@@ -169,21 +132,26 @@ export class DefaultProfileEditorModalComponent implements OnInit {
     this.showNewInlineDataType = !this.showNewInlineDataType;
     this.dataTypeErrors = '';
     if (this.showNewInlineDataType) {
-       const newDT = {
+      const newDT: DataType = {
         label: item.value.label,
         description: '',
         metadata: [],
         domainType: CatalogueItemDomainType.PrimitiveType,
-        enumerationValues: [],
-        classifiers: [],
-        organisation: '',
-        referencedTerminology: {id : ''},
-        referencedDataType: { id: '' },
-        referencedDataClass: { id: '' },
-        referencedModel: { id: '', domainType: '' }
+        classifiers: []
       };
 
       item.value = newDT;
+    }
+  }
+
+  validationStatusEventHandler(value: string) {
+    const hasErrors = value === 'true' ? true : false;
+    this.newDataTypeHasErrors = hasErrors;
+
+    if (this.newDataTypeHasErrors) {
+      this.dataTypeErrors = '';
+      this.dataTypeErrors =
+        'Please fill in all required values for the new Data Type';
     }
   }
 

--- a/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.ts
+++ b/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.ts
@@ -135,7 +135,6 @@ export class DefaultProfileEditorModalComponent implements OnInit {
       const newDT: DataType = {
         label: item.value.label,
         description: '',
-        metadata: [],
         domainType: CatalogueItemDomainType.PrimitiveType,
         classifiers: []
       };

--- a/src/app/shared/element-data-type/element-data-type.component.html
+++ b/src/app/shared/element-data-type/element-data-type.component.html
@@ -17,17 +17,36 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <div>
   <span *ngIf="elementDataType.domainType == 'PrimitiveType'">
-    <a class="dataTypePrimitive" href="{{link}}" [hidden]="hideName"><span [innerHtml]="elementDataType.label"></span></a><span class="dataTypeLabel dataTypePrimitive" [hidden]="hideName">(Primitive)</span>
+    <a class="dataTypePrimitive" href="{{ link }}" [hidden]="hideName"
+      ><span [innerHtml]="elementDataType.label"></span></a
+    ><span class="dataTypeLabel dataTypePrimitive" [hidden]="hideName"
+      >(Primitive)</span
+    >
   </span>
   <span *ngIf="elementDataType.domainType == 'EnumerationType'">
-    <a class="dataTypeEnumeration" href="{{link}}" [hidden]="hideName">{{elementDataType.label}}</a>
-    <span class="dataTypeLabel dataTypeEnumeration" [hidden]="hideName">(Enumeration)</span>
-    <span *ngIf="!hideEnumList" class="enumCaretShow" style="margin-right: 2px;cursor: pointer; width:40px;" (click)="showEnums()" matTooltip="Show Enumerations">
+    <a class="dataTypeEnumeration" href="{{ link }}" [hidden]="hideName">{{
+      elementDataType.label
+    }}</a>
+    <span class="dataTypeLabel dataTypeEnumeration" [hidden]="hideName"
+      >(Enumeration)</span
+    >
+    <span
+      *ngIf="!hideEnumList"
+      class="enumCaretShow"
+      style="margin-right: 2px; cursor: pointer; width: 40px"
+      (click)="showEnums()"
+      matTooltip="Show Enumerations"
+    >
       <span class="fas fa-caret-down fa-xs"></span>
       &nbsp;&nbsp;&nbsp;
     </span>
 
-    <table class="table enumerationKeyValueTable" *ngIf="elementDataType.enumerationValues && !hideEnumList && toggleShowEnums">
+    <table
+      class="table enumerationKeyValueTable"
+      *ngIf="
+        elementDataType.enumerationValues && !hideEnumList && toggleShowEnums
+      "
+    >
       <thead>
         <tr>
           <th *ngIf="hasCategory" scope="col">Group</th>
@@ -36,29 +55,78 @@ SPDX-License-Identifier: Apache-2.0
         </tr>
       </thead>
       <tbody>
-        <ng-container *ngFor="let record of allRecordsWithGroups; let i = index">
-          <tr *ngIf="!record.isCategoryRow || (record.isCategoryRow && hasCategory)" [ngClass]="{'moreEnumerationKeyValue': i >= showCount,'hiddenMoreEnumerationKeyValue': i >= showCount}">
-            <td class="full-width" *ngIf="hasCategory && record.isCategoryRow" [attr.colspan]="(hasCategory && record.isCategoryRow) ? 3 : 1">
-              <div *ngIf="record.isCategoryRow" style="font-weight: bold; font-style: italic;">
-                {{record.category}}
+        <ng-container
+          *ngFor="let record of allRecordsWithGroups; let i = index"
+        >
+          <tr
+            *ngIf="
+              !record.isCategoryRow || (record.isCategoryRow && hasCategory)
+            "
+            [ngClass]="{
+              moreEnumerationKeyValue: i >= showCount,
+              hiddenMoreEnumerationKeyValue: i >= showCount
+            }"
+          >
+            <td
+              class="full-width"
+              *ngIf="hasCategory && record.isCategoryRow"
+              [attr.colspan]="hasCategory && record.isCategoryRow ? 3 : 1"
+            >
+              <div
+                *ngIf="record.isCategoryRow"
+                style="font-weight: bold; font-style: italic"
+              >
+                {{ record.category }}
               </div>
               <div *ngIf="!record.category">&nbsp;</div>
             </td>
-            <td *ngIf="hasCategory && !record.isCategoryRow" style="width: 15%"></td>
-            <td style="width: 30%; word-break: break-all;" class="enumerationKey" *ngIf="!record.isCategoryRow">
+            <td
+              *ngIf="hasCategory && !record.isCategoryRow"
+              style="width: 15%"
+            ></td>
+            <td
+              style="width: 30%; word-break: break-all"
+              class="enumerationKey"
+              *ngIf="!record.isCategoryRow"
+            >
               <div *ngIf="!record.isCategoryRow">
-                <span style="margin: 0px !important; width: 100%; padding-left: 2px; word-wrap: break-word; white-space: normal; max-width: 100px; min-width: 50px;" [innerHtml]="record.key"></span>
+                <span
+                  style="
+                    margin: 0px !important;
+                    width: 100%;
+                    padding-left: 2px;
+                    word-wrap: break-word;
+                    white-space: normal;
+                    max-width: 100px;
+                    min-width: 50px;
+                  "
+                  [innerHtml]="record.key"
+                ></span>
               </div>
             </td>
-            <td style="width: 40%; word-break: break-all;" class="enumerationValue" *ngIf="!record.isCategoryRow">
-              <span style="word-wrap: break-word; white-space: normal; display: block; max-width: 400px;" [innerHtml]="record.value ">
+            <td
+              style="width: 40%; word-break: break-all"
+              class="enumerationValue"
+              *ngIf="!record.isCategoryRow"
+            >
+              <span
+                style="
+                  word-wrap: break-word;
+                  white-space: normal;
+                  display: block;
+                  max-width: 400px;
+                "
+                [innerHtml]="record.value"
+              >
               </span>
             </td>
           </tr>
         </ng-container>
-        <tr *ngIf="showMoreIcon" style="list-style: none;">
+        <tr *ngIf="showMoreIcon" style="list-style: none">
           <td [attr.colspan]="hasCategory ? 3 : 2">
-            <a class="showMoreEnumerations" (click)="showMore($event.target)">... more <span class="fas fa-caret-down fa-xs"></span></a>
+            <a class="showMoreEnumerations" (click)="showMore($event.target)"
+              >... more <span class="fas fa-caret-down fa-xs"></span
+            ></a>
           </td>
         </tr>
       </tbody>
@@ -66,13 +134,26 @@ SPDX-License-Identifier: Apache-2.0
   </span>
   <span *ngIf="elementDataType.domainType == 'ReferenceType'">
     <span *ngIf="!onlyShowRefDataClass">
-      <div><a href="{{link}}">{{elementDataType.label}}</a><span class="dataTypeLabel dataTypeEnumeration">(Reference)</span></div>
-      <div *ngIf="referenceClass"><span style="font-size: 13px;">[<span style="font-style: italic">ref:&nbsp;</span>
-          <mdm-element-link [element]="elementDataType.referenceClass" [newWindow]="newWindow"></mdm-element-link>]
-        </span></div>
+      <div>
+        <a href="{{ link }}">{{ elementDataType.label }}</a
+        ><span class="dataTypeLabel dataTypeEnumeration">(Reference)</span>
+      </div>
+      <div *ngIf="referenceClass">
+        <span style="font-size: 13px"
+          >[<span style="font-style: italic">ref:&nbsp;</span>
+          <mdm-element-link
+            [element]="elementDataType.referenceClass"
+            [newWindow]="newWindow"
+          ></mdm-element-link
+          >]
+        </span>
+      </div>
     </span>
     <span *ngIf="onlyShowRefDataClass">
-      <mdm-element-link [element]="elementDataType.referenceClass" [newWindow]="newWindow"></mdm-element-link>
+      <mdm-element-link
+        [element]="elementDataType.referenceClass"
+        [newWindow]="newWindow"
+      ></mdm-element-link>
     </span>
   </span>
   <span *ngIf="elementDataType.domainType == 'TerminologyType'">
@@ -88,11 +169,19 @@ SPDX-License-Identifier: Apache-2.0
   </span>
   <span *ngIf="elementDataType.domainType == 'ModelDataType'">
     <div>
-      <a href="{{link}}">{{elementDataType.label}}</a><span class="dataTypeLabel dataTypeEnumeration">({{elementDataType.modelResourceDomainType}})</span>
+      <a href="{{ link }}">{{ elementDataType.label }}</a
+      ><span class="dataTypeLabel dataTypeEnumeration"
+        >({{ elementDataType.modelResourceDomainType }})</span
+      >
     </div>
     <div *ngIf="modelResource">
-      <span style="font-size: 13px;">[<span style="font-style: italic">ref:&nbsp;</span>
-        <mdm-element-link [element]="modelResource" [newWindow]="newWindow"></mdm-element-link>]
+      <span style="font-size: 13px"
+        >[<span style="font-style: italic">ref:&nbsp;</span>
+        <mdm-element-link
+          [element]="modelResource"
+          [newWindow]="newWindow"
+        ></mdm-element-link
+        >]
       </span>
     </div>
   </span>

--- a/src/app/shared/element-data-type/element-data-type.component.html
+++ b/src/app/shared/element-data-type/element-data-type.component.html
@@ -158,13 +158,26 @@ SPDX-License-Identifier: Apache-2.0
   </span>
   <span *ngIf="elementDataType.domainType == 'TerminologyType'">
     <span *ngIf="!onlyShowRefDataClass">
-      <div><a href="{{link}}">{{elementDataType.label}}</a><span class="dataTypeLabel dataTypeEnumeration">(Terminology)</span></div>
-      <div *ngIf="referenceClass"><span style="font-size: 13px;">[<span style="font-style: italic">ref:&nbsp;</span>
-          <mdm-element-link [element]="elementDataType.terminology" [newWindow]="newWindow"></mdm-element-link>]
-        </span></div>
+      <div>
+        <a href="{{ link }}">{{ elementDataType.label }}</a
+        ><span class="dataTypeLabel dataTypeEnumeration">(Terminology)</span>
+      </div>
+      <div *ngIf="referenceClass">
+        <span style="font-size: 13px"
+          >[<span style="font-style: italic">ref:&nbsp;</span>
+          <mdm-element-link
+            [element]="elementDataType.modelResourceId"
+            [newWindow]="newWindow"
+          ></mdm-element-link
+          >]
+        </span>
+      </div>
     </span>
     <span *ngIf="onlyShowRefDataClass">
-      <mdm-element-link [element]="elementDataType.terminology" [newWindow]="newWindow"></mdm-element-link>
+      <mdm-element-link
+        [element]="elementDataType.modelResourceId"
+        [newWindow]="newWindow"
+      ></mdm-element-link>
     </span>
   </span>
   <span *ngIf="elementDataType.domainType == 'ModelDataType'">

--- a/src/app/utility/new-data-type-inline/new-data-type-inline.component.html
+++ b/src/app/utility/new-data-type-inline/new-data-type-inline.component.html
@@ -87,7 +87,7 @@ SPDX-License-Identifier: Apache-2.0
               <div
                 *ngIf="
                   model.domainType === 'Terminology' &&
-                  !model.referencedTerminology &&
+                  !model.modelResourceId &&
                   !terminologies
                 "
               >

--- a/src/app/utility/new-data-type-inline/new-data-type-inline.component.html
+++ b/src/app/utility/new-data-type-inline/new-data-type-inline.component.html
@@ -78,8 +78,7 @@ SPDX-License-Identifier: Apache-2.0
             >
               <div
                 *ngIf="
-                  model.domainType === 'ReferenceType' &&
-                  !model.referencedDataClass
+                  model.domainType === 'ReferenceType' && !model.referenceClass
                 "
               >
                 Please select the reference DataClass.
@@ -98,8 +97,7 @@ SPDX-License-Identifier: Apache-2.0
 
               <div
                 *ngIf="
-                  model.domainType === 'ReferenceType' &&
-                  !model.referencedDataClass
+                  model.domainType === 'ReferenceType' && !model.referenceClass
                 "
               >
                 The DataModel does not have any DataClass, so you can not define
@@ -109,7 +107,8 @@ SPDX-License-Identifier: Apache-2.0
               <div
                 *ngIf="
                   model.domainType === 'EnumerationType' &&
-                  model.enumerationValues == 0
+                  (!model.enumerationValues ||
+                    model.enumerationValues.length == 0)
                 "
               >
                 At least one enumeration key/value should be added.
@@ -159,8 +158,7 @@ SPDX-License-Identifier: Apache-2.0
             </div>
             <div
               *ngIf="
-                model.domainType === 'ReferenceDataModelType' &&
-                referenceDataModels
+                model.domainType === 'ReferenceDataModelType' && dataModels
               "
             >
               <mdm-select
@@ -168,7 +166,7 @@ SPDX-License-Identifier: Apache-2.0
                 name="newDataTypeSelect"
                 [acceptTypedInput]="false"
                 [valueType]="'static'"
-                [staticValues]="referenceDataModels"
+                [staticValues]="dataModels"
                 [minInputLength]="1"
                 [hasError]="false"
                 [idProperty]="'id'"
@@ -185,7 +183,7 @@ SPDX-License-Identifier: Apache-2.0
               <mdm-model-selector-tree
                 name="newDataTypeClassSelect"
                 (ngModelChange)="onDataClassSelect($event)"
-                [defaultElements]="model.referencedDataClass"
+                [defaultElements]="model.referenceClass"
                 [root]="parentDataModel"
                 [placeholder]="'Select Data Class'"
                 [readOnlySearchInput]="true"

--- a/src/app/utility/new-data-type-inline/new-data-type-inline.component.ts
+++ b/src/app/utility/new-data-type-inline/new-data-type-inline.component.ts
@@ -15,19 +15,38 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import {Component, OnInit, Input, Output, EventEmitter, ViewChild, AfterViewInit, OnDestroy} from '@angular/core';
+import {
+  Component,
+  OnInit,
+  Input,
+  Output,
+  EventEmitter,
+  ViewChild,
+  AfterViewInit,
+  OnDestroy
+} from '@angular/core';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { ElementTypesService } from '@mdm/services/element-types.service';
 import { NgForm } from '@angular/forms';
 import { Subscription } from 'rxjs';
-import { CodeSet, CodeSetIndexResponse, ReferenceDataModel, ReferenceDataModelIndexResponse, Terminology, TerminologyIndexResponse } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  CodeSet,
+  CodeSetIndexResponse,
+  DataType,
+  ReferenceDataModel,
+  ReferenceDataModelIndexResponse,
+  Terminology,
+  TerminologyIndexResponse
+} from '@maurodatamapper/mdm-resources';
 
 @Component({
   selector: 'mdm-data-type-inline',
   templateUrl: './new-data-type-inline.component.html',
   styleUrls: ['./new-data-type-inline.component.sass']
 })
-export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDestroy {
+export class NewDataTypeInlineComponent
+  implements OnInit, AfterViewInit, OnDestroy {
   @Output() validationStatusEvent = new EventEmitter<string>();
 
   @Input() parentDataModel;
@@ -36,12 +55,17 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDest
   @Input() showLabelAndDescription = false;
 
   @ViewChild('myFormNewDataType', { static: false }) myFormNewDataType: NgForm;
-  @Input() model: any = {
+  @Input() model: DataType = {
     label: '',
     description: '',
-    domainType: '',
-    referencedDataClass: '',
-    referencedTerminology: ''
+    domainType: CatalogueItemDomainType.PrimitiveType,
+    model: '',
+    breadcrumbs: [],
+    classifiers: [],
+    modelResourceId: '',
+    modelResourceDomainType: null,
+    enumerationValues: [],
+    referenceClass: null
   };
 
   @Input() parentScopeHandler;
@@ -51,7 +75,7 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDest
   reloading = false;
   terminologies: Terminology[];
   codesets: CodeSet[];
-  referenceDataModels: ReferenceDataModel[];
+  dataModels: ReferenceDataModel[];
   @Input() advanced = false;
 
   constructor(
@@ -59,12 +83,16 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDest
     private elementTypes: ElementTypesService
   ) {
     this.allDataTypes = this.elementTypes.getAllDataTypesArray();
-    if (this.allDataTypes) { this.model.domainType = this.allDataTypes[0]; }
+    if (this.allDataTypes) {
+      this.model.domainType = this.allDataTypes[0];
+    }
     this.loadTerminologies();
     this.loadCodeSets();
     this.loadReferenceModels();
   }
 
+  // Sending the negation of isValid because
+  // parent component want to know if error is present
   sendValidationStatus() {
     this.validationStatusEvent.emit(String(!this.isValid));
   }
@@ -81,15 +109,24 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDest
 
   ngAfterViewInit() {
     this.formDataTypeChangesSubscription = this.myFormNewDataType.form.valueChanges.subscribe(
-      x => {
+      (x) => {
         this.validate(x);
       }
     );
   }
 
   onTypeSelect() {
-    if (this.model.domainType !== 'TerminologyType' && this.model.referencedTerminology) {
-      this.model.referencedTerminology.id = '';
+    if (
+      this.model.domainType !== CatalogueItemDomainType.EnumerationType &&
+      this.model.enumerationValues &&
+      this.model.enumerationValues.length > 0
+    ) {
+      this.model.enumerationValues = [];
+    } else if (
+      this.model.domainType !== CatalogueItemDomainType.ReferenceType &&
+      this.model.referenceClass
+    ) {
+      this.model.referenceClass = null;
     }
     this.advanced = false;
     this.validate();
@@ -100,39 +137,61 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDest
       this.model.label = newValue.label;
       this.model.domainType = newValue.dataModelType;
     }
-    if ((!this.model.label || this.model.label.trim().length === 0) &&
-      (this.model.domainType === 'PrimitiveType' || this.model.domainType === 'EnumerationType')) {
+
+    if (
+      (!this.model.label || this.model.label.trim().length === 0) &&
+      (this.model.domainType === CatalogueItemDomainType.PrimitiveType ||
+        this.model.domainType === CatalogueItemDomainType.EnumerationType)
+    ) {
       isValid = false;
     }
     // Check if for EnumerationType, at least one value is added
-    if (this.model.domainType === 'EnumerationType' && this.model.enumerationValues.length === 0) {
+    if (
+      this.model.domainType === CatalogueItemDomainType.EnumerationType &&
+      (!this.model.enumerationValues ||
+        this.model.enumerationValues.length === 0)
+    ) {
       isValid = false;
     }
     // Check if for ReferenceType, the dataClass is selected
-    if (this.model.domainType === 'ReferenceType' && (!this.model.referencedDataClass || this.model.referencedDataClass.id === '')) {
+    if (
+      this.model.domainType === CatalogueItemDomainType.ReferenceType &&
+      (!this.model.referenceClass || this.model.referenceClass.id === '')
+    ) {
       isValid = false;
     }
     // Check if for TerminologyType, the terminology is selected
-    if (this.model.domainType === 'TerminologyType' && (!this.model.referencedModel || this.model.referencedModel.id === '')) {
+    if (
+      this.model.domainType === CatalogueItemDomainType.TerminologyType &&
+      !this.model.modelResourceId
+    ) {
       isValid = false;
     }
 
-    if (this.model.domainType === 'CodeSetType' && (!this.model.referencedModel || this.model.referencedModel.id === '')) {
+    if (
+      this.model.domainType === CatalogueItemDomainType.CodeSet &&
+      !this.model.modelResourceId
+    ) {
       isValid = false;
     }
 
-    if (this.model.domainType === 'ReferenceDataModelType' && (!this.model.referencedModel || this.model.referencedModel.id === '')) {
+    if (
+      this.model.domainType ===
+        CatalogueItemDomainType.ReferenceDataModelType &&
+      !this.model.modelResourceId
+    ) {
       isValid = false;
     }
+
     this.isValid = isValid;
     this.sendValidationStatus();
   }
 
-  onDataClassSelect = dataClasses => {
+  onDataClassSelect = (dataClasses) => {
     if (dataClasses && dataClasses.length > 0) {
-      this.model.referencedDataClass = dataClasses[0];
+      this.model.referenceClass = dataClasses[0];
     } else {
-      this.model.referencedDataClass = null;
+      this.model.referenceClass = null;
     }
 
     this.validate();
@@ -141,48 +200,58 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDest
 
   loadTerminologies() {
     this.reloading = true;
-    this.resourceService.terminology.list({ all: true }).subscribe((data: TerminologyIndexResponse) => {
-      this.terminologies = data.body.items.sort((a, b) => a.label.localeCompare(b.label));
-      this.reloading = false;
-    }, () => {
-      this.reloading = false;
-    });
+    this.resourceService.terminology.list({ all: true }).subscribe(
+      (data: TerminologyIndexResponse) => {
+        this.terminologies = data.body.items.sort((a, b) =>
+          a.label.localeCompare(b.label)
+        );
+        this.reloading = false;
+      },
+      () => {
+        this.reloading = false;
+      }
+    );
   }
 
-  // onTerminologySelect(terminology: any) {
-  //   this.model.referencedTerminology = terminology;
-  //   this.model.terminology = terminology;
-  //   this.validate();
-  //   this.sendValidationStatus();
-  // }
-
   modelDataTypeSelected(value: any) {
-    this.model.referencedModel = value;
+    this.model.modelResourceId = value.id;
+    this.model.modelResourceDomainType = value.domainType;
+
     this.validate();
     this.sendValidationStatus();
   }
 
   loadCodeSets() {
-   this.reloading = true;
-   this.resourceService.codeSet.list({ all: true }).subscribe((data: CodeSetIndexResponse) => {
-     this.codesets = data.body.items.sort((a, b) => a.label.localeCompare(b.label));
-     this.reloading = false;
-   }, () => {
-     this.reloading = false;
-   });
- }
+    this.reloading = true;
+    this.resourceService.codeSet.list({ all: true }).subscribe(
+      (data: CodeSetIndexResponse) => {
+        this.codesets = data.body.items.sort((a, b) =>
+          a.label.localeCompare(b.label)
+        );
+        this.reloading = false;
+      },
+      () => {
+        this.reloading = false;
+      }
+    );
+  }
 
- loadReferenceModels() {
-   this.reloading = true;
-   this.resourceService.referenceDataModel.list({ all: true }).subscribe((data: ReferenceDataModelIndexResponse) => {
-     this.referenceDataModels = data.body.items.sort((a, b) => a.label.localeCompare(b.label));
-     this.reloading = false;
-   }, () => {
-     this.reloading = false;
-   });
- }
+  loadReferenceModels() {
+    this.reloading = true;
+    this.resourceService.referenceDataModel.list({ all: true }).subscribe(
+      (data: ReferenceDataModelIndexResponse) => {
+        this.dataModels = data.body.items.sort((a, b) =>
+          a.label.localeCompare(b.label)
+        );
+        this.reloading = false;
+      },
+      () => {
+        this.reloading = false;
+      }
+    );
+  }
 
-  onEnumListUpdated = newEnumList => {
+  onEnumListUpdated = (newEnumList) => {
     this.model.enumerationValues = newEnumList;
     this.validate();
     this.sendValidationStatus();
@@ -191,5 +260,4 @@ export class NewDataTypeInlineComponent implements OnInit, AfterViewInit, OnDest
   ngOnDestroy(): void {
     this.formDataTypeChangesSubscription.unsubscribe();
   }
-
 }

--- a/src/app/wizards/dataElement/data-element-main/data-element-main.component.ts
+++ b/src/app/wizards/dataElement/data-element-main/data-element-main.component.ts
@@ -199,11 +199,11 @@ export class DataElementMainComponent implements OnInit {
         description: this.model.newlyAddedDataType.description,
         domainType,
 
-        referenceDataType: {
-          id: this.model.newlyAddedDataType.referencedDataType
-            ? this.model.newlyAddedDataType.referencedDataType.id
-            : null
-        },
+        // referenceDataType: {
+        //   id: this.model.newlyAddedDataType.referencedDataType
+        //     ? this.model.newlyAddedDataType.referencedDataType.id
+        //     : null
+        // },
 
         referenceClass: this.model.newlyAddedDataType.referenceClass
           ? this.model.newlyAddedDataType.referenceClass

--- a/src/app/wizards/dataElement/data-element-main/data-element-main.component.ts
+++ b/src/app/wizards/dataElement/data-element-main/data-element-main.component.ts
@@ -73,17 +73,8 @@ export class DataElementMainComponent implements OnInit {
     showNewInlineDataType: false,
     allDataTypesCount: 0,
     newlyAddedDataType: {
-      label: '',
-      description: '',
-      metadata: [],
-      domainType: CatalogueItemDomainType.PrimitiveType,
-      enumerationValues: [],
-      classifiers: [],
-      organisation: '',
-      referencedDataType: { id: '' },
-      referencedDataClass: { id: '' },
-      referencedModel: { id: '', domainType: '' }
-    },
+      domainType: CatalogueItemDomainType.PrimitiveType
+    } as DataType,
     isProcessComplete: false
   };
 
@@ -154,7 +145,6 @@ export class DataElementMainComponent implements OnInit {
 
   save = () => {
     if (this.model.createType === 'new') {
-      this.validateDataType();
       this.saveNewDataElement();
     } else {
       this.saveCopiedDataClasses();
@@ -207,7 +197,6 @@ export class DataElementMainComponent implements OnInit {
       const res: DataType = {
         label: this.model.newlyAddedDataType.label,
         description: this.model.newlyAddedDataType.description,
-        organisation: this.model.newlyAddedDataType.organisation,
         domainType,
 
         referenceDataType: {
@@ -215,35 +204,28 @@ export class DataElementMainComponent implements OnInit {
             ? this.model.newlyAddedDataType.referencedDataType.id
             : null
         },
-        referenceClass: {
-          id: this.model.newlyAddedDataType.referencedDataClass
-            ? this.model.newlyAddedDataType.referencedDataClass.id
-            : null
-        },
+
+        referenceClass: this.model.newlyAddedDataType.referenceClass
+          ? this.model.newlyAddedDataType.referenceClass
+          : null,
 
         modelResourceDomainType:
           domainType === CatalogueItemDomainType.ModelDataType
-            ? (this.model.newlyAddedDataType.referencedModel
-                .domainType as CatalogueItemDomainType)
+            ? (this.model.newlyAddedDataType
+                .modelResourceDomainType as CatalogueItemDomainType)
             : null,
+
         modelResourceId:
           domainType === CatalogueItemDomainType.ModelDataType
-            ? this.model.newlyAddedDataType.referencedModel.id
+            ? this.model.newlyAddedDataType.modelResourceId
             : null,
 
         classifiers: this.model.classifiers.map((cls) => ({ id: cls.id })),
-        enumerationValues: this.model.newlyAddedDataType.enumerationValues.map(
-          (m) => ({
-            key: m.key,
-            value: m.value,
-            category: m.category
-          })
-        ),
-        metadata: this.model.metadata.map((m) => ({
-          key: m.key,
-          value: m.value,
-          namespace: m.namespace
-        }))
+
+        enumerationValues:
+          domainType === CatalogueItemDomainType.EnumerationType
+            ? this.model.newlyAddedDataType.enumerationValues
+            : null
       };
 
       this.resources.dataType.save(this.parentDataModelId, res).subscribe(
@@ -308,46 +290,6 @@ export class DataElementMainComponent implements OnInit {
           );
         }
       );
-  }
-
-  validateDataType() {
-    let isValid = true;
-
-    if (!this.model.showNewInlineDataType) {
-      return true;
-    }
-    if (
-      !this.model.newlyAddedDataType.label ||
-      this.model.newlyAddedDataType.label.trim().length === 0
-    ) {
-      isValid = false;
-    }
-    // Check if for EnumerationType, at least one value is added
-    if (
-      this.model.newlyAddedDataType.domainType ===
-        CatalogueItemDomainType.EnumerationType &&
-      this.model.newlyAddedDataType.enumerationValues.length === 0
-    ) {
-      isValid = false;
-    }
-    // Check if for ReferenceType, the dataClass is selected
-    if (
-      this.model.newlyAddedDataType.domainType ===
-        CatalogueItemDomainType.ReferenceType &&
-      !this.model.newlyAddedDataType.referencedDataClass
-    ) {
-      isValid = false;
-    }
-
-    // Check if for TerminologyType, the terminology is selected
-    if (
-      this.model.newlyAddedDataType.domainType ===
-        CatalogueItemDomainType.TerminologyType &&
-      !this.model.newlyAddedDataType.referencedModel
-    ) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      isValid = false;
-    }
   }
 
   saveCopiedDataClasses = () => {

--- a/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.html
+++ b/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.html
@@ -204,25 +204,6 @@ SPDX-License-Identifier: Apache-2.0
           </tr>
         </tbody>
       </table>
-
-      <!--
-            <div *ngIf="model.allDataTypesCount === 0">
-                No Data Type defined for '{{model.parent.breadcrumbs[0].label}}' Data Model.
-                <br>Please enter Data Type details:
-            </div>
-
-            <div *ngIf="model.allDataTypesCount != 0" class="mb-2">
-                <div *ngIf="!model.showNewInlineDataType">
-                    Please select a Data Type below or
-                    <button mat-stroked-button color="primary" (click)="toggleShowNewInlineDataType()">Add a new Data Type</button>
-                </div>
-                <div *ngIf="model.showNewInlineDataType">
-                    Please
-                    <button mat-stroked-button color="primary" (click)="toggleShowNewInlineDataType()">select a Data Type</button>
-                    or Add a new Data Type by completing the form below:</div>
-            </div>
-
--->
     </form>
   </div>
   <div *ngIf="['copy', 'import'].includes(model.createType)" class="mb-3">

--- a/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.html
+++ b/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.html
@@ -176,6 +176,7 @@ SPDX-License-Identifier: Apache-2.0
                     [model]="model.newlyAddedDataType"
                     [parentDataModel]="model.parentDataModel"
                     [showParentDataModel]="false"
+                    [showLabelAndDescription]="true"
                     (validationStatusEvent)="validationStatusEmitter($event)"
                   >
                   </mdm-data-type-inline>

--- a/src/app/wizards/dataType/data-type-main/data-type-main.component.ts
+++ b/src/app/wizards/dataType/data-type-main/data-type-main.component.ts
@@ -24,13 +24,18 @@ import { Step } from '@mdm/model/stepModel';
 import { DataTypeStep1Component } from '../data-type-step1/data-type-step1.component';
 import { DataTypeStep2Component } from '../data-type-step2/data-type-step2.component';
 import { Title } from '@angular/platform-browser';
-import { CatalogueItemDomainType, DataModelDetailResponse, DataType, Uuid } from '@maurodatamapper/mdm-resources';
+import {
+  CatalogueItemDomainType,
+  DataModelDetailResponse,
+  DataType,
+  Uuid
+} from '@maurodatamapper/mdm-resources';
 import { ElementTypesService } from '@mdm/services';
 
 @Component({
   selector: 'mdm-data-type-main',
   templateUrl: './data-type-main.component.html',
-  styleUrls: ['./data-type-main.component.sass'],
+  styleUrls: ['./data-type-main.component.sass']
 })
 export class DataTypeMainComponent implements OnInit {
   parentDataModelId: Uuid;
@@ -42,7 +47,7 @@ export class DataTypeMainComponent implements OnInit {
     copyFromDataModel: [],
     isValid: false,
     parent: {
-      id: '',
+      id: ''
     },
     parentDataModel: { id: '' },
     label: '',
@@ -55,7 +60,7 @@ export class DataTypeMainComponent implements OnInit {
     referencedDataType: { id: '' },
     referencedModel: { id: '', domainType: '' },
     referencedDataClass: { id: '' },
-    isProcessComplete: false,
+    isProcessComplete: false
   };
   constructor(
     private stateService: StateService,
@@ -65,7 +70,7 @@ export class DataTypeMainComponent implements OnInit {
     private title: Title,
     private changeRef: ChangeDetectorRef,
     private elementTypes: ElementTypesService
-  ) { }
+  ) {}
 
   ngOnInit() {
     // tslint:disable-next-line: deprecation
@@ -89,15 +94,17 @@ export class DataTypeMainComponent implements OnInit {
     step2.scope = this;
     step2.invalid = true;
 
-    this.resources.dataModel.get(this.parentDataModelId).subscribe((result: DataModelDetailResponse) => {
-      result.body.breadcrumbs = [];
-      result.body.breadcrumbs.push(Object.assign({}, result.body));
-      this.model.parent.id = result.body.id || '';
+    this.resources.dataModel
+      .get(this.parentDataModelId)
+      .subscribe((result: DataModelDetailResponse) => {
+        result.body.breadcrumbs = [];
+        result.body.breadcrumbs.push(Object.assign({}, result.body));
+        this.model.parent.id = result.body.id || '';
 
-      this.steps.push(step1);
-      this.steps.push(step2);
-      this.changeRef.detectChanges();
-    });
+        this.steps.push(step1);
+        this.steps.push(step2);
+        this.changeRef.detectChanges();
+      });
 
     this.title.setTitle('New Data Type');
   }
@@ -145,16 +152,20 @@ export class DataTypeMainComponent implements OnInit {
     };
 
     if (domainType === CatalogueItemDomainType.ModelDataType) {
-      resource.modelResourceDomainType = this.model.referencedModel?.domainType;
+      resource.modelResourceDomainType = this.model.referencedModel
+        ?.domainType as CatalogueItemDomainType;
       resource.modelResourceId = this.model.referencedModel?.id;
-    }
-    else {
+    } else {
       resource.organisation = this.model.organisation;
       resource.referenceDataType = {
-        id: this.model.referencedDataType ? this.model.referencedDataType.id : null
+        id: this.model.referencedDataType
+          ? this.model.referencedDataType.id
+          : null
       };
       resource.referenceClass = {
-        id: this.model.referencedDataClass ? this.model.referencedDataClass.id : null
+        id: this.model.referencedDataClass
+          ? this.model.referencedDataClass.id
+          : null
       };
       resource.enumerationValues = this.model.enumerationValues.map((m) => {
         return {
@@ -171,16 +182,22 @@ export class DataTypeMainComponent implements OnInit {
         };
       });
     }
-    this.resources.dataType.save(this.model.parent.id, resource).subscribe(response => {
-      this.messageHandler.showSuccess('Data Type saved successfully.');
-      this.stateHandler.Go(
-        'DataType',
-        { dataModelId: response.body.model, id: response.body.id },
-        { reload: true, location: true }
-      );
-    }, error => {
-      this.messageHandler.showError('There was a problem saving the Data Type.', error);
-    });
+    this.resources.dataType.save(this.model.parent.id, resource).subscribe(
+      (response) => {
+        this.messageHandler.showSuccess('Data Type saved successfully.');
+        this.stateHandler.Go(
+          'DataType',
+          { dataModelId: response.body.model, id: response.body.id },
+          { reload: true, location: true }
+        );
+      },
+      (error) => {
+        this.messageHandler.showError(
+          'There was a problem saving the Data Type.',
+          error
+        );
+      }
+    );
   }
 
   saveCopiedDataTypes = () => {

--- a/src/app/wizards/dataType/data-type-main/data-type-main.component.ts
+++ b/src/app/wizards/dataType/data-type-main/data-type-main.component.ts
@@ -156,12 +156,10 @@ export class DataTypeMainComponent implements OnInit {
         ?.domainType as CatalogueItemDomainType;
       resource.modelResourceId = this.model.referencedModel?.id;
     } else {
-      resource.organisation = this.model.organisation;
-      resource.referenceDataType = {
-        id: this.model.referencedDataType
-          ? this.model.referencedDataType.id
-          : null
-      };
+      resource.id = this.model.referencedDataType
+        ? this.model.referencedDataType.id
+        : null;
+
       resource.referenceClass = {
         id: this.model.referencedDataClass
           ? this.model.referencedDataClass.id
@@ -172,13 +170,6 @@ export class DataTypeMainComponent implements OnInit {
           key: m.key,
           value: m.value,
           category: m.category
-        };
-      });
-      resource.metadata = this.model.metadata.map((m) => {
-        return {
-          key: m.key,
-          value: m.value,
-          namespace: m.namespace
         };
       });
     }


### PR DESCRIPTION
This PR will be marked as "Draft" because it depends on a [PR for mdm-resources](https://github.com/MauroDataMapper/mdm-resources/pull/104).

The main cause of the issue was that `new-data-type-inline.component` was using an anonymous type with the wrong variable names, and `default-profile-editor-modal.component` was using those variable names without treating them. All this is allowed because the `DataType`definition allows `[key : string]: value` as a variable.

There is a number of changes in this PR:
- Removing unused validations and some small fixes that I spotted while working in the different components.
- Removing anonymous types to use `DataType`.
- Adding some comments on the code to describe better what needs to happen or why we do certain transformations.
- When creating a new `DataType` the label for the new `dataType `is mandatory, so we should show the fields from the start.

Both creating a new `dataType` while editing an existing `dataElement `and when creating a brand new `dataElement `should work fine now.


closes #318 