### PR TITLE
Fixes for the 'search for a catalogue item' dialog box 

### DIFF
--- a/src/app/catalogue-search/catalogue-search.service.ts
+++ b/src/app/catalogue-search/catalogue-search.service.ts
@@ -27,7 +27,8 @@ import {
   ProfileFieldQueryData,
   ProfileSummary,
   ProfileSummaryResponse,
-  SearchQueryParameters
+  SearchQueryParameters,
+  DataElementIndexParameters
 } from '@maurodatamapper/mdm-resources';
 import { MdmResourcesService } from '@mdm/modules/resources';
 import { forkJoin, Observable, of } from 'rxjs';
@@ -67,7 +68,8 @@ export class CatalogueSearchService {
           ...this.getCommonQueryParameters(params),
           ...pageParams,
           searchTerm: this.getSearchTerm(params),
-          profileFields: profileFieldsQueryData
+          profileFields: profileFieldsQueryData,
+          prefixSearch: params.prefixSearch
         };
 
         return this.searchCatalogue(query, params.context).pipe(
@@ -226,8 +228,10 @@ export class CatalogueSearchService {
     if (context) {
       if (context.domainType === CatalogueItemDomainType.DataClass) {
         // Data Classes are a special case. Otherwise use a generic approach for SearchableItemResource
-        return this.resources.dataClass
-          .search(context.dataModelId, context.id, query)
+        const indexParams: DataElementIndexParameters = {
+            label: query.searchTerm
+        };
+        return this.resources.dataElement.list(context.dataModelId, context.id, indexParams)
           .pipe(map((response: CatalogueItemSearchResponse) => response.body));
       }
 

--- a/src/app/catalogue-search/catalogue-search.types.ts
+++ b/src/app/catalogue-search/catalogue-search.types.ts
@@ -206,6 +206,12 @@ export const deserializeProfileFiltersToDto = (base64String: string) => {
  * Represents the parameters to drive a Catalogue Search.
  */
 export interface CatalogueSearchParameters {
+
+  /**
+   * Whether the search should be by matching terms / keywords or run as a 'prefix search'
+   */
+  prefixSearch?: boolean
+
   /**
    * If provided, a search context element i.e. the catalogue item within
    * which searching should be restricted to.

--- a/src/app/utility/element-selector.component.html
+++ b/src/app/utility/element-selector.component.html
@@ -15,7 +15,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 -->
-<mat-dialog-content style="height: 100%">
+<mat-dialog-content style="min-width: 50em; min-height: 50em">
   <div style="padding: 24px">
     <div class="mb-2" style="margin-bottom: 10px">
       <div style="margin-top: 10px" *ngIf="formData.step === 0">

--- a/src/app/utility/element-selector.component.ts
+++ b/src/app/utility/element-selector.component.ts
@@ -335,14 +335,13 @@ export class ElementSelectorComponent implements OnInit {
         pageSize,
         offset
       );
-    }
- else {
+    } else {
       this.formData.searchResultOffset = offset;
 
       const hasSearchContext = this.formData.currentContext;
-
       const parameters: CatalogueSearchParameters = {
         search: this.searchInput,
+        prefixSearch: true,
         offset,
         max: pageSize,
         domainTypes: [this.formData.selectedType],
@@ -360,7 +359,6 @@ export class ElementSelectorComponent implements OnInit {
       };
 
       this.loading = true;
-
       this.catalogueSearch.search(parameters).subscribe((resultSet) => {
         const rows = resultSet.items;
         this.loading = false;
@@ -370,8 +368,7 @@ export class ElementSelectorComponent implements OnInit {
           if (this.dataSource.data) {
             this.dataSource.data = this.dataSource.data.concat(rows);
             this.dataSource._updateChangeSubscription();
-          }
- else {
+          } else {
             this.dataSource = new MatTableDataSource<any>(rows);
           }
           this.totalItemCount = resultSet.count;
@@ -381,8 +378,7 @@ export class ElementSelectorComponent implements OnInit {
           this.dataSource._updateChangeSubscription();
           this.noData = false;
           this.isProcessing = false;
-        }
- else {
+        } else {
           this.isProcessing = true;
           this.dataSource = new MatTableDataSource<any>(rows);
           this.currentRecord = this.dataSource.data.filter(
@@ -424,8 +420,7 @@ export class ElementSelectorComponent implements OnInit {
           result.body.items.forEach((element) => {
             if (element.hasOwnProperty('breadcrumbs')) {
               rows.push(element, { detailRow: true, element });
-            }
- else {
+            } else {
               rows.push(element);
             }
           });
@@ -433,8 +428,7 @@ export class ElementSelectorComponent implements OnInit {
           this.calculateDisplayedSoFar(result);
           if (this.dataSource.data) {
             this.dataSource.data = this.dataSource.data.concat(rows);
-          }
- else {
+          } else {
             this.dataSource.data = rows;
           }
           this.totalItemCount = result.body.count;
@@ -461,8 +455,7 @@ export class ElementSelectorComponent implements OnInit {
           result.body.items.forEach((element) => {
             if (element.hasOwnProperty('breadcrumbs')) {
               rows.push(element, { detailRow: true, element });
-            }
- else {
+            } else {
               rows.push(element);
             }
           });
@@ -471,8 +464,7 @@ export class ElementSelectorComponent implements OnInit {
           this.termsList = rows;
           if (this.dataSource.data) {
             this.dataSource.data = this.dataSource.data.concat(this.termsList);
-          }
- else {
+          } else {
             this.dataSource.data = this.termsList;
           }
           this.totalItemCount = result.body.count;
@@ -501,8 +493,7 @@ export class ElementSelectorComponent implements OnInit {
           this.totalItemCount = result.body.count;
           if (this.dataSource.data) {
             this.dataSource.data = this.dataSource.data.concat(this.termsList);
-          }
- else {
+          } else {
             this.dataSource.data = this.termsList;
           }
           this.currentRecord = this.dataSource.data.filter(


### PR DESCRIPTION
- Fix the search by adding a prefix search option (requires update to mdm-resources), and making the dialog box bigger.  
- Use a different endpoint for searching DataElements