### PR TITLE
Branch/version can come from owningModel

### DIFF
--- a/src/app/model-header/model-header.component.ts
+++ b/src/app/model-header/model-header.component.ts
@@ -180,6 +180,8 @@ export class ModelHeaderComponent implements OnInit {
       return false;
     }
 
+    if (this.item.owningModel) return false;
+
     const model = this.item as Branchable;
     return this.access.showEdit && model.branchName !== defaultBranchName;
   }

--- a/src/app/utility/element-link/element-link.component.ts
+++ b/src/app/utility/element-link/element-link.component.ts
@@ -117,13 +117,13 @@ export class ElementLinkComponent implements OnInit {
         .get({ id: parentDM.id, domainType: parentDM.domainType })
         .pipe(
           map((model) => {
-            if (model.finalised) {
-              return `${model.label} [${model.modelVersion}] : ${
+            if (model.finalised || model.owningModel?.finalised) {
+              return `${model.label} [${model.modelVersion || model.owningModel?.modelVersion}] : ${
                 this.element?.label ?? this.element?.definition ?? ''
               }`;
             }
 
-            return `${model.label} [${model.branchName}] : ${
+            return `${model.label} [${model.branchName || model.owningModel?.branchName}] : ${
               this.element?.label ?? this.element?.definition ?? ''
             }`;
           })


### PR DESCRIPTION
A model may not 'own' the versioning information but it will point to owningModel instead; fixed unguarded use of branchName and modelVersion

element-link.component.ts uses owningModel

canChangeBranchName() returns false when versioning is owned elsewhere

Didn't find any more