### PR TITLE
Fix the 'add all' button to add all terms from a terminology to a codeset on creation.

### DIFF
--- a/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
+++ b/src/app/utility/multiple-terms-selector/multiple-terms-selector.component.ts
@@ -55,7 +55,9 @@ export class MultipleTermsSelectorComponent {
   @Input() hideAddButton = true;
 
   @Output() selectedTermsChange = new EventEmitter<any[]>();
+  @Output() selectedTerminologyChange = new EventEmitter<any[]>();
   @Output() addingTerms = new EventEmitter<Term[]>();
+  @Output() addAllTerms = false;
 
   @ViewChild('searchInputTerms', { static: true })
   dataSource = new MatTableDataSource<Term>();
@@ -79,7 +81,6 @@ export class MultipleTermsSelectorComponent {
     loading: false
   };
   loading = false;
-  addAllTerms = false;
 
   searchInputTerms: ElementRef;
   currentRecord: number;
@@ -150,6 +151,7 @@ export class MultipleTermsSelectorComponent {
       this.totalItemCount = 0;
       this.currentRecord = 0;
     }
+    this.selectedTerminologyChange.emit(this.selectorSection.selectedTerminology);
   }
 
   runTermSearch() {

--- a/src/app/wizards/codeSet/code-set-main/code-set-main.component.html
+++ b/src/app/wizards/codeSet/code-set-main/code-set-main.component.html
@@ -59,7 +59,7 @@ SPDX-License-Identifier: Apache-2.0
     </div>
 
     <mdm-element-classifications [readOnly]="false" (classificationsChanged)="classifiersValue = $event" class="mb-2"></mdm-element-classifications>
-    <mdm-multiple-terms-selector (selectedTerminologyChange)="terminologiesValue=$event" (selectedTermsChange)="termsValue = $event"></mdm-multiple-terms-selector>
+    <mdm-multiple-terms-selector (selectedTerminologyChange)="terminologyValue=$event" (selectedTermsChange)="termsValue = $event"></mdm-multiple-terms-selector>
     <mat-error *ngIf="setupForm && terms.errors?.required">
       At least one term is required
     </mat-error>

--- a/src/app/wizards/codeSet/code-set-main/code-set-main.component.html
+++ b/src/app/wizards/codeSet/code-set-main/code-set-main.component.html
@@ -59,7 +59,7 @@ SPDX-License-Identifier: Apache-2.0
     </div>
 
     <mdm-element-classifications [readOnly]="false" (classificationsChanged)="classifiersValue = $event" class="mb-2"></mdm-element-classifications>
-    <mdm-multiple-terms-selector (selectedTermsChange)="termsValue = $event"></mdm-multiple-terms-selector>
+    <mdm-multiple-terms-selector (selectedTerminologyChange)="terminologiesValue=$event" (selectedTermsChange)="termsValue = $event"></mdm-multiple-terms-selector>
     <mat-error *ngIf="setupForm && terms.errors?.required">
       At least one term is required
     </mat-error>

--- a/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
+++ b/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
@@ -49,7 +49,9 @@ export class CodeSetMainComponent implements OnInit {
     organisation: new FormControl(''), // eslint-disable-line @typescript-eslint/unbound-method
     description: new FormControl(''),
     classifiers: new FormControl([]),
-    terms: new FormControl([]) // eslint-disable-line @typescript-eslint/unbound-method
+    terms: new FormControl([]), // eslint-disable-line @typescript-eslint/unbound-method
+    terminology: new FormControl([]),
+    addAllTerms: new FormControl(false)
   });
 
   get label() {
@@ -76,12 +78,24 @@ export class CodeSetMainComponent implements OnInit {
     this.classifiers.setValue(value);
   }
 
+  get addAllTerms() {
+    return this.setupForm.controls.addAllTerms;
+  }
+
   get terms() {
     return this.setupForm.controls.terms;
   }
 
+  get terminology() {
+    return this.setupForm.controls.terminology;
+  }
+
   set termsValue(value: any[]) {
     this.terms.setValue(value);
+  }
+
+  set terminologiesValue(value: any[]) {
+    this.terminology.setValue(value);
   }
 
   constructor(
@@ -127,7 +141,8 @@ export class CodeSetMainComponent implements OnInit {
       description: this.description.value,
       classifiers: this.classifiers.value,
       folder: this.parentFolderId,
-      terms: this.terms.value
+      terms: this.terms.value,
+      terminologies: this.addAllTerms? [this.terminology.value] : null
     };
 
     this.resources.codeSet

--- a/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
+++ b/src/app/wizards/codeSet/code-set-main/code-set-main.component.ts
@@ -50,7 +50,7 @@ export class CodeSetMainComponent implements OnInit {
     description: new FormControl(''),
     classifiers: new FormControl([]),
     terms: new FormControl([]), // eslint-disable-line @typescript-eslint/unbound-method
-    terminology: new FormControl([]),
+    terminology: new FormControl({ id: ''}),
     addAllTerms: new FormControl(false)
   });
 
@@ -94,7 +94,7 @@ export class CodeSetMainComponent implements OnInit {
     this.terms.setValue(value);
   }
 
-  set terminologiesValue(value: any[]) {
+  set terminologyValue(value: any) {
     this.terminology.setValue(value);
   }
 


### PR DESCRIPTION
Relies on changes to mdm-resources and mdm-core.  Fixes #881