### PR TITLE
Minor style tweaks for the admin interface 

### DIFF
--- a/src/app/admin/app-container/app-container.component.html
+++ b/src/app/admin/app-container/app-container.component.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
   >
     <aside
       role="menu"
-      class="menu"
+      class="menu pane"
       fxFlex="18"
       fxFlex.md="18"
       fxHide.sm
@@ -204,6 +204,7 @@ SPDX-License-Identifier: Apache-2.0
     </aside>
     <div
       id="settings-content"
+      class="pane padded-pane"
       fxFlex="82"
       fxFlex.md="100"
       fxFlex.sm="100"

--- a/src/app/users/users-app-container/users-app-container.component.html
+++ b/src/app/users/users-app-container/users-app-container.component.html
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
   >
     <aside
       role="menu"
-      class="menu"
+      class="menu pane"
       fxFlex="18"
       fxFlex.md="18"
       fxHide.sm
@@ -158,13 +158,15 @@ SPDX-License-Identifier: Apache-2.0
             uiSrefActive="active"
           >
             <span class="fas fa-user-clock"></span>
+            <span>Pending users</span>
             <span
-              matBadge="{{ pendingUsersCount }}"
-              matBadgeOverlap="false"
-              matBadgeColor="warn"
-              [matBadgeHidden]="!pendingUsersCount"
-              >Pending users</span
+              class="badge pill-card--red"
+              aria-hidden="false"
+              *ngIf="pendingUsersCount > 0"
+              style="margin-left: 6px"
             >
+              {{ pendingUsersCount }}
+            </span>
           </a>
         </li>
         <li>
@@ -202,6 +204,7 @@ SPDX-License-Identifier: Apache-2.0
     </aside>
     <div
       id="settings-content"
+      class="pane padded-pane"
       fxFlex="82"
       fxFlex.md="100"
       fxFlex.sm="100"

--- a/src/style/_default.scss
+++ b/src/style/_default.scss
@@ -43,6 +43,9 @@ div.as-split-gutter {
   padding: 2rem !important;
 }
 
+.padded-pane {
+  padding: 1rem  !important;
+}
 
 /* include border and padding in element width and height */
 * {

--- a/src/style/layout/_admin.scss
+++ b/src/style/layout/_admin.scss
@@ -39,7 +39,6 @@ SPDX-License-Identifier: Apache-2.0
   padding: 10px 0;
   margin-bottom: -1px;
   list-style: none;
-  background-color: #fcfcfd;
   li {
     padding: 0;
     position: relative;


### PR DESCRIPTION
to match the others made as part of #812

Before:
<img width="1387" alt="Screenshot 2023-07-13 at 14 20 33" src="https://github.com/MauroDataMapper/mdm-ui/assets/1869668/44f36c65-73f9-44bf-83f1-dbf652676d2a">

After:
<img width="1685" alt="Screenshot 2023-07-13 at 14 19 04" src="https://github.com/MauroDataMapper/mdm-ui/assets/1869668/e01e3213-3736-40bf-9cec-03aa87dbb9fb">

Also fixed an annoying change in styling of the pending users number badge, which changed style when you moved between user settings and admin settings