### PR TITLE
gh-894 Fixed pagination and sorting on data classes and data elements tables

### DIFF
--- a/src/app/model-header/model-header.component.ts
+++ b/src/app/model-header/model-header.component.ts
@@ -260,7 +260,6 @@ export class ModelHeaderComponent implements OnInit {
           this.ancestorTreeItems = ancestorTreeItems.filter(
             (treeItem) => treeItem.id !== this.item.id
           );
-          console.log(this.ancestorTreeItems);
         });
     }
   }

--- a/src/app/shared/data-class-components-list/data-class-components-list.component.html
+++ b/src/app/shared/data-class-components-list/data-class-components-list.component.html
@@ -15,8 +15,18 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<div *ngIf="!isLoadingClassResults && !isLoadingElementResults && !totalDataClassCount && !totalDataElementCount && !elementFilter && !classFilter" class="pxy-2">
-  <div *ngIf="isEditable" style="width: 100%; text-align: right;" >
+<div
+  *ngIf="
+    !isLoadingClassResults &&
+    !isLoadingElementResults &&
+    !totalDataClassCount &&
+    !totalDataElementCount &&
+    !elementFilter &&
+    !classFilter
+  "
+  class="pxy-2"
+>
+  <div *ngIf="isEditable" style="width: 100%; text-align: right">
     <button
       mat-flat-button
       color="primary"
@@ -37,11 +47,10 @@ SPDX-License-Identifier: Apache-2.0
       <span class="fas fa-plus" aria-hidden="true"></span>
       Add Data Element
     </button>
-
   </div>
   <p>
     This Data Class has no contents: data classes or data elements
-    <br/>
+    <br />
     <span *ngIf="isEditable">
       Click one of the buttons above to begin adding content to this Data Class
     </span>
@@ -69,10 +78,14 @@ SPDX-License-Identifier: Apache-2.0
       >
         <h4 class="marginless">
           <span>Data Classes</span>
-          <mdm-skeleton-badge *ngIf="isLoadingClassResults"></mdm-skeleton-badge>
-          <span class="mdm--badge mdm--element-count" *ngIf="!isLoadingClassResults">{{
-            totalDataClassCount
-          }}</span>
+          <mdm-skeleton-badge
+            *ngIf="isLoadingClassResults"
+          ></mdm-skeleton-badge>
+          <span
+            class="mdm--badge mdm--element-count"
+            *ngIf="!isLoadingClassResults"
+            >{{ totalDataClassCount }}</span
+          >
           <span
             class="fas fa-filter"
             (click)="classFilterClick()"
@@ -99,9 +112,15 @@ SPDX-License-Identifier: Apache-2.0
             *ngIf="bulkClassActionsVisible > 0"
           >
             Bulk actions
-            <span class="fas fa-caret-down fa-xs" style="margin-left: 2px"></span>
+            <span
+              class="fas fa-caret-down fa-xs"
+              style="margin-left: 2px"
+            ></span>
           </button>
-          <mat-menu #contentClassBulkActions="matMenu" class="mdm--mat-menu--actions">
+          <mat-menu
+            #contentClassBulkActions="matMenu"
+            class="mdm--mat-menu--actions"
+          >
             <button mat-menu-item (click)="bulkEditClass()">
               <span class="fas fa-pencil-alt"></span> Edit selected rows
             </button>
@@ -120,7 +139,12 @@ SPDX-License-Identifier: Apache-2.0
             <span class="fas fa-plus" aria-hidden="true"></span>
             Add Data Class
           </button>
-          <button *ngIf="!isLoadingElementResults && !totalDataElementCount && !elementFilter"
+          <button
+            *ngIf="
+              !isLoadingElementResults &&
+              !totalDataElementCount &&
+              !elementFilter
+            "
             mat-flat-button
             color="primary"
             type="button"
@@ -137,7 +161,7 @@ SPDX-License-Identifier: Apache-2.0
   <div class="table-responsive">
     <table
       mat-table
-      #tableDataClasses
+      #tableDataClasses="matSort"
       matSort
       cdkDropList
       (cdkDropListDropped)="dropClassItem($event)"
@@ -158,7 +182,12 @@ SPDX-License-Identifier: Apache-2.0
           <div [hidden]="hideClassFilters">
             <mat-form-field class="filter" floatLabel="never">
               <mat-label>Name</mat-label>
-              <input #classFilters matInput name="label" (keyup)="applyClassFilter()" />
+              <input
+                #classFilters
+                matInput
+                name="label"
+                (keyup)="applyClassFilter()"
+              />
             </mat-form-field>
           </div>
         </th>
@@ -218,7 +247,9 @@ SPDX-License-Identifier: Apache-2.0
             *ngIf="record.description && record.description.length > 0"
             style="margin-bottom: 10px"
           >
-            <span style="font-style: italic; font-size: 11px">Description:</span>
+            <span style="font-style: italic; font-size: 11px"
+              >Description:</span
+            >
             <mdm-more-description
               description="{{ record.description }}"
             ></mdm-more-description>
@@ -313,7 +344,9 @@ SPDX-License-Identifier: Apache-2.0
     [ngClass]="{ 'is-hidden': totalDataClassCount < 6 }"
   >
     <mdm-paginator
+      #classPaginator
       [length]="totalDataClassCount"
+      [pageSizeOptions]="pageSizeOptions"
       showFirstLastButtons
     ></mdm-paginator>
   </div>
@@ -321,7 +354,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <!-- Elements Below here -->
 <div [hidden]="!totalDataElementCount && !elementFilter">
-  <div class="heading-container" >
+  <div class="heading-container">
     <div
       fxFlex
       fxLayout="row"
@@ -341,10 +374,14 @@ SPDX-License-Identifier: Apache-2.0
       >
         <h4 class="marginless">
           <span>Data Elements</span>
-          <mdm-skeleton-badge *ngIf="isLoadingElementResults"></mdm-skeleton-badge>
-          <span class="mdm--badge mdm--element-count" *ngIf="!isLoadingElementResults">{{
-            totalDataElementCount
-            }}</span>
+          <mdm-skeleton-badge
+            *ngIf="isLoadingElementResults"
+          ></mdm-skeleton-badge>
+          <span
+            class="mdm--badge mdm--element-count"
+            *ngIf="!isLoadingElementResults"
+            >{{ totalDataElementCount }}</span
+          >
           <span
             class="fas fa-filter"
             (click)="elementFilterClick()"
@@ -371,9 +408,15 @@ SPDX-License-Identifier: Apache-2.0
             *ngIf="bulkElementActionsVisible > 0"
           >
             Bulk actions
-            <span class="fas fa-caret-down fa-xs" style="margin-left: 2px"></span>
+            <span
+              class="fas fa-caret-down fa-xs"
+              style="margin-left: 2px"
+            ></span>
           </button>
-          <mat-menu #contentElementBulkActions="matMenu" class="mdm--mat-menu--actions">
+          <mat-menu
+            #contentElementBulkActions="matMenu"
+            class="mdm--mat-menu--actions"
+          >
             <button mat-menu-item (click)="bulkEditElement()">
               <span class="fas fa-pencil-alt"></span> Edit selected rows
             </button>
@@ -382,7 +425,10 @@ SPDX-License-Identifier: Apache-2.0
               <span class="far fa-trash-alt"></span> Delete selected rows
             </button>
           </mat-menu>
-          <button *ngIf="!isLoadingClassResults && !totalDataClassCount && !classFilter"
+          <button
+            *ngIf="
+              !isLoadingClassResults && !totalDataClassCount && !classFilter
+            "
             mat-flat-button
             color="primary"
             type="button"
@@ -409,7 +455,7 @@ SPDX-License-Identifier: Apache-2.0
   <div class="table-responsive">
     <table
       mat-table
-      #tableDataElements
+      #tableDataElements="matSort"
       matSort
       cdkDropList
       (cdkDropListDropped)="dropElementItem($event)"
@@ -430,7 +476,12 @@ SPDX-License-Identifier: Apache-2.0
           <div [hidden]="hideElementFilters">
             <mat-form-field class="filter" floatLabel="never">
               <mat-label>Name</mat-label>
-              <input #elementFilters matInput name="label" (keyup)="applyElementFilter()" />
+              <input
+                #elementFilters
+                matInput
+                name="label"
+                (keyup)="applyElementFilter()"
+              />
             </mat-form-field>
           </div>
         </th>
@@ -448,7 +499,7 @@ SPDX-License-Identifier: Apache-2.0
               title="Reference: {{
                 record.breadcrumbs | joinArray: ' / ':'label'
               }} / {{ record.label }}"
-            >External Reference &nbsp;<span class="fas fa-info-circle"></span
+              >External Reference &nbsp;<span class="fas fa-info-circle"></span
             ></span>
           </div>
         </td>
@@ -481,7 +532,9 @@ SPDX-License-Identifier: Apache-2.0
             *ngIf="record.description && record.description.length > 0"
             style="margin-bottom: 10px"
           >
-            <span style="font-style: italic; font-size: 11px">Description:</span>
+            <span style="font-style: italic; font-size: 11px"
+              >Description:</span
+            >
             <mdm-more-description
               description="{{ record.description }}"
             ></mdm-more-description>
@@ -585,7 +638,9 @@ SPDX-License-Identifier: Apache-2.0
     [ngClass]="{ 'is-hidden': totalDataElementCount < 6 }"
   >
     <mdm-paginator
+      #elementPaginator
       [length]="totalDataElementCount"
+      [pageSizeOptions]="pageSizeOptions"
       showFirstLastButtons
     ></mdm-paginator>
   </div>

--- a/src/app/shared/data-class-components-list/data-class-components-list.component.ts
+++ b/src/app/shared/data-class-components-list/data-class-components-list.component.ts
@@ -55,17 +55,23 @@ import { EditingService } from '@mdm/services/editing.service';
   styleUrls: ['./data-class-components-list.component.scss']
 })
 export class DataClassComponentsListComponent implements AfterViewInit {
-  @ViewChildren('classFilters', { read: ElementRef }) classFilters: ElementRef[];
-  @ViewChildren('elementFilters', { read: ElementRef }) elementFilters: ElementRef[];
+  @ViewChildren('classFilters', { read: ElementRef })
+  classFilters: ElementRef[];
+  @ViewChildren('elementFilters', { read: ElementRef })
+  elementFilters: ElementRef[];
 
-  @ViewChild(MatSort, { static: false }) classSort: MatSort;
-  @ViewChild(MatSort, { static: false }) elementSort: MatSort;
+  @ViewChild('tableDataClasses', { static: false }) classSort: MatSort;
+  @ViewChild('tableDataElements', { static: false }) elementSort: MatSort;
 
-  @ViewChild(MdmPaginatorComponent, { static: true }) classPaginator: MdmPaginatorComponent;
-  @ViewChild(MdmPaginatorComponent, { static: true }) elementPaginator: MdmPaginatorComponent;
+  @ViewChild('classPaginator', { static: true })
+  classPaginator: MdmPaginatorComponent;
+  @ViewChild('elementPaginator', { static: true })
+  elementPaginator: MdmPaginatorComponent;
 
   @ViewChild(MatTable, { static: false }) classTable: MatTable<DataClassDetail>;
-  @ViewChild(MatTable, { static: false }) elementTable: MatTable<DataElementDetail>;
+  @ViewChild(MatTable, { static: false }) elementTable: MatTable<
+    DataElementDetail
+  >;
 
   @Input() parentDataModel: DataModelDetail;
   @Input() grandParentDataClass: DataClassDetail;
@@ -97,6 +103,7 @@ export class DataClassComponentsListComponent implements AfterViewInit {
   bulkElementActionsVisible = 0;
 
   isOrderedDataSource = false;
+  pageSizeOptions = [10, 20, 50];
 
   constructor(
     private resources: MdmResourcesService,
@@ -110,18 +117,34 @@ export class DataClassComponentsListComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     if (this.isEditable && !this.parentDataModel.finalised) {
-      this.displayedClassColumns = ['name', 'description', 'multiplicity', 'checkbox'];
-      this.displayedElementColumns = ['name', 'description', 'multiplicity', 'checkbox'];
+      this.displayedClassColumns = [
+        'name',
+        'description',
+        'multiplicity',
+        'checkbox'
+      ];
+      this.displayedElementColumns = [
+        'name',
+        'description',
+        'multiplicity',
+        'checkbox'
+      ];
     } else {
       this.displayedClassColumns = ['name', 'description', 'multiplicity'];
       this.displayedElementColumns = ['name', 'description', 'multiplicity'];
     }
     this.changeRef.detectChanges();
-    this.classSort?.sortChange.subscribe(() => (this.classPaginator.pageIndex = 0));
-    this.elementSort?.sortChange.subscribe(() => (this.elementPaginator.pageIndex = 0));
+    this.classSort?.sortChange.subscribe(
+      () => (this.classPaginator.pageIndex = 0)
+    );
+    this.elementSort?.sortChange.subscribe(
+      () => (this.elementPaginator.pageIndex = 0)
+    );
 
     this.filterClassEvent.subscribe(() => (this.classPaginator.pageIndex = 0));
-    this.filterElementEvent.subscribe(() => (this.elementPaginator.pageIndex = 0));
+    this.filterElementEvent.subscribe(
+      () => (this.elementPaginator.pageIndex = 0)
+    );
 
     this.loadDataClasses();
     this.loadDataElements();
@@ -130,7 +153,11 @@ export class DataClassComponentsListComponent implements AfterViewInit {
   }
 
   loadDataClasses() {
-    merge(this.classSort?.sortChange, this.classPaginator?.page, this.filterClassEvent)
+    merge(
+      this.classSort?.sortChange,
+      this.classPaginator?.page,
+      this.filterClassEvent
+    )
       .pipe(
         startWith({}),
         switchMap(() => {
@@ -174,7 +201,11 @@ export class DataClassComponentsListComponent implements AfterViewInit {
       });
   }
   loadDataElements() {
-    merge(this.elementSort?.sortChange, this.elementPaginator?.page, this.filterElementEvent)
+    merge(
+      this.elementSort?.sortChange,
+      this.elementPaginator?.page,
+      this.filterElementEvent
+    )
       .pipe(
         startWith({}),
         switchMap(() => {
@@ -182,7 +213,10 @@ export class DataClassComponentsListComponent implements AfterViewInit {
           this.isOrderedDataSource = true;
           if (!this.elementSort?.direction) {
             this.isOrderedDataSource = false;
-            [this.elementSort.active, this.elementSort.direction] = ['idx', 'asc'];
+            [this.elementSort.active, this.elementSort.direction] = [
+              'idx',
+              'asc'
+            ];
           }
           return this.dataElementsFetch(
             this.elementPaginator?.pageSize,
@@ -237,7 +271,6 @@ export class DataClassComponentsListComponent implements AfterViewInit {
     );
   }
 
-
   applyClassFilter() {
     const classFilter = {};
     this.classFilters.forEach((x: any) => {
@@ -265,7 +298,6 @@ export class DataClassComponentsListComponent implements AfterViewInit {
     this.filterElementEvent.emit(elementFilter);
   }
 
-
   classFilterClick() {
     this.hideClassFilters = !this.hideClassFilters;
   }
@@ -273,7 +305,6 @@ export class DataClassComponentsListComponent implements AfterViewInit {
   elementFilterClick() {
     this.hideElementFilters = !this.hideElementFilters;
   }
-
 
   dataClassesFetch(
     pageSize?: number,
@@ -320,12 +351,16 @@ export class DataClassComponentsListComponent implements AfterViewInit {
   }
 
   onClassChecked() {
-    this.dataClassRecords.forEach((x) => (x.checked = this.checkAllClassCheckbox));
+    this.dataClassRecords.forEach(
+      (x) => (x.checked = this.checkAllClassCheckbox)
+    );
     this.classListChecked();
   }
 
   onElementChecked() {
-    this.dataElementRecords.forEach((x) => (x.checked = this.checkAllElementCheckbox));
+    this.dataElementRecords.forEach(
+      (x) => (x.checked = this.checkAllElementCheckbox)
+    );
     this.elementListChecked();
   }
 


### PR DESCRIPTION
Resolves #894 

# Overview

- @ViewChild was used to select the pagination/sorting components but was not specifying which ones to map to (the whole component shows two tables). So observable events were not being captured when paging or sorting
- Added page size options to the tables too

![image](https://github.com/user-attachments/assets/ab332780-9acf-4bce-b453-d6959102fa90)

# Testing

1. Sign in the MDM UI
2. View one of the NHS Data Dictionary branches, then go to "Data Elements" then one of the letters - these should contain enough data elements beyond 10.
3. Click on the "Contents" tab
4. Scroll down to the paginator, then try clicking next/previous page buttons and adjust the page size option. The table should refresh with new rows
5. Also test sorting the table columns, these should now work too.
6. If you can find a Data Class with multiple sub-data classes, then test that too - but this is optional.