### PR TITLE
Feature/gh 890   pagination in history tab

### DIFF
--- a/src/app/shared/history/history.component.html
+++ b/src/app/shared/history/history.component.html
@@ -171,13 +171,14 @@ SPDX-License-Identifier: Apache-2.0
   </table>
 </div>
 <div
-class="mdm--mat-pagination"
-[ngClass]="{ 'is-hidden': totalItemCount < 6 }"
+  class="mdm--mat-pagination"
+  [ngClass]="{ 'is-hidden': totalItemCount < 6 }"
 >
-<mdm-paginator
-  [length]="totalItemCount"
-  [pageSize]="pageSize"
-  pageIndex="0"
-  showFirstLastButtons
-></mdm-paginator>
+  <mdm-paginator
+    [length]="totalItemCount"
+    [pageSize]="pageSize"
+    [pageSizeOptions]="pageSizeOptions"
+    pageIndex="0"
+    showFirstLastButtons
+  ></mdm-paginator>
 </div>

--- a/src/app/shared/history/history.component.html
+++ b/src/app/shared/history/history.component.html
@@ -171,8 +171,13 @@ SPDX-License-Identifier: Apache-2.0
   </table>
 </div>
 <div
-  class="mdm--mat-pagination"
-  [ngClass]="{ 'is-hidden': totalItemCount < 6 }"
+class="mdm--mat-pagination"
+[ngClass]="{ 'is-hidden': totalItemCount < 6 }"
 >
-  <mdm-paginator [length]="totalItemCount" showFirstLastButtons></mdm-paginator>
+<mdm-paginator
+  [length]="totalItemCount"
+  [pageSize]="pageSize"
+  pageIndex="0"
+  showFirstLastButtons
+></mdm-paginator>
 </div>

--- a/src/app/shared/history/history.component.ts
+++ b/src/app/shared/history/history.component.ts
@@ -119,7 +119,6 @@ export class HistoryComponent implements OnInit, AfterViewInit {
           );
         }),
         map((data: any) => {
-          // this is always the base item count for some reason
           this.totalItemCount = data.body.count;
           this.totalCount.emit(String(data.body.count));
           this.isLoadingResults = false;

--- a/src/app/shared/history/history.component.ts
+++ b/src/app/shared/history/history.component.ts
@@ -29,7 +29,7 @@ import {
 } from '@angular/core';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { SearchResult } from '@mdm/model/folderModel';
-import { MatSort, Sort, SortDirection } from '@angular/material/sort';
+import { MatSort, SortDirection } from '@angular/material/sort';
 import { merge } from 'rxjs';
 import { catchError, map, startWith, switchMap } from 'rxjs/operators';
 import { MdmPaginatorComponent } from '@mdm/shared/mdm-paginator/mdm-paginator';
@@ -48,6 +48,7 @@ export class HistoryComponent implements OnInit, AfterViewInit {
   @Input() parentType: string;
   @Input() parentId: string;
   @Input() domainType: string;
+  @Input() pageSize: number;
   @Output() totalCount = new EventEmitter<string>();
   @ViewChild(MatSort, { static: true }) sort: MatSort;
   public result: SearchResult;
@@ -74,12 +75,18 @@ export class HistoryComponent implements OnInit, AfterViewInit {
     private changeRef: ChangeDetectorRef
   ) {}
 
-  public getSortedData($event: Sort) {
+  public getSortedData(
+    pageSize?: number,
+    pageIndex?: number,
+    filters?: {},
+    sortBy?: string,
+    sortType?: SortDirection) {
     this.fetch(
-      this.paginator.pageSize,
-      this.paginator.pageIndex,
-      $event.active,
-      $event.direction
+      pageSize,
+      pageIndex,
+      sortBy,
+      sortType,
+      filters
     );
   }
 
@@ -112,6 +119,7 @@ export class HistoryComponent implements OnInit, AfterViewInit {
           );
         }),
         map((data: any) => {
+          // this is always the base item count for some reason
           this.totalItemCount = data.body.count;
           this.totalCount.emit(String(data.body.count));
           this.isLoadingResults = false;
@@ -132,13 +140,15 @@ export class HistoryComponent implements OnInit, AfterViewInit {
     pageSize: number,
     pageOffset: number,
     sortBy: string,
-    sortType: SortDirection
+    sortType: SortDirection,
+    filters?: {}
   ): any {
     const options = this.gridService.constructOptions(
       pageSize,
       pageOffset,
       sortBy,
-      sortType
+      sortType,
+      filters
     );
 
     if (this.parentId) {

--- a/src/app/shared/history/history.component.ts
+++ b/src/app/shared/history/history.component.ts
@@ -64,6 +64,7 @@ export class HistoryComponent implements OnInit, AfterViewInit {
   parentTypeVal;
   parentIdVal;
   isLoadingResults = true;
+  pageSizeOptions = [10, 20, 50];
 
   records: any[] = [];
   filter: any = '';
@@ -80,14 +81,9 @@ export class HistoryComponent implements OnInit, AfterViewInit {
     pageIndex?: number,
     filters?: {},
     sortBy?: string,
-    sortType?: SortDirection) {
-    this.fetch(
-      pageSize,
-      pageIndex,
-      sortBy,
-      sortType,
-      filters
-    );
+    sortType?: SortDirection
+  ) {
+    this.fetch(pageSize, pageIndex, sortBy, sortType, filters);
   }
 
   ngOnInit() {


### PR DESCRIPTION
Closes #890

Requires backend change: https://github.com/MauroDataMapper/mdm-core/pull/484

History tab was not correctly receiving the totalCount from the backend, bricking the paginator.
while I was fixing the backend I ended up changing a few things to make the code more obvious, I'd like to keep the changes

To test:
Get application build or mdm core up and running with the new backend

1. Navigate to an item in the UI and open the "History" tab
2. If there are less than 50 items in the list make edits (to the description, label etc.) until there are more than 51 items or more in the list
3. Notice that the total number displayed on the page is correct, next scroll to the bottom of the page and notice the pagination controls are working correctly
5. Rejoice (optional)