### PR TITLE
safe or {{ }} or escapeHtml

### DIFF
--- a/src/app/folders-tree/folders-tree.component.html
+++ b/src/app/folders-tree/folders-tree.component.html
@@ -370,7 +370,7 @@ SPDX-License-Identifier: Apache-2.0
         isGhost: node.isGhost,
         modified: node.modified
       }">
-      <span [innerHTML]="node.label | mchighlighter: searchCriteria"></span>
+      <span [innerHTML]="node.label | escapeHtml | mchighlighter: searchCriteria"></span>
         <small *ngIf="node.branchName" class="ml-1 text-muted">
       <span> | </span>
       <span class="fas fa-code-branch mr-xsm"></span>

--- a/src/app/folders-tree/folders-tree.component.ts
+++ b/src/app/folders-tree/folders-tree.component.ts
@@ -57,6 +57,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatIcon } from '@angular/material/icon';
 import { MatIconButton } from '@angular/material/button';
 import { NgIf, NgTemplateOutlet, NgFor, NgClass } from '@angular/common';
+import { EscapeHtmlPipe } from '@mdm/pipes/escapeHtml.pipe';
 
 /**
  * Event arguments for confirming a click of a node in the FoldersTreeComponent.
@@ -77,7 +78,7 @@ export class NodeConfirmClickEvent {
     templateUrl: './folders-tree.component.html',
     styleUrls: ['./folders-tree.component.scss'],
     standalone: true,
-    imports: [NgIf, MatTree, MatTreeNodeDef, MatTreeNode, MatTreeNodePadding, MatIconButton, MatIcon, NgTemplateOutlet, MatTreeNodeToggle, MatMenuTrigger, MatMenu, MatMenuContent, MatMenuItem, NgFor, NgClass, MatCheckbox, FormsModule, HighlighterPipe]
+    imports: [NgIf, MatTree, MatTreeNodeDef, MatTreeNode, MatTreeNodePadding, MatIconButton, MatIcon, NgTemplateOutlet, MatTreeNodeToggle, MatMenuTrigger, MatMenu, MatMenuContent, MatMenuItem, NgFor, NgClass, MatCheckbox, FormsModule, HighlighterPipe, EscapeHtmlPipe]
 })
 export class FoldersTreeComponent implements OnChanges, OnDestroy {
   @Input() node: any;

--- a/src/app/modals/add-rule-modal/add-rule-modal.component.html
+++ b/src/app/modals/add-rule-modal/add-rule-modal.component.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 </div>
 <form [formGroup]="formGroup">
   <div class="modal-body pxy-2">
-    <p *ngIf="message" [innerHtml]="message"></p>
+    <p *ngIf="message" [innerHtml]="message | safe: 'html'"></p>
     <div class="mdm--form-input">
       <mat-form-field appearance="outline" required class="full-width">
         <mat-label>Name</mat-label>

--- a/src/app/modals/add-rule-modal/add-rule-modal.component.ts
+++ b/src/app/modals/add-rule-modal/add-rule-modal.component.ts
@@ -24,6 +24,7 @@ import { MatButton } from '@angular/material/button';
 import { MatInput } from '@angular/material/input';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { NgIf } from '@angular/common';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 export interface AddRuleModalConfig {
   name: string
@@ -47,7 +48,7 @@ export interface AddRuleModalResult {
     templateUrl: './add-rule-modal.component.html',
     styleUrls: ['./add-rule-modal.component.scss'],
     standalone: true,
-    imports: [FormsModule, ReactiveFormsModule, NgIf, MatFormField, MatLabel, MatInput, MatError, MatButton]
+    imports: [FormsModule, ReactiveFormsModule, NgIf, MatFormField, MatLabel, MatInput, MatError, MatButton, SafePipe]
 })
 export class AddRuleModalComponent implements OnInit {
   okBtn: string;

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.html
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
   <h4 class="modal-title marginless">{{ modalTitle }}</h4>
 </div>
 <div class="modal-body pxy-2">
-  <p [innerHtml]="message"></p>
+  <p [innerHtml]="message | safe: 'html'"></p>
   <form [formGroup]="formGroup">
     <div class="mdm--form-input">
       <mat-form-field appearance="outline" class="full-width paddingless">

--- a/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
+++ b/src/app/modals/add-rule-representation-modal/add-rule-representation-modal.component.ts
@@ -46,6 +46,7 @@ import { MatOption } from '@angular/material/core';
 import { NgFor, NgIf } from '@angular/common';
 import { MatSelect } from '@angular/material/select';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 export class RuleLanguage {
   displayName: string;
@@ -115,7 +116,7 @@ export interface AddRuleRepresentationModalResult {
     templateUrl: './add-rule-representation-modal.component.html',
     styleUrls: ['./add-rule-representation-modal.component.scss'],
     standalone: true,
-    imports: [FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatSelect, NgFor, MatOption, NgIf, MatError, MatToolbar, MatInput, MatButton, AceModule]
+    imports: [FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatSelect, NgFor, MatOption, NgIf, MatError, MatToolbar, MatInput, MatButton, AceModule, SafePipe]
 })
 export class AddRuleRepresentationModalComponent implements OnInit {
   dmnCanvas: ElementRef;

--- a/src/app/modals/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/modals/confirmation-modal/confirmation-modal.component.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
     <h4 class="modal-title marginless">{{ title }}</h4>
   </div>
   <div class="modal-body">
-    <span [innerHtml]="message"></span>
+    <span [innerHtml]="message | safe: 'html'"></span>
   </div>
   <div class="modal-footer" style="padding: 10px">
     <button

--- a/src/app/modals/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/modals/confirmation-modal/confirmation-modal.component.ts
@@ -21,6 +21,7 @@ import { ModalDialogStatus } from '@mdm/constants/modal-dialog-status';
 import { MatButton } from '@angular/material/button';
 import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 export interface ConfirmationModalConfig {
   title?: string
@@ -40,7 +41,7 @@ export interface ConfirmationModalResult {
     templateUrl: './confirmation-modal.component.html',
     styleUrls: ['./confirmation-modal.component.sass'],
     standalone: true,
-    imports: [FormsModule, NgIf, MatButton]
+    imports: [FormsModule, NgIf, MatButton, SafePipe]
 })
 export class ConfirmationModalComponent implements OnInit {
   title: string;

--- a/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.html
+++ b/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.html
@@ -149,7 +149,7 @@ SPDX-License-Identifier: Apache-2.0
                   let-searchTerm="inputText"
                 >
                   <div
-                    [innerHTML]="item.label | mchighlighter: searchTerm"
+                    [innerHTML]="item.label | escapeHtml | mchighlighter: searchTerm"
                   ></div>
                   <div>
                     <mdm-element-link

--- a/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.ts
+++ b/src/app/modals/default-profile-editor-modal/default-profile-editor-modal.component.ts
@@ -48,13 +48,14 @@ import { MatInput } from '@angular/material/input';
 import { ContentEditorComponent } from '../../content/content-editor/content-editor.component';
 import { ElementAliasComponent } from '../../utility/element-alias/element-alias.component';
 import { NgFor, NgIf, NgClass } from '@angular/common';
+import { EscapeHtmlPipe } from '@mdm/pipes/escapeHtml.pipe';
 
 @Component({
     selector: 'mdm-default-profile-editor-modal',
     templateUrl: './default-profile-editor-modal.component.html',
     styleUrls: ['./default-profile-editor-modal.component.sass'],
     standalone: true,
-    imports: [MatDialogTitle, MatDialogContent, NgFor, NgIf, ElementAliasComponent, ContentEditorComponent, MatInput, FormsModule, InlineTextEditComponent, NgClass, ExtendedModule, MatButton, NewDataTypeInlineComponent, McSelectComponent, ElementLinkComponent, ElementClassificationsComponent, MatDialogActions, HighlighterPipe]
+    imports: [MatDialogTitle, MatDialogContent, NgFor, NgIf, ElementAliasComponent, ContentEditorComponent, MatInput, FormsModule, InlineTextEditComponent, NgClass, ExtendedModule, MatButton, NewDataTypeInlineComponent, McSelectComponent, ElementLinkComponent, ElementClassificationsComponent, MatDialogActions, HighlighterPipe, EscapeHtmlPipe]
 })
 export class DefaultProfileEditorModalComponent implements OnInit {
   multiplicityError: string;

--- a/src/app/modals/finalise-modal/finalise-modal.component.html
+++ b/src/app/modals/finalise-modal/finalise-modal.component.html
@@ -22,17 +22,17 @@ SPDX-License-Identifier: Apache-2.0
 <mat-dialog-content class="mat-typography">
   <div class="full-width">
     <form role="form" class="mb-2">
-      <span [innerHtml]="message"></span>
+      <span [innerHtml]="message | safe: 'html'"></span>
       <mat-radio-group name="versionList" [(value)]="data.versionList" [(ngModel)]="data.versionList" (ngModelChange)="onVersionChange()" class="mb-0">
 
         <mat-radio-button value="Major" [checked]="data.versionList == 'Major'">Major <small><em>(default)</em></small></mat-radio-button>
-        <div class="mb-1" style="margin-left: 29px;"><small class="text-muted"><span [innerHtml]="versionMajor"></span></small></div>
+        <div class="mb-1" style="margin-left: 29px;"><small class="text-muted"><span>{{ versionMajor }}</span></small></div>
 
         <mat-radio-button value="Minor" [checked]="data.versionList == 'Minor'">Minor</mat-radio-button>
-        <div class="mb-1" style="margin-left: 29px;"><small class="text-muted"><span [innerHtml]="versionMinor"></span></small></div>
+        <div class="mb-1" style="margin-left: 29px;"><small class="text-muted"><span>{{ versionMinor }}</span></small></div>
 
         <mat-radio-button value="Patch" [checked]="data.versionList == 'Patch'">Patch</mat-radio-button>
-        <div class="mb-1" style="margin-left: 29px;"><small class="text-muted"><span [innerHtml]="versionPatch"></span></small></div>
+        <div class="mb-1" style="margin-left: 29px;"><small class="text-muted"><span>{{ versionPatch }}</span></small></div>
 
         <mat-radio-button value="Custom" [checked]="data.versionList == 'Custom'">Custom version</mat-radio-button>
         <div style="margin-left: 29px;"><small class="text-muted">Define your custom version </small></div>

--- a/src/app/modals/finalise-modal/finalise-modal.component.ts
+++ b/src/app/modals/finalise-modal/finalise-modal.component.ts
@@ -27,6 +27,7 @@ import { ExtendedModule } from '@angular/flex-layout/extended';
 import { NgClass, NgIf } from '@angular/common';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { FormsModule } from '@angular/forms';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 export interface FinaliseModalResponse {
   status: ModalDialogStatus
@@ -38,7 +39,7 @@ export interface FinaliseModalResponse {
     templateUrl: './finalise-modal.component.html',
     styleUrls: ['./finalise-modal.component.scss'],
     standalone: true,
-    imports: [MatDialogTitle, MatDialogContent, FormsModule, MatRadioGroup, MatRadioButton, NgClass, ExtendedModule, MatFormField, MatLabel, MatInput, MatDialogActions, NgIf, MatButton]
+    imports: [MatDialogTitle, MatDialogContent, FormsModule, MatRadioGroup, MatRadioButton, NgClass, ExtendedModule, MatFormField, MatLabel, MatInput, MatDialogActions, NgIf, MatButton, SafePipe]
 })
 export class FinaliseModalComponent implements OnInit {
   title: string;

--- a/src/app/modals/input-modal/input-modal.component.html
+++ b/src/app/modals/input-modal/input-modal.component.html
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
     <h4 class='modal-title marginless'>{{modalTitle}}</h4>
 </div>
 <div class="modal-body pxy-2">
-    <p [innerHtml]="message"></p>
+    <p [innerHtml]="message | safe: 'html'"></p>
     <div class="mdm--form-input">
         <mat-form-field appearance="outline" class="full-width paddingless">
             <mat-label>{{inputLabel}}</mat-label>

--- a/src/app/modals/input-modal/input-modal.component.ts
+++ b/src/app/modals/input-modal/input-modal.component.ts
@@ -21,13 +21,14 @@ import { MatButton } from '@angular/material/button';
 import { FormsModule } from '@angular/forms';
 import { MatInput } from '@angular/material/input';
 import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 @Component({
     selector: 'mdm-input-modal',
     templateUrl: './input-modal.component.html',
     styleUrls: ['./input-modal.component.scss'],
     standalone: true,
-    imports: [MatFormField, MatLabel, MatInput, FormsModule, MatButton, MatDialogClose]
+    imports: [MatFormField, MatLabel, MatInput, FormsModule, MatButton, MatDialogClose, SafePipe]
 })
 export class InputModalComponent implements OnInit {
   okBtn: string;

--- a/src/app/modals/markup-display-modal/markup-display-modal.component.html
+++ b/src/app/modals/markup-display-modal/markup-display-modal.component.html
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
   <hr>
   <mat-dialog-content class="mat-typography">
     <div class="full-width">
-    <span [innerHtml]="data.content"></span>
+    <span [innerHtml]="data.content | safe: 'html'"></span>
     </div>
   </mat-dialog-content>
   <mat-dialog-actions align="end" class="pt-2 pb-2">

--- a/src/app/modals/markup-display-modal/markup-display-modal.component.ts
+++ b/src/app/modals/markup-display-modal/markup-display-modal.component.ts
@@ -18,13 +18,14 @@ SPDX-License-Identifier: Apache-2.0
 import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
 import { MatButton } from '@angular/material/button';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 @Component({
     selector: 'mdm-markup-display-modal',
     templateUrl: './markup-display-modal.component.html',
     styleUrls: ['./markup-display-modal.component.scss'],
     standalone: true,
-    imports: [MatDialogTitle, MatDialogContent, MatDialogActions, MatButton]
+    imports: [MatDialogTitle, MatDialogContent, MatDialogActions, MatButton, SafePipe]
 })
 export class MarkupDisplayModalComponent implements OnInit {
   title: string;

--- a/src/app/modals/new-folder-modal/new-folder-modal.component.html
+++ b/src/app/modals/new-folder-modal/new-folder-modal.component.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
     <h4 class="modal-title marginless">{{ modalTitle }}</h4>
   </div>
   <div class="modal-body pxy-2">
-    <p [innerHtml]="message"></p>
+    <p [innerHtml]="message | safe: 'html'"></p>
     <mdm-alert *ngIf="createRootFolder" alertStyle="info" [showIcon]="true">
       This will be added at the top of the tree.
     </mdm-alert>

--- a/src/app/modals/new-folder-modal/new-folder-modal.component.ts
+++ b/src/app/modals/new-folder-modal/new-folder-modal.component.ts
@@ -33,13 +33,14 @@ import { MatInput } from '@angular/material/input';
 import { MatFormField, MatLabel, MatError } from '@angular/material/form-field';
 import { AlertComponent } from '../../shared/alert/alert.component';
 import { NgIf } from '@angular/common';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 @Component({
     selector: 'mdm-new-folder-modal',
     templateUrl: './new-folder-modal.component.html',
     styleUrls: ['./new-folder-modal.component.scss'],
     standalone: true,
-    imports: [FormsModule, ReactiveFormsModule, NgIf, AlertComponent, MatFormField, MatLabel, MatInput, MatError, MatCheckbox, MatButton]
+    imports: [FormsModule, ReactiveFormsModule, NgIf, AlertComponent, MatFormField, MatLabel, MatInput, MatError, MatCheckbox, MatButton, SafePipe]
 })
 export class NewFolderModalComponent implements OnInit {
   okBtn: string;

--- a/src/app/pipes/escapeHtml.pipe.ts
+++ b/src/app/pipes/escapeHtml.pipe.ts
@@ -1,0 +1,105 @@
+/*
+Copyright 2020-2025 University of Oxford and NHS England
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'escapeHtml',
+    standalone: true
+})
+export class EscapeHtmlPipe implements PipeTransform {
+    transform(value: string): any {
+        return (value) ? rawToXml(value) : '';
+  }
+}
+
+function rawToXml(raw: string | null, full: boolean = false): string | null {
+  if (raw == null) return null;
+
+  let count = 0;
+
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw.charCodeAt(i);
+
+    if (
+      (c >= 0x0000 && c < 0x0020 && c !== 10 && c !== 13 && c !== 9)
+      || (c >= 0x007f && c < 0x00a0)
+      || (c >= 0x00fe)
+      || c === 60 || c === 62 || c === 38 || c === 59
+      || c === 35 || c === 39 || c === 34 || c === 45
+      || (c & 128) !== 0
+    ) {
+      count++;
+    }
+  }
+
+  if (count === 0) return raw;
+
+  const result: string[] = [];
+
+  for (let i = 0; i < raw.length; i++) {
+    xmlEscapeCharacter(raw.charCodeAt(i), result, full);
+  }
+
+  return result.join('');
+}
+
+function xmlEscapeCharacter(c: number, into: string[], full: boolean): void {
+  if (c >= 32 && c < 126) {
+    if (
+        c !== 60 && c !== 62 && c !== 38
+        && c !== 59 && c !== 35
+        && c !== 39 && c !== 34 && c !== 45
+    ) {
+      into.push(String.fromCharCode(c));
+      return;
+    }
+  }
+
+  if (
+    (c >= 0x0000 && c < 0x0020 && c !== 10 && c !== 13 && c !== 9)
+    || (c >= 0x007f && c < 0x00a0)
+  ) {
+    if (/\s/.test(String.fromCharCode(c))) {
+      into.push(' ');
+    }
+    return;
+  }
+
+  if (
+    (c & 128) !== 0
+    || c >= 0x00fe
+    || c === 60 || c === 62 || c === 38
+    || c === 59 || c === 35
+    || c === 39 || c === 34 || c === 45
+  ) {
+    into.push('&#x');
+
+    const a = (c >> 8) & 0xff;
+    if (full || a !== 0) {
+      into.push(a.toString(16).padStart(2, '0'));
+    }
+
+    const b = c & 0xff;
+    into.push(b.toString(16).padStart(2, '0'));
+
+    into.push(';');
+    return;
+  }
+
+  into.push(String.fromCharCode(c));
+}

--- a/src/app/pipes/highlighter.pipe.ts
+++ b/src/app/pipes/highlighter.pipe.ts
@@ -29,11 +29,11 @@ export class HighlighterPipe implements PipeTransform {
       if (wildcardMatch) {
         const sections: string[] = phrase.split(' ');
         sections.forEach((section) => {
-          text = value.replace(new RegExp('(' + escape(section) + ')', 'gi'), '<span class="mchighlighter">$1</span>');
+          text = value.replace(new RegExp('(' + encodeURIComponent(section) + ')', 'gi'), '<span class="mchighlighter">$1</span>');
         });
       }
  else {
-        text = value.replace(new RegExp('(' + escape(phrase) + ')', 'gi'), '<span class="mchighlighter">$1</span>');
+        text = value.replace(new RegExp('(' + encodeURIComponent(phrase) + ')', 'gi'), '<span class="mchighlighter">$1</span>');
       }
     }
     return text;

--- a/src/app/shared/code-set-terms-table/code-set-terms-table.component.html
+++ b/src/app/shared/code-set-terms-table/code-set-terms-table.component.html
@@ -84,7 +84,7 @@ SPDX-License-Identifier: Apache-2.0
             </th>
             <td mat-cell *matCellDef="let record" style="width: 35%;text-align: left;word-wrap: break-word;">
                 <div *ngIf="record.definition && record.definition.length>0" style="margin-bottom: 10px;">
-                    <span [innerHTML]="record.definition"></span>
+                    <span [innerHTML]="record.definition | safe: 'html'"></span>
                 </div>
 
                 <div  *ngIf="record.aliases">

--- a/src/app/shared/code-set-terms-table/code-set-terms-table.component.ts
+++ b/src/app/shared/code-set-terms-table/code-set-terms-table.component.ts
@@ -49,13 +49,14 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { MatButton } from '@angular/material/button';
 import { NgIf, NgClass } from '@angular/common';
 import { FlexModule } from '@angular/flex-layout/flex';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 @Component({
     selector: 'mdm-code-set-terms-table',
     templateUrl: './code-set-terms-table.component.html',
     styleUrls: ['./code-set-terms-table.component.scss'],
     standalone: true,
-    imports: [FlexModule, NgIf, MatButton, MatTooltip, MultipleTermsSelectorComponent, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatSortHeader, MatFormField, MatLabel, MatInput, MatCellDef, MatCell, ElementLinkComponent, ElementAliasComponent, TableButtonsComponent, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, NgxSkeletonLoaderModule, NgClass, ExtendedModule, MdmPaginatorComponent]
+    imports: [FlexModule, NgIf, MatButton, MatTooltip, MultipleTermsSelectorComponent, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatSortHeader, MatFormField, MatLabel, MatInput, MatCellDef, MatCell, ElementLinkComponent, ElementAliasComponent, TableButtonsComponent, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, NgxSkeletonLoaderModule, NgClass, ExtendedModule, MdmPaginatorComponent, SafePipe]
 })
 export class CodeSetTermsTableComponent implements OnInit, AfterViewInit {
   @Input() codeSet: CodeSetDetail;

--- a/src/app/shared/element-data-type/element-data-type.component.html
+++ b/src/app/shared/element-data-type/element-data-type.component.html
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 <div>
   <span *ngIf="elementDataType.domainType == 'PrimitiveType'">
     <a class="dataTypePrimitive" href="{{ link }}" [hidden]="hideName"
-      ><span [innerHtml]="elementDataType.label"></span></a
+      ><span>{{ elementDataType.label }}</span></a
     ><span class="dataTypeLabel dataTypePrimitive" [hidden]="hideName"
       >(Primitive)</span
     >
@@ -100,8 +100,7 @@ SPDX-License-Identifier: Apache-2.0
                     max-width: 100px;
                     min-width: 50px;
                   "
-                  [innerHtml]="record.key"
-                ></span>
+                >{{ record.key }}</span>
               </div>
             </td>
             <td
@@ -116,8 +115,7 @@ SPDX-License-Identifier: Apache-2.0
                   display: block;
                   max-width: 400px;
                 "
-                [innerHtml]="record.value"
-              >
+              >{{ record.value }}
               </span>
             </td>
           </tr>

--- a/src/app/shared/element-link-list/element-link-list.component.html
+++ b/src/app/shared/element-link-list/element-link-list.component.html
@@ -107,6 +107,7 @@ SPDX-License-Identifier: Apache-2.0
             <span
               [innerHtml]="
                 record.sourceMultiFacetAwareItem?.label
+                  | escapeHtml
                   | mchighlighter: searchCriteria
               "
             ></span>
@@ -191,6 +192,7 @@ SPDX-License-Identifier: Apache-2.0
                 <span
                   [innerHtml]="
                     record.targetMultiFacetAwareItem.label
+                      | escapeHtml
                       | mchighlighter: searchCriteria
                   "
                 ></span>
@@ -208,6 +210,7 @@ SPDX-License-Identifier: Apache-2.0
                 <span
                   [innerHtml]="
                     record.targetMultiFacetAwareItem.label
+                      | escapeHtml
                       | mchighlighter: searchCriteria
                   "
                 ></span>

--- a/src/app/shared/element-link-list/element-link-list.component.ts
+++ b/src/app/shared/element-link-list/element-link-list.component.ts
@@ -44,13 +44,14 @@ import { MatButton } from '@angular/material/button';
 import { NgIf, NgFor, NgClass, KeyValuePipe } from '@angular/common';
 import { MatTooltip } from '@angular/material/tooltip';
 import { FlexModule } from '@angular/flex-layout/flex';
+import { EscapeHtmlPipe } from '@mdm/pipes/escapeHtml.pipe';
 
 @Component({
     selector: 'mdm-element-link-list',
     templateUrl: './element-link-list.component.html',
     styleUrls: ['./element-link-list.component.sass'],
     standalone: true,
-    imports: [FlexModule, MatTooltip, NgIf, MatButton, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, ElementLinkComponent, MatSortHeader, MatFormField, MatLabel, MatInput, FormsModule, NgFor, TableButtonsComponent, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, NgClass, ExtendedModule, NgxSkeletonLoaderModule, MdmPaginatorComponent_1, KeyValuePipe, HighlighterPipe]
+    imports: [FlexModule, MatTooltip, NgIf, MatButton, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, ElementLinkComponent, MatSortHeader, MatFormField, MatLabel, MatInput, FormsModule, NgFor, TableButtonsComponent, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, NgClass, ExtendedModule, NgxSkeletonLoaderModule, MdmPaginatorComponent_1, KeyValuePipe, HighlighterPipe, EscapeHtmlPipe]
 })
 export class ElementLinkListComponent implements AfterViewInit {
   @Input() parent: any;

--- a/src/app/shared/history/history.component.html
+++ b/src/app/shared/history/history.component.html
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
         *matCellDef="let element"
       >
         <div *ngIf="element && element.createdByUser && element.createdByUser.name" style="float: left; margin: 3px">
-          <span [innerHTML]="element.createdByUser.name"></span>
+          <span>{{ element.createdByUser.name }}</span>
         </div>
       </td>
     </ng-container>

--- a/src/app/shared/new-version/new-version.component.html
+++ b/src/app/shared/new-version/new-version.component.html
@@ -72,6 +72,7 @@ SPDX-License-Identifier: Apache-2.0
                                 domainType,
                                 catalogueItem
                               )
+                              | safe : 'html'
                             "
                           >
                           </small>

--- a/src/app/shared/new-version/new-version.component.ts
+++ b/src/app/shared/new-version/new-version.component.ts
@@ -54,6 +54,7 @@ import { MatOption } from '@angular/material/core';
 import { MatSelect, MatSelectTrigger } from '@angular/material/select';
 import { MatFormField, MatLabel, MatError, MatHint } from '@angular/material/form-field';
 import { NgIf, NgFor } from '@angular/common';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 interface NewVersionAction {
   name: string
@@ -71,7 +72,7 @@ interface NewVersionAction {
     templateUrl: './new-version.component.html',
     styleUrls: ['./new-version.component.scss'],
     standalone: true,
-    imports: [NgIf, FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatSelect, MatSelectTrigger, NgFor, MatOption, MatError, MatInput, MatHint, MatCheckbox, AlertComponent, MatButton, MatProgressBar]
+    imports: [NgIf, FormsModule, ReactiveFormsModule, MatFormField, MatLabel, MatSelect, MatSelectTrigger, NgFor, MatOption, MatError, MatInput, MatHint, MatCheckbox, AlertComponent, MatButton, MatProgressBar, SafePipe]
 })
 export class NewVersionComponent implements OnInit {
   catalogueItem: CatalogueItem & Modelable;

--- a/src/app/utility/element-link/element-link.component.html
+++ b/src/app/utility/element-link/element-link.component.html
@@ -30,7 +30,7 @@ SPDX-License-Identifier: Apache-2.0
   target="{{ openLinkLocation }}"
 >
   <!-- <span [innerHtml]="label | mchighlighter:searchCriteria:!searchExactMatch"></span>-->
-  <span [innerHtml]="label"></span>
+  <span>{{ label }}</span>
 </a>
 <a
   *ngIf="elementVal && !showHref && showLink"
@@ -40,7 +40,7 @@ SPDX-License-Identifier: Apache-2.0
   target="{{ openLinkLocation }}"
 >
   <!-- <span [innerHtml]="label | mchighlighter:searchCriteria:!searchExactMatch"></span>-->
-  <span [innerHtml]="label"></span>
+  <span>{{ label }}</span>
 </a>
 <span
   ><small *ngIf="elementVal && showTypeTitle" class="item-type ml-1">{{

--- a/src/app/utility/model-path/model-path.component.html
+++ b/src/app/utility/model-path/model-path.component.html
@@ -19,12 +19,12 @@ SPDX-License-Identifier: Apache-2.0
   <ol [ngClass]="{ breadcrumb: true, emptyBackground: showAsSimpleText }" *ngIf="updatedPath && updatedPath.length > 0">
       <li class="breadcrumb-item" *ngFor="let p of updatedPath; let i = index">
           <small>
-            <a *ngIf="i >= 0 && showHref" aria-hidden="false" href="{{ p.link }}" target="{{ targetWindow }}"><span [innerHtml]="p.label"></span></a>
-            <a *ngIf="i >= 0 && !showHref" aria-hidden="false" target="{{ targetWindow }}" style="margin-left: 7px;"><span [innerHtml]="p.label"></span></a>
+            <a *ngIf="i >= 0 && showHref" aria-hidden="false" href="{{ p.link }}" target="{{ targetWindow }}"><span [innerHtml]="p.label | safe: 'html'"></span></a>
+            <a *ngIf="i >= 0 && !showHref" aria-hidden="false" target="{{ targetWindow }}" style="margin-left: 7px;"><span [innerHtml]="p.label | safe: 'html'"></span></a>
             <span [hidden]="!doNotShowParentDataModel && i == 0">
               <a *ngIf="p.domainType == 'DataModel' && showHref" href="{{ p.link }}" target="{{ targetWindow }}">{{ p.label }}</a>
-              <a *ngIf="p.domainType == 'DataModel' && !showHref" aria-hidden="false" target="{{ targetWindow }}"><span [innerHtml]="p.label"></span></a>
-              <a *ngIf="i >= 0 && !showHref" aria-hidden="false" target="{{ targetWindow }}"><span [innerHtml]="p.label"></span></a>
+              <a *ngIf="p.domainType == 'DataModel' && !showHref" aria-hidden="false" target="{{ targetWindow }}"><span [innerHtml]="p.label | safe: 'html'"></span></a>
+              <a *ngIf="i >= 0 && !showHref" aria-hidden="false" target="{{ targetWindow }}"><span [innerHtml]="p.label | safe: 'html'"></span></a>
             </span>
             <span *ngIf="!doNotDisplayStatus && i == 0 && !p.finalised" class="badge badge-warning ml-1">Draft</span>
             <!-- <span *ngIf="!doNotDisplayStatus && i == 0 && p.finalised" class="badge badge-success mr-1">Finalised</span> -->

--- a/src/app/utility/model-path/model-path.component.ts
+++ b/src/app/utility/model-path/model-path.component.ts
@@ -19,6 +19,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { ElementTypesService } from '@mdm/services/element-types.service';
 import { ExtendedModule } from '@angular/flex-layout/extended';
 import { NgIf, NgClass, NgFor } from '@angular/common';
+import { SafePipe } from '@mdm/content/safe.pipe';
 
 @Component({
     selector: 'mdm-model-path',
@@ -29,6 +30,7 @@ import { NgIf, NgClass, NgFor } from '@angular/common';
         NgClass,
         ExtendedModule,
         NgFor,
+      SafePipe,
     ],
 })
 

--- a/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.html
+++ b/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.html
@@ -148,7 +148,7 @@ SPDX-License-Identifier: Apache-2.0
                       let-searchTerm="inputText"
                     >
                       <div
-                        [innerHTML]="item.label | mchighlighter: searchTerm"
+                        [innerHTML]="item.label | escapeHtml | mchighlighter: searchTerm"
                       ></div>
                       <div>
                         <mdm-element-link

--- a/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.ts
+++ b/src/app/wizards/dataElement/data-element-step2/data-element-step2.component.ts
@@ -59,13 +59,14 @@ import { MatInput } from '@angular/material/input';
 import { MatFormField, MatLabel, MatHint } from '@angular/material/form-field';
 import { ModelPathComponent } from '@mdm/utility/model-path/model-path.component';
 import { NgIf, NgClass } from '@angular/common';
+import { EscapeHtmlPipe } from '@mdm/pipes/escapeHtml.pipe';
 
 @Component({
     selector: 'mdm-data-element-step2',
     templateUrl: './data-element-step2.component.html',
     styleUrls: ['./data-element-step2.component.sass'],
     standalone: true,
-    imports: [NgIf, FormsModule, ModelPathComponent, MatFormField, MatInput, ContentEditorComponent, FlexModule, MatLabel, MatHint, ElementDataTypeComponent, MatButton, McSelectComponent, ElementLinkComponent, NewDataTypeInlineComponent, ElementClassificationsComponent, MatTooltip, NgClass, ExtendedModule, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MoreDescriptionComponent, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatPaginator, MatProgressBar, HighlighterPipe]
+    imports: [NgIf, FormsModule, ModelPathComponent, MatFormField, MatInput, ContentEditorComponent, FlexModule, MatLabel, MatHint, ElementDataTypeComponent, MatButton, McSelectComponent, ElementLinkComponent, NewDataTypeInlineComponent, ElementClassificationsComponent, MatTooltip, NgClass, ExtendedModule, MatTable, MatSort, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCheckbox, MatCellDef, MatCell, MatSortHeader, MoreDescriptionComponent, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatPaginator, MatProgressBar, HighlighterPipe, EscapeHtmlPipe]
 })
 export class DataElementStep2Component
   implements OnInit, AfterViewInit, OnDestroy {


### PR DESCRIPTION
Ensure that all [innerHTML]= use | safe: 'html'
or else are converted to {{ }}

For use with the mchighlighter, add a pipe for escaping a string for use in html