### PR TITLE
gh-860 Intercept HTML content to display correctly in the html-editor-component

### DIFF
--- a/src/app/content/content.utils.ts
+++ b/src/app/content/content.utils.ts
@@ -1,4 +1,4 @@
-<!--
+/*
 Copyright 2020-2024 University of Oxford and NHS England
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
--->
+*/
+export const isUrl = (href: string): boolean => {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch (_) {
+    return false;
+  }
 
-<jodit-editor
-  *ngIf="inEditMode"
-  [(ngModel)]="description"
-  [config]="editorConfig"
-  (onChange)="onHtmlEditorChanged($event)"
-  (onKeydown)="onHtmlEditorKeydown($event)"
->
-</jodit-editor>
-<div style="clear: both">
-  <span [innerHTML]="displayContent | safe: 'html'" *ngIf="!inEditMode"></span>
-</div>
+  return url.protocol === 'http:' || url.protocol === 'https:';
+};

--- a/src/app/content/element-search-dialog/element-search-dialog.component.ts
+++ b/src/app/content/element-search-dialog/element-search-dialog.component.ts
@@ -22,8 +22,10 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import {
   CatalogueItem,
   CatalogueItemSearchResponse,
-  CatalogueItemSearchResult
+  CatalogueItemSearchResult,
+  Pathable
 } from '@maurodatamapper/mdm-resources';
+import { MauroItem } from '@mdm/mauro/mauro-item.types';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { EMPTY } from 'rxjs';
 import {
@@ -45,7 +47,7 @@ export interface ElementSearchDialogData {
 }
 
 export interface ElementSearchDialogResponse {
-  selected?: CatalogueItemSearchResult;
+  selected?: MauroItem & Pathable;
 }
 
 @Component({
@@ -120,6 +122,7 @@ export class ElementSearchDialogComponent implements OnInit {
 
   onCatalogueItemSelected(event: MatAutocompleteSelectedEvent) {
     const selected = event.option.value as CatalogueItemSearchResult;
-    this.dialogRef.close({ selected });
+    const item = (selected as unknown) as MauroItem & Pathable;
+    this.dialogRef.close({ selected: item });
   }
 }

--- a/src/app/content/html/html-parser/html-parser.service.spec.ts
+++ b/src/app/content/html/html-parser/html-parser.service.spec.ts
@@ -1,0 +1,81 @@
+/*
+Copyright 2020-2024 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { setupTestModuleForService } from '@mdm/testing/testing.helpers';
+import { HtmlParserService } from './html-parser.service';
+import { PathNameService } from '@mdm/shared/path-name/path-name.service';
+
+describe('HtmlParserService', () => {
+  let service: HtmlParserService;
+
+  const pathNamesStub = {
+    createHref: jest.fn() as jest.MockedFunction<(path: string) => string>
+  };
+
+  beforeEach(() => {
+    service = setupTestModuleForService(HtmlParserService, {
+      providers: [
+        {
+          provide: PathNameService,
+          useValue: pathNamesStub
+        }
+      ]
+    });
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should ignore empty hrefs in links', () => {
+    const content = '<a href="">No link</a>';
+    const modified = service.parseAndModify(content);
+    expect(modified).toStrictEqual(content);
+  });
+
+  it('should ignore empty fragment links', () => {
+    const content = '<a href="#">Empty fragment</a>';
+    const modified = service.parseAndModify(content);
+    expect(modified).toStrictEqual(content);
+  });
+
+  it.each([
+    'http://localhost',
+    'https://www.google.com',
+    'https://my.web.site/folder/page'
+  ])('should ignore regular url %p', (url) => {
+    const content = `<a href="${url}">Page link</a>`;
+    const modified = service.parseAndModify(content);
+    expect(modified).toStrictEqual(content);
+  });
+
+  it.each([
+    ['dm:model', '/dataModels/dm:model'],
+    ['dm:model|dc:class', '/dataModels/dm:model|dc:class'],
+    ['dm:model|dc:class|de:element', '/dataModels/dm:model|dc:class|de:element']
+  ])('should rewrite mauro item path %p to valid url %p', (path, pathUrl) => {
+    const baseUrl = 'http://localhost/#/catalogue/item';
+    pathNamesStub.createHref.mockImplementationOnce(
+      () => `${baseUrl}${pathUrl}`
+    );
+
+    const content = `<a href="${path}">Mauro item link</a>`;
+    const expected = `<a href="${baseUrl}${pathUrl}">Mauro item link</a>`;
+    const modified = service.parseAndModify(content);
+    expect(modified).toStrictEqual(expected);
+  });
+});

--- a/src/app/content/html/html-parser/html-parser.service.ts
+++ b/src/app/content/html/html-parser/html-parser.service.ts
@@ -1,0 +1,63 @@
+/*
+Copyright 2020-2024 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Injectable } from '@angular/core';
+import { isUrl } from '@mdm/content/content.utils';
+import { PathNameService } from '@mdm/shared/path-name/path-name.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HtmlParserService {
+  private domParser = new DOMParser();
+
+  constructor(private pathNames: PathNameService) {}
+
+  /**
+   * Parse the given HTML (fragment) and modify to make suitable for local content display.
+   *
+   * @param original The original HTML source.
+   * @returns A modified version of the HTML source for local content display.
+   */
+  parseAndModify(original: string): string {
+    const document = this.domParser.parseFromString(original, 'text/html');
+    this.rewriteHrefs(document);
+
+    return document.body.innerHTML;
+  }
+
+  private rewriteHrefs(document: Document) {
+    const links = document.querySelectorAll('a');
+
+    links.forEach((link) => {
+      if (!link.href || link.href === '' || link.href === 'about:blank#') {
+        // Ignore missing hrefs or script references
+        return;
+      }
+
+      if (isUrl(link.href)) {
+        // Consider this to be a link to an external document, should not change
+        return;
+      }
+
+      // Create internal link, assuming the href is a Mauro path to a catalogue item
+      const path = link.href;
+      const internalHref = this.pathNames.createHref(path);
+      link.href = internalHref;
+    });
+  }
+}

--- a/src/app/content/markdown/markdown-parser/custom-html-renderer.service.ts
+++ b/src/app/content/markdown/markdown-parser/custom-html-renderer.service.ts
@@ -16,6 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 import { Injectable } from '@angular/core';
+import { isUrl } from '@mdm/content/content.utils';
 import { PathNameService } from '@mdm/shared/path-name/path-name.service';
 import * as marked from 'marked';
 
@@ -32,7 +33,7 @@ export class CustomHtmlRendererService extends marked.Renderer {
       return `<a href='#'>${text}</a>`;
     }
 
-    if (this.isUrl(href)) {
+    if (isUrl(href)) {
       // Create external link
       return `<a href='${href}' target="_blank">${text}</a>`;
     }
@@ -55,15 +56,4 @@ export class CustomHtmlRendererService extends marked.Renderer {
   table = (header, body) => {
     return `<table class='table table-bordered'> ${header} ${body}</table>`;
   };
-
-  private isUrl(href: string): boolean {
-    let url: URL;
-    try {
-      url = new URL(href);
-    } catch (_) {
-      return false;
-    }
-
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  }
 }

--- a/src/app/content/markdown/markdown-text-area/markdown-text-area.component.ts
+++ b/src/app/content/markdown/markdown-text-area/markdown-text-area.component.ts
@@ -29,14 +29,11 @@ import { MarkdownParserService } from '../markdown-parser/markdown-parser.servic
 import { ElementSelectorDialogueService } from '@mdm/services/element-selector-dialogue.service';
 import { MessageService } from '@mdm/services/message.service';
 import { MatDialog } from '@angular/material/dialog';
-import {
-  CatalogueItem,
-  Modelable,
-  Navigatable
-} from '@maurodatamapper/mdm-resources';
+import { CatalogueItem, Pathable } from '@maurodatamapper/mdm-resources';
 import { PathNameService } from '@mdm/shared/path-name/path-name.service';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { filter, map, Subject, takeUntil } from 'rxjs';
+import { MauroItem } from '@mdm/mauro/mauro-item.types';
 
 const macShortcuts = {
   bold: 'Bold (⌘ + B)',
@@ -289,8 +286,8 @@ export class MarkdownTextAreaComponent implements OnInit, OnDestroy {
     this.description = el.value;
   }
 
-  private createAndInsertLink(element: Modelable & Navigatable) {
-    const path = this.pathNames.createFromBreadcrumbs(element);
+  private createAndInsertLink(element: MauroItem & Pathable) {
+    const path = element.path ?? this.pathNames.createFromBreadcrumbs(element);
     const link = `[${element.label}](${path})`;
     this.insertText({
       type: 'inline',


### PR DESCRIPTION
Resolves #860 

- Add a HtmlParserService to modify links in content
- Adjust any link hrefs that contain just a Mauro path to use a correct Angular routing URL to a page
- Fix inserting links in HTML/Markdown editors. Use the correct path information for inserting links from either autocomplete or dialogs

This should work in conjunction with the issue below, so that HTML content is stored maintaining Mauro paths as hyperlinks, yet will correct them at display time:

- MauroDataMapper-NHSD/mdm-plugin-nhs-data-dictionary#11