### PR TITLE
Add relative paths

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -60,6 +60,8 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ],
+              "baseHref": "./",
+              "deployUrl": "./",
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
@@ -92,7 +94,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "buildTarget": "mdm-ui:build"
+            "buildTarget": "mdm-ui:build",
+            "proxyConfig": "proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,8 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -20,7 +20,7 @@ const packageFile = require('../../package.json');
 export const environment = {
   production: true,
   version: packageFile?.version ?? '',
-  apiEndpoint: 'api',
+  apiEndpoint: '/api',
   HDFLink: '',
   themeName: $ENV.themeName ?? 'default',
   appTitle: 'Mauro Data Mapper',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -24,7 +24,7 @@ const packageFile = require('../../package.json');
 export const environment = {
   production: false,
   version: packageFile?.version ?? '',
-  apiEndpoint: 'http://localhost:8080/api',
+  apiEndpoint: '/api',
   HDFLink: '',
   themeName: 'default',
   appTitle: 'Mauro Data Mapper',


### PR DESCRIPTION
Add relative paths to production configuration (baseHref, deployUrl)

Use a proxy configuration for /api for ng serve so that:
* both production and dev retrieve ui and api in the same way from the same base url,
* and the environment.ts and environment.prod.ts both use /api rather than absolute URLS for the apiEndpoint