### PR TITLE
Fixes for the Element Selector dialog and link creation in HTML editor

### DIFF
--- a/src/app/content/html/html-editor/html-editor.component.ts
+++ b/src/app/content/html/html-editor/html-editor.component.ts
@@ -234,11 +234,19 @@ export class HtmlEditorComponent implements OnInit, OnChanges {
     const path =
       element.path ?? component.pathNames.createFromBreadcrumbs(element);
 
+    // Need to do this for NHS England, local paths should be used so that links can be maintained within the context of the branches
+    // they live under
+    const pathElements = this.pathNames.parse(path);
+    const pathElementsWithoutBranch = this.pathNames.removeVersionOrBranchName(
+      pathElements
+    );
+    const pathWithoutBranch = this.pathNames.build(pathElementsWithoutBranch);
+
     // The href will be the Mauro item path. This is not a valid URL, but the HtmlParserService will
     // automatically look for these paths in the content and rewrite them to correct URLs before
     // rendering for display
     const html = editor.create.fromHTML(
-      `<a href='${path}' title='${element.label}'>${element.label}</a>`
+      `<a href='${pathWithoutBranch}' title='${element.label}'>${element.label}</a>`
     );
 
     editor.selection.setCursorIn(focusNode);

--- a/src/app/shared/path-name/path-name.service.spec.ts
+++ b/src/app/shared/path-name/path-name.service.spec.ts
@@ -612,4 +612,26 @@ describe('PathNameService', () => {
       }
     );
   });
+
+  describe('remove branch name', () => {
+    it.each([
+      ['dm:Data Model$main', 'dm:Data Model'],
+      ['dm:Data Model$main|dc:Data Class', 'dm:Data Model|dc:Data Class'],
+      ['dm:Data Model$another', 'dm:Data Model'],
+      [
+        'dm:Data Model$another|dc:Data Class|de:Data Element',
+        'dm:Data Model|dc:Data Class|de:Data Element'
+      ]
+    ])(
+      'should remove the branch name from %p to give %p',
+      (originalPath, expectedPath) => {
+        const originaPathElements = service.parse(originalPath);
+        const updatedPathElements = service.removeVersionOrBranchName(
+          originaPathElements
+        );
+        const actualPath = service.build(updatedPathElements);
+        expect(actualPath).toBe(expectedPath);
+      }
+    );
+  });
 });

--- a/src/app/shared/path-name/path-name.service.ts
+++ b/src/app/shared/path-name/path-name.service.ts
@@ -183,6 +183,15 @@ export class PathNameService {
     return matching.version;
   }
 
+  removeVersionOrBranchName(pathElements: PathElement[]): PathElement[] {
+    if (!pathElements || pathElements.length === 0) {
+      return [];
+    }
+
+    pathElements.forEach((pathElement) => (pathElement.version = ''));
+    return pathElements;
+  }
+
   createHref(path: string) {
     const domain = this.getPathableDomainFromPath(path);
     return this.createHrefFromPath(domain, path);

--- a/src/app/utility/element-selector.component.html
+++ b/src/app/utility/element-selector.component.html
@@ -139,8 +139,8 @@ SPDX-License-Identifier: Apache-2.0
               [inSearchMode]="formData.inSearchMode"
               [doNotMakeSelectedBold]="true"
               [searchCriteria]="formData.treeSearchText"
-              [filterByDomainType]="['Folder', 'CodeSet']"
-              [expandOnNodeClickFor]="['Folder']"
+              [filterByDomainType]="['Folder', 'VersionedFolder', 'CodeSet']"
+              [expandOnNodeClickFor]="['Folder', 'VersionedFolder']"
               (nodeClickEvent)="onNodeInTreeSelect($event)"
               [node]="rootNode"
             ></mdm-folders-tree>
@@ -167,8 +167,8 @@ SPDX-License-Identifier: Apache-2.0
               [inSearchMode]="formData.inSearchMode"
               [doNotMakeSelectedBold]="true"
               [searchCriteria]="formData.treeSearchText"
-              [filterByDomainType]="['Folder', 'DataModel']"
-              [expandOnNodeClickFor]="['Folder']"
+              [filterByDomainType]="['Folder', 'VersionedFolder', 'DataModel']"
+              [expandOnNodeClickFor]="['Folder', 'VersionedFolder']"
               (nodeClickEvent)="onNodeInTreeSelect($event)"
               [node]="rootNode"
             ></mdm-folders-tree>
@@ -195,8 +195,18 @@ SPDX-License-Identifier: Apache-2.0
             <mdm-folders-tree
               [inSearchMode]="formData.inSearchMode"
               [doNotMakeSelectedBold]="true"
-              [filterByDomainType]="['Folder', 'DataModel', 'DataClass']"
-              [expandOnNodeClickFor]="['Folder', 'DataModel', 'DataClass']"
+              [filterByDomainType]="[
+                'Folder',
+                'VersionedFolder',
+                'DataModel',
+                'DataClass'
+              ]"
+              [expandOnNodeClickFor]="[
+                'Folder',
+                'VersionedFolder',
+                'DataModel',
+                'DataClass'
+              ]"
               [searchCriteria]="formData.treeSearchText"
               (nodeClickEvent)="onNodeInTreeSelect($event)"
               [node]="rootNode"

--- a/src/app/utility/element-selector.component.html
+++ b/src/app/utility/element-selector.component.html
@@ -228,80 +228,102 @@ SPDX-License-Identifier: Apache-2.0
                   [node]="rootNode"></mdm-folders-tree>
       </div>
   </div>-->
-
-      <div *ngIf="formData.selectedType === 'Term'">
-        <div>Please select a Term:</div>
-        <div style="padding-bottom: 1.2em">
-          <mdm-select
-            [width]="'100%'"
-            [acceptTypedInput]="false"
-            [valueType]="'static'"
-            [staticValues]="terminologies"
-            [minInputLength]="1"
-            [hasError]="false"
-            [idProperty]="'id'"
-            [displayProperty]="'label'"
-            [searchProperty]="'label'"
-            (selectEvent)="onTerminologySelect($event[0])"
-          >
-            <ng-template #lineContent let-item>
-              <mdm-element-label [item]="item"></mdm-element-label>
-            </ng-template>
-          </mdm-select>
+      <div
+        *ngIf="formData.selectedType === 'Term'"
+        style="background-color: #fff"
+      >
+        <div style="margin-bottom: 10px; margin-left: 5px">
+          Please select a {{ formData.selectedType }}
         </div>
-        <div>
+        <div style="margin-top: 10px">
           <input
             type="text"
-            id="searchInput"
+            id="dataElementsearchInput"
             class="form-control outlined-input ng-pristine ng-valid ng-touched"
             autocomplete="off"
             [(ngModel)]="searchInput"
-            #searchInputControl
+            (ngModelChange)="searchTextChanged()"
             [ngModelOptions]="{ debounce: 500 }"
-            placeholder="Search for Terms..."
-            [disabled]="noData"
-            aria-invalid="false"
+            [placeholder]="
+              formData.currentContext
+                ? 'Search within ' + formData.currentContext.label
+                : 'Search...'
+            "
           />
         </div>
+
+        <div style="margin-top: 5px">
+          <div style="margin-left: 5px">
+            Restrict your search to a context (optional):
+          </div>
+          <div style="margin-top: 2px">
+            <mdm-model-selector-tree
+              [onSelect]="onContextSelected"
+              [placeholder]="'Choose a Terminology'"
+              [accepts]="['Terminology']"
+              [usedInModalDialogue]="true"
+            >
+            </mdm-model-selector-tree>
+          </div>
+        </div>
+
         <div style="height: 240px">
           <mat-table
-            #table
             [dataSource]="dataSource"
             (scroll)="onTableScroll($event)"
             style="max-height: 100%; overflow: auto"
           >
+            <!--- Note that these columns can be defined in any order.
+                        The actual rendered columns are set as a property on the row definition" -->
             <!-- Position Column -->
             <ng-container matColumnDef="label">
-              <mat-header-row *matHeaderCellDef> Term </mat-header-row>
+              <mat-header-cell *matHeaderCellDef></mat-header-cell>
               <mat-cell
-                style="
-                  max-width: 50%;
-                  width: 50%;
-                  text-align: left;
-                  word-wrap: break-word;
-                  padding-right: 5px;
-                  padding-left: 5px;
-                "
-                mat-cell
+                style="max-width: 100%; width: 90%; text-align: left"
                 *matCellDef="let element"
               >
-                <mdm-element-link
-                  [showTypeTitle]="true"
-                  [newWindow]="true"
-                  [parentDataModel]="{ id: element.dataModel }"
-                  [parentDataClass]="{ id: element.dataClass }"
+                {{ element.label }}</mat-cell
+              >
+            </ng-container>
+
+            <!-- Expanded Content Column - The detail row is made up of this one column -->
+            <ng-container matColumnDef="expandedDetail">
+              <mat-cell *matCellDef="let record">
+                <mdm-model-path
+                  [path]="record.element.breadcrumbs"
                   [showHref]="false"
-                  [element]="element"
-                ></mdm-element-link>
+                  [newWindow]="true"
+                ></mdm-model-path>
               </mat-cell>
             </ng-container>
+
+            <mat-header-row
+              *matHeaderRowDef="displayedColumns"
+            ></mat-header-row>
+            <mat-row
+              *matRowDef="let row; columns: displayedColumns"
+              matRipple
+              class="element-row mat-table-row-select"
+              [class.expanded]="expandedElement == row"
+              (mouseover)="expandedElement = row"
+              (click)="onTermSelect(row)"
+            ></mat-row>
             <mat-row
               class="mat-table-row-select"
               (click)="onTermSelect(row)"
-              *matRowDef="let row; columns: displayedColumns"
+              *matRowDef="
+                let row;
+                columns: ['expandedDetail'];
+                when: isExpansionDetailRow
+              "
+              [@detailExpand]="
+                row.element == expandedElement ? 'expanded' : 'collapsed'
+              "
+              style="overflow: hidden"
             ></mat-row>
           </mat-table>
         </div>
+
         <div *ngIf="totalItemCount > 0" style="float: right">
           <span *ngIf="loading">
             <span class="fas fa-sync-alt fa-spin"></span>
@@ -342,8 +364,8 @@ SPDX-License-Identifier: Apache-2.0
           <div style="margin-top: 2px">
             <mdm-model-selector-tree
               [onSelect]="onContextSelected"
-              [placeholder]="'Choose a Folder or Data Model or Data Class'"
-              [accepts]="['Folder', 'DataModel', 'DataClass']"
+              [placeholder]="'Choose a Data Class'"
+              [accepts]="['DataClass']"
               [usedInModalDialogue]="true"
             >
             </mdm-model-selector-tree>
@@ -445,9 +467,9 @@ SPDX-License-Identifier: Apache-2.0
           <div style="margin-top: 2px">
             <mdm-model-selector-tree
               [onSelect]="onContextSelected"
-              [placeholder]="'Choose a Folder or Data Model'"
+              [placeholder]="'Choose a Data Model'"
               [doNotShowDataClasses]="true"
-              [accepts]="['Folder', 'DataModel']"
+              [accepts]="['DataModel']"
               [usedInModalDialogue]="true"
             >
             </mdm-model-selector-tree>

--- a/src/app/utility/element-selector.component.ts
+++ b/src/app/utility/element-selector.component.ts
@@ -48,7 +48,6 @@ import {
   FolderIndexResponse,
   MdmTreeItemListResponse,
   Terminology,
-  TerminologyIndexResponse,
   SearchQueryParameters
 } from '@maurodatamapper/mdm-resources';
 import { CatalogueSearchService } from '@mdm/catalogue-search/catalogue-search.service';

--- a/src/app/utility/element-selector.component.ts
+++ b/src/app/utility/element-selector.component.ts
@@ -185,7 +185,6 @@ export class ElementSelectorComponent implements OnInit {
 
     if (this.formData.selectedType === 'Term') {
       this.showPrevBtn = true;
-      this.loadTerminologies();
     }
     this.showPrevBtn = true;
   }
@@ -227,36 +226,6 @@ export class ElementSelectorComponent implements OnInit {
       },
       () => {
         this.loading = false;
-      }
-    );
-  };
-
-  loadTerminologies = () => {
-    this.reloading = true;
-    this.resourceService.terminology.list({ all: true }).subscribe(
-      (res: TerminologyIndexResponse) => {
-        if (
-          this.data.notAllowedToSelectIds &&
-          this.data.notAllowedToSelectIds.length > 0
-        ) {
-          let i = res.body.items.length - 1;
-          while (i >= 0) {
-            let found = false;
-            this.data.notAllowedToSelectIds.forEach((terminologyId) => {
-              if (terminologyId === res.body.items[i].id) {
-                found = true;
-              }
-            });
-            if (found) {
-              res.body.items.splice(i, 1);
-            }
-            i--;
-          }
-        }
-        this.terminologies = res.body.items;
-      },
-      () => {
-        this.reloading = false;
       }
     );
   };


### PR DESCRIPTION
Resolves #882 

# Overview

Fixed the element selector dialog when using the HTML editor, triggered by this button:

![image](https://github.com/user-attachments/assets/b6382e9b-7678-4479-b901-24b800cff1f8)

All element types can now expand the model trees so that versioned folders are included:

![image](https://github.com/user-attachments/assets/c075da67-845b-40f3-9576-b1546d99a9e2)

I've updated the Terms selection to work without loading every Terminology in the catalogue, restrict to a context:

![image](https://github.com/user-attachments/assets/b8e764f3-b3a3-45d7-8c4d-e7959cfb090b)

And I've updated the creation of the hyperlink when added to the HTML editor to remove the branch name from the path in the link. This is because all links should be considered local to the branch they are directly under, other link rewriting code will automatically fill in a branch so the links work correctly, but they must be saved to Mauro without branches in them.

# Testing

1. Test the Element Selector - make sure that you can create a link of every type
2. Test that the links created in the HTML editor work and are constrained to the branch they are under, even if you select an element from another versioned folder branch.