### PR TITLE
gh-896 Fix copy screen so that it works for child data classes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -530,7 +530,7 @@ export const pageRoutes: { states: Ng2StateDeclaration[] } = {
     },
     {
       name: 'appContainer.mainApp.twoSidePanel.catalogue.dataClassCopy',
-      url: '/:domainType/:dataModelId/copy/:id/',
+      url: '/:domainType/:dataModelId/:dataClassId/copy/:id/',
       component: CopyActionComponent
     },
     {

--- a/src/app/mauro/mauro-item-provider.service.ts
+++ b/src/app/mauro/mauro-item-provider.service.ts
@@ -184,7 +184,7 @@ export class MauroItemProviderService {
     }
 
     const dataClassId = identifier.parentDataClass ?? identifier.dataClass;
-    if (dataClassId) {
+    if (dataClassId && dataClassId !== '') {
       return this.resources.dataClass.getChildDataClass(
         identifier.model,
         dataClassId,

--- a/src/app/model-header/model-header.component.ts
+++ b/src/app/model-header/model-header.component.ts
@@ -194,21 +194,35 @@ export class ModelHeaderComponent implements OnInit {
       return false;
     }
 
-    if (![CatalogueItemDomainType.DataModel, CatalogueItemDomainType.Terminology, CatalogueItemDomainType.CodeSet,  CatalogueItemDomainType.DataClass, CatalogueItemDomainType.DataElement, CatalogueItemDomainType.Term].includes(this.item.domainType)) {
+    if (
+      ![
+        CatalogueItemDomainType.DataModel,
+        CatalogueItemDomainType.Terminology,
+        CatalogueItemDomainType.CodeSet,
+        CatalogueItemDomainType.DataClass,
+        CatalogueItemDomainType.DataElement,
+        CatalogueItemDomainType.Term
+      ].includes(this.item.domainType)
+    ) {
       return false;
     }
 
-    if ([CatalogueItemDomainType.DataModel, CatalogueItemDomainType.Terminology, CatalogueItemDomainType.CodeSet].includes(this.item.domainType)) {
+    if (
+      [
+        CatalogueItemDomainType.DataModel,
+        CatalogueItemDomainType.Terminology,
+        CatalogueItemDomainType.CodeSet
+      ].includes(this.item.domainType)
+    ) {
       // need to check it is in a versionedfolder
       // has a ancestor with a domaintype.versionedfolder property
-      return this.ancestorTreeItems.some(item => item.domainType === CatalogueItemDomainType.VersionedFolder);
-
+      return this.ancestorTreeItems.some(
+        (item) => item.domainType === CatalogueItemDomainType.VersionedFolder
+      );
     }
 
     return this.item.availableActions.includes('update');
   }
-
-
 
   get hasMenuOptions() {
     if (!this.item) {
@@ -290,7 +304,8 @@ export class ModelHeaderComponent implements OnInit {
         return this.stateHandler.Go('dataClassCopy', {
           id: this.item.id,
           domainType: this.item.domainType,
-          dataModelId: this.item.model
+          dataModelId: this.item.model,
+          dataClassId: this.item.parentDataClass ?? ''
         });
       }
       case CatalogueItemDomainType.DataElement: {

--- a/src/app/shared/copy-action/copy-action.component.html
+++ b/src/app/shared/copy-action/copy-action.component.html
@@ -16,12 +16,12 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-<div *ngIf="source">
+<div *ngIf="sourceItem">
   <div class="mdm--shadow-block">
     <div class="panel">
       <div class="panel-heading">
         <div class="heading-container">
-          <h4>Create copy of "{{ source.label }}"</h4>
+          <h4>Create copy of "{{ sourceItem.label }}"</h4>
         </div>
 
         <div class="mb-2">
@@ -34,8 +34,8 @@ SPDX-License-Identifier: Apache-2.0
           <div class="panel-body">
             <div class="mb-2 mt-2">
               <p>
-                A new copy of <strong>{{ source.label }}</strong> keeps all of
-                the following:
+                A new copy of <strong>{{ sourceItem.label }}</strong> keeps all
+                of the following:
               </p>
               <ul>
                 <li *ngIf="domainType === 'VersionedFolder'">Models</li>
@@ -63,7 +63,7 @@ SPDX-License-Identifier: Apache-2.0
                         />
                         <mat-hint
                           >The name should be different from the current name
-                          '{{ source.label }}'</mat-hint
+                          '{{ sourceItem.label }}'</mat-hint
                         >
                         <mat-error *ngIf="setupForm && label?.errors?.required">
                           Please enter a label
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
                           *ngIf="setupForm && label?.errors?.forbiddenName"
                         >
                           Please choose a different label than '{{
-                            source.label
+                            sourceItem.label
                           }}'
                         </mat-error>
                       </mat-form-field>
@@ -118,14 +118,15 @@ SPDX-License-Identifier: Apache-2.0
                   </div>
                 </div>
                 <div *ngIf="destinationSelector === 'datamodels'">
-                  <mat-label>Destination DataModel</mat-label>
+                  <mat-label>Destination DataModel or DataClass</mat-label>
                   <div class="destination">
                     <mdm-folders-tree
                       tree-name="'DataModels'"
                       [filterByDomainType]="[
                         'Folder',
                         'VersionedFolder',
-                        'DataModel'
+                        'DataModel',
+                        'DataClass'
                       ]"
                       [node]="tree"
                       (nodeClickEvent)="onNodeInTreeSelect($event)"


### PR DESCRIPTION
Resolves #896 

Depends on:

- MauroDataMapper/mdm-resources#118

Changes:

- Update the URL route to provide a parent data class ID
- Improve the fetch of the source item to copy
- Use new mdm-resources endpoint
- Send correct IDs for copying the child data class

To test this works, follow the steps explained in the original issue, then also test that copying the other item types still work.