### PR TITLE
gh-886 HtmlParserService now generates Mauro path URLs relative to a version or branch

### DIFF
--- a/src/app/content/html/html-editor/html-editor.component.ts
+++ b/src/app/content/html/html-editor/html-editor.component.ts
@@ -155,7 +155,11 @@ export class HtmlEditorComponent implements OnInit, OnChanges {
       }
 
       // Intercept the HTML content to render for display only so that certain parts can be altered
-      this.displayContent = this.htmlParser.parseAndModify(this.description);
+      // The version or branch override will try to force all Mauro path links to work within the same context as
+      // the containing model the root element is in, if available
+      this.displayContent = this.htmlParser.parseAndModify(this.description, {
+        versionOrBranchOverride: this.getVersionOrBranchOverride()
+      });
     }
   }
 
@@ -276,5 +280,21 @@ export class HtmlEditorComponent implements OnInit, OnChanges {
         customButtons.find((custom) => `component:${custom.name}` === button) ||
         button
     );
+  }
+
+  private getVersionOrBranchOverride() {
+    if (!this.rootElement) {
+      return undefined;
+    }
+
+    const pathableRootElement = (this.rootElement as unknown) as CatalogueItem &
+      Pathable;
+
+    if (!pathableRootElement.path) {
+      return undefined;
+    }
+
+    const pathElements = this.pathNames.parse(pathableRootElement.path);
+    return this.pathNames.getVersionOrBranchName(pathElements);
   }
 }

--- a/src/app/shared/default-profile/default-profile.component.html
+++ b/src/app/shared/default-profile/default-profile.component.html
@@ -18,17 +18,18 @@ SPDX-License-Identifier: Apache-2.0
 
 <table *ngIf="controls" class="table table-bordered mdm--table-fixed">
   <tbody>
-  <tr *ngIf="isInControlList('dataTypeDetails')" data-cy="data-type-details">
-    <th class="detailsRowHeader" scope="col">Data Type Details</th>
-    <td data-cy="value">
-      <mdm-element-data-type-details
-        *ngIf="catalogueItem"
-        [elementDataType]="catalogueItem.dataType ? catalogueItem.dataType : catalogueItem"
-      ></mdm-element-data-type-details>
-
-    </td>
-  </tr>
-  <tr *ngIf="isInControlList('code')" data-cy="code">
+    <tr *ngIf="isInControlList('dataTypeDetails')" data-cy="data-type-details">
+      <th class="detailsRowHeader" scope="col">Data Type Details</th>
+      <td data-cy="value">
+        <mdm-element-data-type-details
+          *ngIf="catalogueItem"
+          [elementDataType]="
+            catalogueItem.dataType ? catalogueItem.dataType : catalogueItem
+          "
+        ></mdm-element-data-type-details>
+      </td>
+    </tr>
+    <tr *ngIf="isInControlList('code')" data-cy="code">
       <td class="detailsRowHeader">Code</td>
       <td data-cy="value" *ngIf="catalogueItem">
         <mdm-inline-text-edit
@@ -54,7 +55,7 @@ SPDX-License-Identifier: Apache-2.0
         </mdm-inline-text-edit>
       </td>
     </tr>
-    <tr *ngIf="isInControlList('aliases')" data-cy="aliases" >
+    <tr *ngIf="isInControlList('aliases')" data-cy="aliases">
       <td class="detailsRowHeader">Aliases</td>
       <td data-cy="value">
         <mdm-element-alias
@@ -72,6 +73,7 @@ SPDX-License-Identifier: Apache-2.0
         <div *ngIf="catalogueItem">
           <mdm-content-editor
             [(content)]="catalogueItem.description"
+            [rootElement]="catalogueItem"
             [inEditMode]="false"
           ></mdm-content-editor>
         </div>
@@ -156,11 +158,13 @@ SPDX-License-Identifier: Apache-2.0
       <th class="detailsRowHeader" scope="col">Data Type</th>
       <td data-cy="value">
         <mdm-element-data-type
-        *ngIf="catalogueItem"
-        [elementDataType]="catalogueItem.dataType ? catalogueItem.dataType : catalogueItem"
-        [mcParentDataModel]="catalogueItem"
-      >
-      </mdm-element-data-type>
+          *ngIf="catalogueItem"
+          [elementDataType]="
+            catalogueItem.dataType ? catalogueItem.dataType : catalogueItem
+          "
+          [mcParentDataModel]="catalogueItem"
+        >
+        </mdm-element-data-type>
       </td>
     </tr>
 

--- a/src/app/shared/path-name/path-name.model.ts
+++ b/src/app/shared/path-name/path-name.model.ts
@@ -191,6 +191,14 @@ export const pathableDomainTypesFromPrefix = new Map<
   [PathElementType.VersionLink, 'versionLinks']
 ]);
 
+export const branchablePathTypes = [
+  PathElementType.DataModel,
+  PathElementType.Terminology,
+  PathElementType.CodeSet,
+  PathElementType.ReferenceDataModel,
+  PathElementType.VersionedFolder
+];
+
 export interface PathProperty {
   name: string;
   qualifiedName: string[];
@@ -203,3 +211,7 @@ export interface PathElement {
   version?: string;
   property?: PathProperty;
 }
+
+export const isPathElementBranchable = (pathElement: PathElement): boolean => {
+  return branchablePathTypes.includes(pathElement.type);
+};

--- a/src/app/shared/path-name/path-name.service.spec.ts
+++ b/src/app/shared/path-name/path-name.service.spec.ts
@@ -552,4 +552,64 @@ describe('PathNameService', () => {
       }
     );
   });
+
+  describe('building paths', () => {
+    it.each([undefined, null])(
+      'should return nothing when no path elements are provided',
+      (path) => {
+        const actual = service.build(path as PathElement[]);
+        expect(actual).toBeNull();
+      }
+    );
+
+    it('should return nothing when empty path elements list is provided', () => {
+      const actual = service.build([]);
+      expect(actual).toBeNull();
+    });
+
+    const pathCases = [
+      'dm:Test Data Model',
+      'dm:Test Data Model$another-branch',
+      'dm:Test Data Model$2.0.0',
+      'te:Test Terminology',
+      'cs:Test Code Set',
+      'dm:Test Data Model|dc:Test Data Class',
+      'dm:Test Data Model|dc:Test Data Class|de:Test Data Element',
+      'dm:Test Data Model@description',
+      'dm:Test Data Model$2.0.0@description',
+      'dm:Test Data Model@rule:rule-representation',
+      'dm:Test Data Model|dc:Test Data Class@description',
+      'dm:Test Data Model$test-branch|dc:Test Data Class@description'
+    ];
+
+    it.each(pathCases)(
+      'when building %p then the correct string is returned',
+      (expected) => {
+        const pathElements = service.parse(expected);
+        const actual = service.build(pathElements);
+        expect(actual).toBe(expected);
+      }
+    );
+  });
+
+  describe('get branch name', () => {
+    it.each([
+      ['', 'dm:Data Model'],
+      ['main', 'dm:Data Model$main'],
+      ['another-branch', 'dm:Data Model$another-branch'],
+      ['main', 'dm:Data Model$main|dc:Data Class'],
+      ['another-branch', 'dm:Data Model$another-branch|dc:Data Class'],
+      ['main', 'te:Terminology$main'],
+      ['another-branch', 'te:Terminology$another-branch'],
+      ['main', 'te:Terminology$main|tm:Term'],
+      ['another-branch', 'te:Terminology$another-branch|tm:Term']
+    ])(
+      'should return branch name %p when given the path %p',
+      (branchName, path) => {
+        const pathElements = service.parse(path);
+        const actual = service.getVersionOrBranchName(pathElements);
+        expect(actual).toBe(branchName);
+      }
+    );
+  });
 });


### PR DESCRIPTION
Resolves #886 

# Overview

- HtmlEditor will determine the version/branch the content is relative to based on the provided root element
- If known, all paths found in the HTML source description text will be rewritten as valid URLs and patched to work relative to the version/branch selected

In the example below, notice that the current item is under a branch called "CR1234 - Test Branch". This means the hyperlinks in the description field have automatically been adjusted to also use that branch name.

![image](https://github.com/user-attachments/assets/70824bb9-ec5c-4d2f-92da-2a5b9816ae31)

# Testing

1. Create an NHS Data Dictionary branch called `main`
2. Create another NHS Data Dictionary branch with a different name
3. Under `main`, navigate to items with descriptions and check the hyperlinks. These links to navigate successfully to items also under the `main` branch.
4. Repeat step 3 but in the other branch - this time, hyperlinks should navigate successfully to items under the other branch name, _not_ the `main` branch