### PR TITLE
Stop the html editor inserting empty `<p></p>` tags when the content is empty

### DIFF
--- a/src/app/content/html/html-editor/html-editor.component.ts
+++ b/src/app/content/html/html-editor/html-editor.component.ts
@@ -170,7 +170,12 @@ export class HtmlEditorComponent implements OnInit, OnChanges {
   }
 
   onHtmlEditorChanged(newValue: string) {
-    this.description = newValue;
+    if (newValue == '<p></p>') {
+      this.description = newValue;
+    }
+    else {
+      this.description = '';
+    }
     this.descriptionChange.emit(this.description);
   }
 

--- a/src/app/content/markdown/markdown-text-area/markdown-text-area.component.ts
+++ b/src/app/content/markdown/markdown-text-area/markdown-text-area.component.ts
@@ -104,7 +104,9 @@ export class MarkdownTextAreaComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.elementSelected();
-
+    if (this.description == '<p></p>') {
+      this.description = '';
+    }
     if (this.inEditMode) {
       const usingMacOs = window.navigator.userAgent.search('Mac') !== -1;
       this.keyboardShortcuts = usingMacOs ? macShortcuts : standardShortcuts;


### PR DESCRIPTION
Attempt to fix the issue where empty paragraphs tags get inserted by the html editor