### PR TITLE
gh-857 Add full and correct breadcrumb trail for each Mauro item displayed

### DIFF
--- a/src/app/model-header/model-header.component.html
+++ b/src/app/model-header/model-header.component.html
@@ -15,7 +15,10 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div *ngIf="item" class="mdm-model-header panel panel-default mdm--shadow-block">
+<div
+  *ngIf="item"
+  class="mdm-model-header panel panel-default mdm--shadow-block"
+>
   <div class="mdm-model-header__title-bar">
     <div class="mdm-model-header__title">
       <h4
@@ -120,13 +123,10 @@ SPDX-License-Identifier: Apache-2.0
     </div>
   </div>
 
-  <mdm-model-path
-    *ngIf="isChildItem"
-    [path]="item.breadcrumbs"
-  ></mdm-model-path>
-
-  <mdm-catalogue-item-properties [item]="item">
-  </mdm-catalogue-item-properties>
+  <mdm-catalogue-item-properties
+    [item]="item"
+    [ancestorTreeItems]="ancestorTreeItems"
+  ></mdm-catalogue-item-properties>
 </div>
 <mat-progress-bar
   *ngIf="busy"

--- a/src/app/model-header/model-header.component.spec.ts
+++ b/src/app/model-header/model-header.component.spec.ts
@@ -20,12 +20,20 @@ import {
   setupTestModuleForComponent
 } from '@mdm/testing/testing.helpers';
 import { ModelHeaderComponent } from './model-header.component';
+import { ModelTreeService } from '@mdm/services/model-tree.service';
 
 describe('ModelHeaderComponent', () => {
   let harness: ComponentHarness<ModelHeaderComponent>;
 
   beforeEach(async () => {
-    harness = await setupTestModuleForComponent(ModelHeaderComponent);
+    harness = await setupTestModuleForComponent(ModelHeaderComponent, {
+      providers: [
+        {
+          provide: ModelTreeService,
+          useValue: jest.fn()
+        }
+      ]
+    });
   });
 
   it('should create', () => {

--- a/src/app/model-header/model-header.component.ts
+++ b/src/app/model-header/model-header.component.ts
@@ -222,7 +222,10 @@ export class ModelHeaderComponent implements OnInit {
           })
         )
         .subscribe((ancestorTreeItems) => {
-          this.ancestorTreeItems = ancestorTreeItems;
+          // Exclude the item being shown (not relevant to display twice)
+          this.ancestorTreeItems = ancestorTreeItems.filter(
+            (treeItem) => treeItem.id !== this.item.id
+          );
           console.log(this.ancestorTreeItems);
         });
     }

--- a/src/app/shared/catalogue-item-properties/catalogue-item-properties.component.html
+++ b/src/app/shared/catalogue-item-properties/catalogue-item-properties.component.html
@@ -16,6 +16,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 <div *ngIf="item" class="detail-icons" data-cy="catalogue-item-properties">
+  <div class="text-muted" data-cy="location">
+    <small class="block">
+      <mdm-location-path
+        [ancestorTreeItems]="ancestorTreeItems"
+      ></mdm-location-path>
+    </small>
+  </div>
   <div class="text-muted" data-cy="item-type">
     <small class="block">
       <div>
@@ -88,7 +95,10 @@ SPDX-License-Identifier: Apache-2.0
   >
     <small>
       <span matTooltip="Model Version" class="fas fa-file-alt"></span>
-      <span><strong>Version: </strong>{{ item.modelVersionTag?item.modelVersionTag:item.modelVersion }} </span>
+      <span
+        ><strong>Version: </strong
+        >{{ item.modelVersionTag ? item.modelVersionTag : item.modelVersion }}
+      </span>
       <span *ngIf="item.modelVersionTag">({{ item.modelVersion }})</span>
     </small>
   </div>

--- a/src/app/shared/catalogue-item-properties/catalogue-item-properties.component.ts
+++ b/src/app/shared/catalogue-item-properties/catalogue-item-properties.component.ts
@@ -16,16 +16,26 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { Branchable, CatalogueItem, CatalogueItemDomainType, DataModelDetail, Finalisable, Historical, ModelableDetail, SecurableModel, Versionable } from '@maurodatamapper/mdm-resources';
+import {
+  Branchable,
+  CatalogueItem,
+  CatalogueItemDomainType,
+  DataModelDetail,
+  Finalisable,
+  Historical,
+  MdmTreeItem,
+  ModelableDetail,
+  SecurableModel,
+  Versionable
+} from '@maurodatamapper/mdm-resources';
 
-export type CatalogueItemPropertiesType =
-  CatalogueItem
-  & Partial<ModelableDetail>
-  & Partial<SecurableModel>
-  & Partial<Finalisable>
-  & Partial<Versionable>
-  & Partial<Branchable>
-  & Partial<Historical>;
+export type CatalogueItemPropertiesType = CatalogueItem &
+  Partial<ModelableDetail> &
+  Partial<SecurableModel> &
+  Partial<Finalisable> &
+  Partial<Versionable> &
+  Partial<Branchable> &
+  Partial<Historical>;
 
 @Component({
   selector: 'mdm-catalogue-item-properties',
@@ -34,10 +44,11 @@ export type CatalogueItemPropertiesType =
 })
 export class CatalogueItemPropertiesComponent implements OnChanges {
   @Input() item: CatalogueItemPropertiesType;
+  @Input() ancestorTreeItems: MdmTreeItem[] = [];
 
   itemType: string;
 
-  constructor() { }
+  constructor() {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.item) {
@@ -64,5 +75,4 @@ export class CatalogueItemPropertiesComponent implements OnChanges {
         break;
     }
   }
-
 }

--- a/src/app/shared/location-path/location-path.component.html
+++ b/src/app/shared/location-path/location-path.component.html
@@ -1,0 +1,46 @@
+<!--
+Copyright 2020-2024 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+<div *ngIf="items && items.length > 0">
+  <nav aria-label="breadcrumb" class="location-path">
+    <ol>
+      <li>
+        <small>
+          <span class="fas fa-map-marker-alt" matTooltip="Location"></span>
+          <strong>Location: </strong>
+        </small>
+      </li>
+      <li class="breadcrumb-item" *ngFor="let item of items">
+        <small>
+          <a [href]="item.href">
+            <span>{{ item.label }}</span>
+            <span *ngIf="item.branchName" class="model-suffix">
+              <span class="fas fa-code-branch"></span>
+              {{ item.branchName }}</span
+            >
+            <span *ngIf="item.modelVersion" class="model-suffix">
+              <span class="fas fa-file-alt"></span>{{ item.modelVersion }}</span
+            >
+            <span *ngIf="item.modelVersionTag" class="model-suffix">
+              <span class="fas fa-tag"></span>{{ item.modelVersionTag }}</span
+            ></a
+          >
+        </small>
+      </li>
+    </ol>
+  </nav>
+</div>

--- a/src/app/shared/location-path/location-path.component.html
+++ b/src/app/shared/location-path/location-path.component.html
@@ -15,32 +15,33 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div *ngIf="items && items.length > 0">
-  <nav aria-label="breadcrumb" class="location-path">
-    <ol>
-      <li>
-        <small>
-          <span class="fas fa-map-marker-alt" matTooltip="Location"></span>
-          <strong>Location: </strong>
-        </small>
-      </li>
-      <li class="breadcrumb-item" *ngFor="let item of items">
-        <small>
-          <a [href]="item.href">
-            <span>{{ item.label }}</span>
-            <span *ngIf="item.branchName" class="model-suffix">
-              <span class="fas fa-code-branch"></span>
-              {{ item.branchName }}</span
-            >
-            <span *ngIf="item.modelVersion" class="model-suffix">
-              <span class="fas fa-file-alt"></span>{{ item.modelVersion }}</span
-            >
-            <span *ngIf="item.modelVersionTag" class="model-suffix">
-              <span class="fas fa-tag"></span>{{ item.modelVersionTag }}</span
-            ></a
+<nav aria-label="breadcrumb" class="location-path">
+  <ol>
+    <li>
+      <small>
+        <span class="fas fa-map-marker-alt" matTooltip="Location"></span>
+        <strong>Location: </strong>
+      </small>
+    </li>
+    <li class="breadcrumb-item" *ngIf="!items || items.length === 0">
+      <small>Locating...</small>
+    </li>
+    <li class="breadcrumb-item" *ngFor="let item of items">
+      <small>
+        <a [href]="item.href">
+          <span>{{ item.label }}</span>
+          <span *ngIf="item.branchName" class="model-suffix">
+            <span class="fas fa-code-branch"></span>
+            {{ item.branchName }}</span
           >
-        </small>
-      </li>
-    </ol>
-  </nav>
-</div>
+          <span *ngIf="item.modelVersion" class="model-suffix">
+            <span class="fas fa-file-alt"></span>{{ item.modelVersion }}</span
+          >
+          <span *ngIf="item.modelVersionTag" class="model-suffix">
+            <span class="fas fa-tag"></span>{{ item.modelVersionTag }}</span
+          ></a
+        >
+      </small>
+    </li>
+  </ol>
+</nav>

--- a/src/app/shared/location-path/location-path.component.html
+++ b/src/app/shared/location-path/location-path.component.html
@@ -23,8 +23,14 @@ SPDX-License-Identifier: Apache-2.0
         <strong>Location: </strong>
       </small>
     </li>
-    <li class="breadcrumb-item" *ngIf="!items || items.length === 0">
+    <li class="breadcrumb-item" *ngIf="loading">
       <small>Locating...</small>
+    </li>
+    <li
+      class="breadcrumb-item"
+      *ngIf="!loading && (!items || items.length === 0)"
+    >
+      <small>Root item</small>
     </li>
     <li class="breadcrumb-item" *ngFor="let item of items">
       <small>

--- a/src/app/shared/location-path/location-path.component.scss
+++ b/src/app/shared/location-path/location-path.component.scss
@@ -19,13 +19,19 @@ SPDX-License-Identifier: Apache-2.0
   display: inline-block;
 
   ol {
-    display: inline-flex;
-    flex-wrap: wrap;
     list-style: none;
     margin-bottom: 0;
     padding: 0;
 
+    li {
+      display: inline;
+    }
+
     li.breadcrumb-item {
+      &::before {
+        float: none;
+      }
+
       padding-left: 0;
       font-size: medium;
 

--- a/src/app/shared/location-path/location-path.component.scss
+++ b/src/app/shared/location-path/location-path.component.scss
@@ -15,3 +15,35 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
+.location-path {
+  display: inline-block;
+
+  ol {
+    display: inline-flex;
+    flex-wrap: wrap;
+    list-style: none;
+    margin-bottom: 0;
+    padding: 0;
+
+    li.breadcrumb-item {
+      padding-left: 0;
+      font-size: medium;
+
+      small {
+        margin-right: 8px;
+      }
+
+      .model-suffix {
+        &::before {
+          padding: 0 0.2rem;
+          content: '|';
+        }
+
+        .fas {
+          font-size: medium;
+          margin-right: 2px;
+        }
+      }
+    }
+  }
+}

--- a/src/app/shared/location-path/location-path.component.ts
+++ b/src/app/shared/location-path/location-path.component.ts
@@ -15,7 +15,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 */
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges
+} from '@angular/core';
 import { MdmTreeItem } from '@maurodatamapper/mdm-resources';
 import { PathNameService } from '../path-name/path-name.service';
 
@@ -32,12 +38,17 @@ interface LocationPathItem {
   templateUrl: './location-path.component.html',
   styleUrls: ['./location-path.component.scss']
 })
-export class LocationPathComponent implements OnChanges {
+export class LocationPathComponent implements OnInit, OnChanges {
   @Input() ancestorTreeItems: MdmTreeItem[] = [];
 
   items: LocationPathItem[] = [];
+  loading = true;
 
   constructor(private pathName: PathNameService) {}
+
+  ngOnInit(): void {
+    this.loading = !this.items || this.items.length === 0;
+  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.ancestorTreeItems) {
@@ -51,6 +62,8 @@ export class LocationPathComponent implements OnChanges {
             modelVersionTag: ancestor.modelVersionTag
           };
         }) ?? [];
+
+      this.loading = false;
     }
   }
 }

--- a/src/app/shared/location-path/location-path.component.ts
+++ b/src/app/shared/location-path/location-path.component.ts
@@ -1,0 +1,56 @@
+/*
+Copyright 2020-2024 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { MdmTreeItem } from '@maurodatamapper/mdm-resources';
+import { PathNameService } from '../path-name/path-name.service';
+
+interface LocationPathItem {
+  label: string;
+  href: string;
+  branchName?: string;
+  modelVersion?: string;
+  modelVersionTag?: string;
+}
+
+@Component({
+  selector: 'mdm-location-path',
+  templateUrl: './location-path.component.html',
+  styleUrls: ['./location-path.component.scss']
+})
+export class LocationPathComponent implements OnChanges {
+  @Input() ancestorTreeItems: MdmTreeItem[] = [];
+
+  items: LocationPathItem[] = [];
+
+  constructor(private pathName: PathNameService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.ancestorTreeItems) {
+      this.items =
+        this.ancestorTreeItems?.map((ancestor) => {
+          return {
+            label: ancestor.label,
+            href: this.pathName.createHref(ancestor.path),
+            branchName: ancestor.branchName,
+            modelVersion: ancestor.modelVersion,
+            modelVersionTag: ancestor.modelVersionTag
+          };
+        }) ?? [];
+    }
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -58,6 +58,7 @@ import { ElementLabelComponent } from './element-label/element-label.component';
 import { ImgCroppieComponent } from './img-croppie/img-croppie.component';
 import { ImageCropperModule } from 'ngx-image-cropper';
 import { ContentModule } from '@mdm/content/content.module';
+import { LocationPathComponent } from './location-path/location-path.component';
 
 @NgModule({
   declarations: [
@@ -90,7 +91,8 @@ import { ContentModule } from '@mdm/content/content.module';
     FileSizePipe,
     MauroItemTreeComponent,
     ElementLabelComponent,
-    ImgCroppieComponent
+    ImgCroppieComponent,
+    LocationPathComponent
   ],
   imports: [
     CommonModule,
@@ -147,7 +149,8 @@ import { ContentModule } from '@mdm/content/content.module';
     FileSizePipe,
     MauroItemTreeComponent,
     ElementLabelComponent,
-    ImgCroppieComponent
+    ImgCroppieComponent,
+    LocationPathComponent
   ]
 })
 export class SharedModule {}


### PR DESCRIPTION
Resolves #857 

This pull request depends on:

- MauroDataMapper/mdm-core#452
- MauroDataMapper/mdm-resources#112

# Changes

- Use ancestors endpoints to create the full location path to an item
- Include branch, versions and version tags for models where applicable
- Location path components are hyperlinks that jump to each other item correctly
- Remove old breadcrumbs for model child items - these are now automatically included in the location paths
- Fix lint issues in `model-header.component`

![image](https://github.com/MauroDataMapper/mdm-ui/assets/3219480/f5a54f1e-0a05-4ab4-bba5-c99a5855ade8)
