### PR TITLE
gh-874 Create term dialog sets default definition

### DIFF
--- a/src/app/terminology/term-list/create-term-dialog/create-term-dialog.component.html
+++ b/src/app/terminology/term-list/create-term-dialog/create-term-dialog.component.html
@@ -27,13 +27,15 @@ SPDX-License-Identifier: Apache-2.0
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Code</mat-label>
         <input matInput type="text" formControlName="code" required />
-        <mat-error *ngIf="code?.errors?.required">Please provide a code</mat-error>
+        <mat-error *ngIf="code?.errors?.required"
+          >Please provide a code</mat-error
+        >
       </mat-form-field>
     </div>
     <div class="mdm--form-input">
-      <mat-form-field appearance="outline" class="full-width" >
+      <mat-form-field appearance="outline" class="full-width">
         <mat-label>Definition</mat-label>
-        <input matInput type="text" formControlName="definition" required/>
+        <input matInput type="text" formControlName="definition" />
       </mat-form-field>
     </div>
     <div class="mdm--form-input">
@@ -41,7 +43,8 @@ SPDX-License-Identifier: Apache-2.0
       <mdm-content-editor
         [content]="description.value"
         (contentChange)="description.setValue($event)"
-        [inEditMode]="true">
+        [inEditMode]="true"
+      >
       </mdm-content-editor>
     </div>
   </div>

--- a/src/app/terminology/term-list/create-term-dialog/create-term-dialog.component.ts
+++ b/src/app/terminology/term-list/create-term-dialog/create-term-dialog.component.ts
@@ -90,12 +90,18 @@ export class CreateTermDialogComponent implements OnInit {
       return;
     }
 
+    // If no definition provided, default to using the code
+    const definition =
+      this.definition.value && this.definition.value.length > 0
+        ? this.definition.value
+        : this.code.value;
+
     this.submitting = true;
     this.resources.terms
       .save(this.data.terminology.id, {
         domainType: CatalogueItemDomainType.Term,
         code: this.code.value,
-        definition: this.definition.value ?? this.code.value,
+        definition,
         description: this.description.value
       })
       .pipe(


### PR DESCRIPTION
If no definition provided, it will auto default to the same value as the code. Definition field is now optional again.

Resolves #874 

To test:

1. Select a terminology that can be edited
2. Go to the "Terms" tab and click "Add term"
3. Enter a code but no definition, then click "Create". This should produce a term where code and definition are the same.
4. Repeat but add a code and definition that are different values. This should produce a term with the values you have set.