### PR TITLE
gh-870, make definition mandatory in line with other add terminology …

### DIFF
--- a/src/app/terminology/term-list/create-term-dialog/create-term-dialog.component.html
+++ b/src/app/terminology/term-list/create-term-dialog/create-term-dialog.component.html
@@ -31,9 +31,9 @@ SPDX-License-Identifier: Apache-2.0
       </mat-form-field>
     </div>
     <div class="mdm--form-input">
-      <mat-form-field appearance="outline" class="full-width">
+      <mat-form-field appearance="outline" class="full-width" >
         <mat-label>Definition</mat-label>
-        <input matInput type="text" formControlName="definition" />
+        <input matInput type="text" formControlName="definition" required/>
       </mat-form-field>
     </div>
     <div class="mdm--form-input">


### PR DESCRIPTION
…screens

I had a look at the terminology screen for adding a new term when creating a link and decided since that one has the field as required, I would follow suite. 

Closes #870 


