### PR TITLE
Add JSON reader view to profile fields that use the "json" field type

### DIFF
--- a/src/app/shared/profile-details/profile-details.component.html
+++ b/src/app/shared/profile-details/profile-details.component.html
@@ -15,7 +15,11 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<table *ngIf="this.currentProfileDetails" class="table table-bordered" role="presentation">
+<table
+  *ngIf="this.currentProfileDetails"
+  class="table table-bordered"
+  role="presentation"
+>
   <tbody *ngFor="let section of this.currentProfileDetails?.sections">
     <tr>
       <td [attr.colspan]="2" class="detailsRowHeader">
@@ -63,7 +67,8 @@ SPDX-License-Identifier: Apache-2.0
             field.dataType != 'datetime' &&
             field.dataType != 'boolean' &&
             field.dataType != 'folder' &&
-            field.dataType != 'boolean'
+            field.dataType != 'boolean' &&
+            field.dataType != 'json'
           "
           style="background-color: #ffffff; width: 100%; border: hidden"
           [readonly]="true"
@@ -94,6 +99,12 @@ SPDX-License-Identifier: Apache-2.0
         </div>
         <div *ngIf="field.dataType === 'folder'">
           {{ field.currentValue }}
+        </div>
+        <div *ngIf="field.dataType === 'json'">
+          <ngx-json-viewer
+            [json]="convertStringToJson(field.currentValue)"
+            [expanded]="true"
+          ></ngx-json-viewer>
         </div>
       </td>
     </tr>

--- a/src/app/shared/profile-details/profile-details.component.ts
+++ b/src/app/shared/profile-details/profile-details.component.ts
@@ -37,4 +37,8 @@ export class ProfileDetailsComponent {
     datetime: 'datetime',
     decimal: 'number'
   };
+
+  convertStringToJson(value: string) {
+    return JSON.parse(value);
+  }
 }


### PR DESCRIPTION
Related to MauroDataMapper-NHSD/mdm-plugin-nhs-data-dictionary#50. Example:

![image](https://github.com/MauroDataMapper/mdm-ui/assets/3219480/9392c60f-1069-483d-ab40-97e1bb2dc803)

To test:

1. Publish the `mdm-plugin-nhs-data-dictionary` plugin from the PR branch and use in your Mauro instance.
2. Use Postman to:
    1. Login as administrator
    2. Send `PUT /api/nhsdd/{versionedFolderId}/graph/{domainType}/{itemId}` request for a versioned folder and item of your choice, so long as it has a description containing various hyperlinks to other dictionary items.
3. Go to that item in MDM UI and look for a "NHS Data Dictionary - Graph" profile, then check the JSON data is rendered correctly.