### PR TITLE
Jodit updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "core-js": "3.44.0",
         "diff-match-patch": "1.0.5",
         "dmn-js": "10.3.0",
-        "jodit": "4.6.2",
+        "jodit": "4.7.9",
         "jszip": "3.10.1",
         "lodash": "4.17.21",
         "marked": "4.0.10",
@@ -7844,16 +7844,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/autobind-decorator": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
-      "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.10",
-        "npm": ">=6.4.1"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -14016,13 +14006,9 @@
       }
     },
     "node_modules/jodit": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/jodit/-/jodit-4.6.2.tgz",
-      "integrity": "sha512-euIYTOBzZO04jroi79RvhRiXVs3ANCSg5JC8HOT/gf81dIdduxUKvkM4lVSdVP28aZBxs0u+nIdLC7OGXh1jhg==",
-      "license": "MIT",
-      "dependencies": {
-        "autobind-decorator": "^2.4.0"
-      }
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/jodit/-/jodit-4.7.9.tgz",
+      "integrity": "sha512-dPlewnu2+vVXELh9BEJTNQoSBL3Cf2E0fNh30yjSEgUtJHYSUYToDjMDEqr0T/L9iNpqPTODy2b4pzyGpPRUog=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "core-js": "3.44.0",
     "diff-match-patch": "1.0.5",
     "dmn-js": "10.3.0",
-    "jodit": "4.6.2",
+    "jodit": "4.7.9",
     "jszip": "3.10.1",
     "lodash": "4.17.21",
     "marked": "4.0.10",

--- a/src/app/content/html/html-editor/html-editor.component.ts
+++ b/src/app/content/html/html-editor/html-editor.component.ts
@@ -147,7 +147,8 @@ export class HtmlEditorComponent implements OnInit, OnChanges {
       buttons,
       buttonsMD: buttons,
       buttonsSM: buttons,
-      buttonsXS: buttons
+      buttonsXS: buttons,
+      sourceEditor: 'ace',
     };
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,18 @@ import { adminPageRoutes } from '@mdm/modules/admin-routes/admin-routes.module';
 import { ModuleRegistry } from '@ag-grid-community/core';
 import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
 
+import 'jodit/esm/plugins/source/source.js';
+import 'jodit/esm/plugins/source/editor/engines/ace.js';
+import 'jodit/esm/plugins/inline-popup/inline-popup.js';
+
+// ACE core
+import 'ace-builds/src-noconflict/ace.js';
+
+// ACE modes & themes Jodit expects
+import 'ace-builds/src-noconflict/mode-html.js';
+import 'ace-builds/src-noconflict/ext-searchbox.js';
+import 'ace-builds/src-noconflict/theme-chrome.js';
+
 if (environment.production) {
   enableProdMode();
   if (window) {

--- a/src/style/_default.scss
+++ b/src/style/_default.scss
@@ -346,6 +346,13 @@ span.mchighlighter {
   width: 2em;
 }
 
+.jodit-popup {
+  pointer-events: auto;
+}
+
+.jodit-source{
+  background-color: white !important;
+}
 
 .jodit-container:not(.jodit_inline) .jodit-workplace {
   background-color: white !important; // Fix Jodit background issues


### PR DESCRIPTION
- Update to latest version of Jodit
- Re-enable the source plugin to allow HTML source editing
- Use the 'Ace' editor to handle html syntax markup
- Fix an issue with the Jodit popups being obscured by the angular-material dialog box
- Fix some dark styling of the html editing box