### PR TITLE
Hide buttons when logged out

### DIFF
--- a/src/app/constraints-rules/constraints-rules.component.html
+++ b/src/app/constraints-rules/constraints-rules.component.html
@@ -67,6 +67,8 @@ SPDX-License-Identifier: Apache-2.0
               fxLayoutAlign="flex-end center"
               fxLayoutAlign.xs="flex-start center"
             >
+
+            <ng-template [ngIf]="isLoggedIn">
               <div class="mt-1">
                 <button
                   mat-flat-button
@@ -89,7 +91,9 @@ SPDX-License-Identifier: Apache-2.0
                 >
                   <span class="fas fa-download"></span> Export
                 </button>
+
               </div>
+            </ng-template>
             </div>
           </div>
         </mat-expansion-panel-header>

--- a/src/app/constraints-rules/constraints-rules.component.ts
+++ b/src/app/constraints-rules/constraints-rules.component.ts
@@ -24,6 +24,7 @@ import {
 } from '@angular/animations';
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { SharedService } from '../services/shared.service';
 import {
   AddRuleModalComponent,
   AddRuleModalConfig,
@@ -91,6 +92,7 @@ export class ConstraintsRulesComponent implements OnInit {
 
   clickButton = false;
   filteredOpen = false;
+  isLoggedIn = false;
 
   canAddRules: boolean;
   canDeleteRules: boolean;
@@ -98,6 +100,7 @@ export class ConstraintsRulesComponent implements OnInit {
   constructor(
     public dialog: MatDialog,
     private editing: EditingService,
+    private sharedService: SharedService,
     protected resourcesService: MdmResourcesService,
     protected messageHandler: MessageHandlerService
   ) {
@@ -106,6 +109,7 @@ export class ConstraintsRulesComponent implements OnInit {
     this.languages.push({ displayName: 'All', value: 'all' });
     this.isLoadingResults = true;
     this.selectedLanguage = this.languages.find((x) => x.value === 'all');
+    this.isLoggedIn = this.sharedService.isLoggedIn();
   }
 
   ngOnInit(): void {

--- a/src/app/dataModel/data-model.component.html
+++ b/src/app/dataModel/data-model.component.html
@@ -112,15 +112,19 @@ SPDX-License-Identifier: Apache-2.0
             fxLayoutAlign="flex-end center"
             fxLayoutAlign.xs="flex-start center"
           >
+
+          <ng-template [ngIf]="isLoggedIn">
             <button
               mat-flat-button
               color="primary"
               type="button"
               (click)="addDataClass()"
             >
-              <span class="fas fa-plus" aria-hidden="true"></span>
+            <span class="fas fa-plus" aria-hidden="true"></span>
               Add Data Class
             </button>
+          </ng-template>
+
           </div>
         </div>
       </div>

--- a/src/app/dataModel/data-model.component.html
+++ b/src/app/dataModel/data-model.component.html
@@ -113,7 +113,7 @@ SPDX-License-Identifier: Apache-2.0
             fxLayoutAlign.xs="flex-start center"
           >
 
-          <ng-template [ngIf]="isLoggedIn">
+          <ng-template [ngIf]="isLoggedIn && canEdit">
             <button
               mat-flat-button
               color="primary"

--- a/src/app/dataModel/data-model.component.ts
+++ b/src/app/dataModel/data-model.component.ts
@@ -83,6 +83,7 @@ export class DataModelComponent
   historyItemCount = 0;
   isLoadingHistory = true;
   showEditDescription = false;
+  isLoggedIn = false;
 
   constructor(
     private resourcesService: MdmResourcesService,
@@ -118,6 +119,8 @@ export class DataModelComponent
     this.title.setTitle('Data Model');
 
     this.dataModelDetails(this.parentId, this.showFinalised);
+
+    this.isLoggedIn = this.sharedService.isLoggedIn();
   }
 
   save(saveItems: Array<DefaultProfileItem>) {

--- a/src/app/dataModel/data-model.component.ts
+++ b/src/app/dataModel/data-model.component.ts
@@ -84,6 +84,7 @@ export class DataModelComponent
   isLoadingHistory = true;
   showEditDescription = false;
   isLoggedIn = false;
+  canEdit = false;
 
   constructor(
     private resourcesService: MdmResourcesService,
@@ -239,6 +240,8 @@ export class DataModelComponent
           }
         });
     }
+
+    this.canEdit = this.dataModel.availableActions.includes('update');
   }
 
   async DataModelPermissions(id: any) {


### PR DESCRIPTION
When loggd out: Hide "Add Data Class" and "Add Rule" & "Export" buttons;
 hide "Add Terms" & "Add Relationship Type" buttons, as well as the icons
 for rule editing. 
The buttons already do nothing since the object they changed is not
 accesssible when logged out. Thus, we prevent a spurious error message
 to be shown.

Apply Welch's suggestions: add canEdit boolean and fill it apropriately.
 Before, we were blindly following the loggedIn status; now we also follow
 backend's hints/permissions of whether we should show the button, in
 addition to checking if the user is logged in.





