### PR TITLE
gh-889 - History tab for types was not functioning

### DIFF
--- a/src/app/data-type/data-type.component.html
+++ b/src/app/data-type/data-type.component.html
@@ -120,7 +120,7 @@ SPDX-License-Identifier: Apache-2.0
           (totalCount)="historyCountEmitter($event)"
           *ngIf="dataType"
           [parent]="dataType"
-          [domainType]="'dataTypes'"
+          [domainType]="typeOfDataType"
         ></mdm-history>
       </div>
     </mat-tab>

--- a/src/app/data-type/data-type.component.ts
+++ b/src/app/data-type/data-type.component.ts
@@ -96,6 +96,10 @@ export class DataTypeComponent
     super();
   }
 
+  get typeOfDataType() {
+    return this.dataType.domainType;
+  }
+
   ngOnInit() {
     this.id = this.uiRouterGlobals.params.id;
     this.dataModelId = this.uiRouterGlobals.params.dataModelId;


### PR DESCRIPTION
Closes #889 

History tab of data types did not work because it was not modifying the endpoint called based on the type of dataType.
added a getter that grabs that info and forwards it to the history tab.

To test: 

1. Create changes in a variety of data type under a data model - either create a type, modify a type, merge changes from a type into another branch or add a rule. (possible future improvement, adding a rule does not refresh the history tab)
2. View the data type
3. Click on the "History" tab.
4. Note all the shiny entries

![image](https://github.com/user-attachments/assets/3f25809c-53f5-418b-bef2-f90dcea08a43)
